### PR TITLE
feat: implement in-memory job queue with basic job handling and testing

### DIFF
--- a/src/__test__/jobQueue.test.ts
+++ b/src/__test__/jobQueue.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  InMemoryJobQueue,
+  type Job,
+  type JobQueue,
+} from "../services/jobQueue.js";
+
+function createQueue(): JobQueue & { _impl?: InMemoryJobQueue } {
+  const q = new InMemoryJobQueue(10, 20);
+  return q as JobQueue & { _impl?: InMemoryJobQueue };
+}
+
+describe("InMemoryJobQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.error as unknown as vi.Mock).mockRestore?.();
+    vi.useRealTimers();
+  });
+
+  it("processes an enqueued job when a handler is registered", async () => {
+    const queue = createQueue();
+    const handler = vi.fn<void, [Job<{ value: number }>]>();
+
+    queue.registerHandler("test", handler);
+    queue.start();
+
+    queue.enqueue("test", { value: 42 });
+
+    await vi.runAllTimersAsync();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const jobArg = handler.mock.calls[0]![0];
+    expect(jobArg.type).toBe("test");
+    expect(jobArg.payload).toEqual({ value: 42 });
+    expect(queue.size()).toBe(0);
+  });
+
+  it("supports delayed execution via delayMs", async () => {
+    const queue = createQueue();
+    const handler = vi.fn<void, [Job<void>]>();
+
+    queue.registerHandler("delayed", handler);
+    queue.start();
+
+    queue.enqueue("delayed", undefined, { delayMs: 1000 });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(handler).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a failing job up to maxAttempts then moves it to failed jobs", async () => {
+    const queue = createQueue();
+    const handler = vi
+      .fn<void, [Job<void>]>()
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockRejectedValueOnce(new Error("second failure"))
+      .mockResolvedValueOnce();
+
+    queue.registerHandler("unstable", handler);
+    queue.start();
+
+    queue.enqueue("unstable", undefined, { maxAttempts: 3 });
+
+    await vi.runAllTimersAsync();
+
+    expect(handler).toHaveBeenCalledTimes(3);
+    expect(queue.getFailedJobs()).toHaveLength(0);
+    expect(queue.size()).toBe(0);
+  });
+
+  it("moves job to failed set after exceeding maxAttempts", async () => {
+    const queue = createQueue();
+    const handler = vi.fn<void, [Job<void>]>().mockRejectedValue(
+      new Error("always fails"),
+    );
+
+    queue.registerHandler("always-fail", handler);
+    queue.start();
+
+    queue.enqueue("always-fail", undefined, { maxAttempts: 2 });
+
+    await vi.runAllTimersAsync();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    const failed = queue.getFailedJobs();
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.type).toBe("always-fail");
+  });
+
+  it("drops jobs for unknown types and records them as failed", async () => {
+    const queue = createQueue();
+    queue.start();
+
+    queue.enqueue("no-handler", { foo: "bar" });
+
+    await vi.runAllTimersAsync();
+
+    expect(queue.getFailedJobs()).toHaveLength(1);
+    expect(queue.getFailedJobs()[0]!.type).toBe("no-handler");
+    expect(queue.size()).toBe(0);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("is idempotent when start() or stop() are called multiple times", () => {
+    const queue = createQueue();
+    expect(queue.isRunning()).toBe(false);
+    queue.start();
+    expect(queue.isRunning()).toBe(true);
+    queue.start();
+    expect(queue.isRunning()).toBe(true);
+    queue.stop();
+    expect(queue.isRunning()).toBe(false);
+    queue.stop();
+    expect(queue.isRunning()).toBe(false);
+  });
+
+  it("drain() processes ready jobs even without timers", async () => {
+    const queue = createQueue();
+    const handler = vi.fn<void, [Job<void>]>();
+
+    queue.registerHandler("immediate", handler);
+    queue.start();
+
+    queue.enqueue("immediate", undefined);
+
+    await queue.drain();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(queue.size()).toBe(0);
+  });
+});
+

--- a/src/services/jobQueue.ts
+++ b/src/services/jobQueue.ts
@@ -1,0 +1,267 @@
+/**
+ * Minimal async job queue abstraction.
+ *
+ * This module intentionally keeps the public surface small so it can later be
+ * backed by a real queue backend (Redis, SQS, etc.) without changing call
+ * sites. The current implementation is purely in-memory and single-process.
+ */
+
+export interface Job<Data = unknown> {
+  /** Stable job identifier (unique within a queue instance). */
+  readonly id: string;
+  /** Logical job type, used for handler routing. */
+  readonly type: string;
+  /** Arbitrary JSON-serialisable payload. */
+  readonly payload: Data;
+  /** Number of times this job has been attempted. */
+  readonly attempts: number;
+  /** Maximum number of attempts before the job is considered failed. */
+  readonly maxAttempts: number;
+  /** Milliseconds since epoch when the job was first enqueued. */
+  readonly createdAt: number;
+  /** Milliseconds since epoch when the job was last updated. */
+  readonly updatedAt: number;
+}
+
+export type JobHandler<Data = unknown> = (job: Job<Data>) => void | Promise<void>;
+
+export interface EnqueueOptions {
+  /**
+   * Maximum attempts before the job is moved to the failed set.
+   * Defaults to 3.
+   */
+  maxAttempts?: number;
+  /**
+   * Optional delay (in milliseconds) before the first attempt.
+   * Defaults to 0 (immediate).
+   */
+  delayMs?: number;
+  /**
+   * Optional caller-provided job id. If omitted, an internal id is generated.
+   */
+  id?: string;
+}
+
+export interface JobQueue {
+  /**
+   * Enqueue a new job for asynchronous processing.
+   *
+   * Returns the job id that can be used for diagnostics.
+   */
+  enqueue<Data = unknown>(
+    type: string,
+    payload: Data,
+    options?: EnqueueOptions,
+  ): string;
+
+  /**
+   * Register a handler for the given job type.
+   *
+   * Registering multiple handlers for the same type replaces the previous one.
+   */
+  registerHandler<Data = unknown>(
+    type: string,
+    handler: JobHandler<Data>,
+  ): void;
+
+  /** Start background processing of queued jobs. Idempotent. */
+  start(): void;
+
+  /** Stop background processing. Pending jobs remain in the queue. Idempotent. */
+  stop(): void;
+
+  /** Whether the queue is currently processing jobs. */
+  isRunning(): boolean;
+
+  /** Number of jobs that are scheduled but not yet completed. */
+  size(): number;
+
+  /** Read-only snapshot of failed jobs for inspection/metrics. */
+  getFailedJobs(): readonly Job[];
+
+  /**
+   * Best-effort attempt to process all due jobs immediately.
+   *
+   * This is primarily intended for tests and shutdown hooks.
+   */
+  drain(): Promise<void>;
+}
+
+interface InternalJob<Data = unknown> extends Job<Data> {
+  nextRunAt: number;
+}
+
+let nextId = 1;
+
+function generateId(): string {
+  return `job-${nextId++}`;
+}
+
+/**
+ * In-memory, single-process job queue implementation.
+ *
+ * Concurrency model:
+ * - A lightweight timer tick wakes up every `tickIntervalMs` and processes
+ *   ready jobs (those with nextRunAt <= now).
+ * - Jobs are handled sequentially to keep behaviour deterministic in tests.
+ */
+export class InMemoryJobQueue implements JobQueue {
+  private readonly handlers = new Map<string, JobHandler<any>>();
+  private readonly pending: InternalJob<any>[] = [];
+  private readonly failed: InternalJob<any>[] = [];
+
+  private running = false;
+  private processing = false;
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly tickIntervalMs = 50,
+    private readonly retryBackoffMs = 500,
+  ) {}
+
+  enqueue<Data = unknown>(
+    type: string,
+    payload: Data,
+    options?: EnqueueOptions,
+  ): string {
+    const id = options?.id ?? generateId();
+    const maxAttempts = options?.maxAttempts ?? 3;
+    const delayMs = options?.delayMs ?? 0;
+    const now = Date.now();
+
+    const job: InternalJob<Data> = {
+      id,
+      type,
+      payload,
+      attempts: 0,
+      maxAttempts,
+      createdAt: now,
+      updatedAt: now,
+      nextRunAt: now + delayMs,
+    };
+
+    this.pending.push(job);
+    return id;
+  }
+
+  registerHandler<Data = unknown>(
+    type: string,
+    handler: JobHandler<Data>,
+  ): void {
+    this.handlers.set(type, handler as JobHandler<any>);
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    if (!this.intervalHandle) {
+      this.intervalHandle = setInterval(
+        () => {
+          void this.processTick();
+        },
+        this.tickIntervalMs,
+      );
+    }
+  }
+
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  size(): number {
+    return this.pending.length;
+  }
+
+  getFailedJobs(): readonly Job[] {
+    return this.failed.slice();
+  }
+
+  async drain(): Promise<void> {
+    // Temporarily run a tight loop until no ready jobs remain.
+    // This intentionally ignores delayMs/backoff that are still in the future.
+    // Callers that rely on timers should combine this with fake timers.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const hadReady = await this.processTick();
+      if (!hadReady) break;
+    }
+  }
+
+  private async processTick(): Promise<boolean> {
+    if (!this.running || this.processing) return false;
+    const now = Date.now();
+    const ready: InternalJob<any>[] = [];
+    const waiting: InternalJob<any>[] = [];
+
+    for (const job of this.pending) {
+      if (job.nextRunAt <= now) {
+        ready.push(job);
+      } else {
+        waiting.push(job);
+      }
+    }
+
+    if (ready.length === 0) {
+      return false;
+    }
+
+    this.processing = true;
+    this.pending.length = 0;
+    this.pending.push(...waiting);
+
+    try {
+      for (const job of ready) {
+        const handler = this.handlers.get(job.type);
+        if (!handler) {
+          // No handler registered – drop the job but log loudly.
+          console.error(
+            `[JobQueue] No handler registered for job type "${job.type}". Dropping job ${job.id}.`,
+          );
+          this.failed.push(job);
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        try {
+          await handler(job);
+        } catch (err) {
+          job.attempts += 1;
+          job.updatedAt = Date.now();
+
+          if (job.attempts < job.maxAttempts) {
+            job.nextRunAt = job.updatedAt + this.retryBackoffMs;
+            this.pending.push(job);
+          } else {
+            this.failed.push(job);
+            console.error(
+              `[JobQueue] Job ${job.id} of type "${job.type}" failed after ${job.attempts} attempts.`,
+              err,
+            );
+          }
+        }
+      }
+    } finally {
+      this.processing = false;
+    }
+
+    return ready.length > 0;
+  }
+}
+
+/**
+ * Shared singleton queue instance for simple use cases.
+ *
+ * Code that needs more control (e.g. tests, workers) can instantiate its own
+ * `InMemoryJobQueue` instead of using this default export.
+ */
+export const defaultJobQueue: JobQueue = new InMemoryJobQueue();
+


### PR DESCRIPTION
Description:

## Summary
- Introduce a minimal, in-memory async job queue abstraction with retries and basic failure handling.
- Provide a default singleton queue plus a typed `JobQueue` interface so the implementation can later be swapped for Redis or another backend with no API changes.
- Cover the queue logic with high-coverage tests (enqueue/dequeue, delays, retries, and failure paths).

## Details
- Add `InMemoryJobQueue` implementing `JobQueue` with support for:
  - Typed jobs (`type`, `payload`) and stable job IDs.
  - Configurable `maxAttempts` and `delayMs` per job.
  - Simple retry backoff and a failed-jobs collection for diagnostics.
- Expose a `defaultJobQueue` instance for application code to use without wiring.
- Add unit tests validating:
  - Successful job processing and payload delivery to handlers.
  - Delayed execution via `delayMs`.
  - Automatic retries up to `maxAttempts`, followed by moving jobs to the failed set.
  - Behaviour when no handler is registered for a job type.
  - Idempotent `start()`/`stop()` and the `drain()` helper for deterministic testing.

## Future work
- Replace the in-memory implementation with a Redis-backed (or other) queue worker, reusing the same `JobQueue` interface.
- Wire the queue into interest accrual, risk recalculation, and notification flows as async jobs.
Closes #35 , #37, #38