### PR TITLE
feat(soroban): implement real reconciliation reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,17 @@ API_KEYS=change-me-before-any-real-traffic
 # API key for admin-only endpoints (X-Admin-Api-Key header).
 # When unset, admin endpoints respond 503 Service Unavailable.
 # ADMIN_API_KEY=
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — Soroban reconciliation read path
+# -----------------------------------------------------------------------------
+
+# Reconciliation keeps using MockSorobanClient while CREDIT_CONTRACT_ID is empty.
+# Set a deployed Credit contract id (C...) to read enumerate_credit_lines through
+# Soroban RPC and compare on-chain state with the backend database.
+# SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+# CREDIT_CONTRACT_ID=
+# STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+# SOROBAN_TIMEOUT_MS=30000
+# SOROBAN_MAX_RETRIES=3
+# SOROBAN_RETRY_JITTER_MS=1000

--- a/docs/INDEXER.md
+++ b/docs/INDEXER.md
@@ -16,7 +16,7 @@ flowchart LR
     HND --> SVC[CreditLineService / TransactionRepository]
 
     DB[(PostgreSQL)] -->|findAll| RCS
-    SRPC[(Soroban RPC)] -->|fetchAllCreditRecords| SOR[MockSorobanClient]
+    SRPC[(Soroban RPC)] -->|enumerate_credit_lines| SOR[StellarSorobanClient / Mock fallback]
     SOR --> RCS[ReconciliationService]
     RCS --> JQ[jobQueue]
     JQ --> RCW[ReconciliationWorker]
@@ -128,6 +128,21 @@ sequenceDiagram
 ```
 
 ### 6.1 Compared fields
+
+`ReconciliationService` reads on-chain state through `createSorobanClient()`.
+An empty `CREDIT_CONTRACT_ID` deliberately selects `MockSorobanClient` for
+local development and tests. A non-empty contract id selects
+`StellarSorobanClient`, which builds read-only `simulateTransaction` requests
+against the Credit contract's `enumerate_credit_lines(start_after, limit)`
+query and follows the contract's stable numeric cursor in pages of 100.
+
+The contract returns `(u32, CreditLineData)` entries. The numeric id is the
+contract enumeration cursor, not the backend database UUID, so reconciliation
+matches DB rows and chain rows by borrower wallet address. `availableCredit` is
+computed from `credit_limit - utilized_amount`; it is not expected as a stored
+contract field. Timeout, retry, and jitter are controlled by
+`SOROBAN_TIMEOUT_MS`, `SOROBAN_MAX_RETRIES`, and `SOROBAN_RETRY_JITTER_MS`.
+Thrown and logged diagnostics redact Stellar public keys and secret seeds.
 
 | Field | Severity if mismatched |
 |---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "creditra-backend",
       "version": "0.1.0",
+      "license": "UNLICENSED",
       "dependencies": {
+        "@stellar/stellar-sdk": "^15.1.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "pg": "^8.11.3",
@@ -35,6 +37,9 @@
         "tsx": "^4.7.0",
         "typescript": "~5.2.2",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -75,7 +80,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1763,11 +1767,25 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2184,6 +2202,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stellar/js-xdr": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-15.0.0.tgz",
+      "integrity": "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "@stellar/js-xdr": "^4.0.0",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-15.1.0.tgz",
+      "integrity": "sha512-GsJUcWx2yboVzYdhTe/LHS3V1wVLSHkUkglC5bBoYWGJt31vzIhbSGno60NP9CdCTNkLJdnrsLJ63oA58Zvh5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^15.0.0",
+        "axios": "1.15.0",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.3",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.11"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2556,7 +2624,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3149,7 +3216,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3165,6 +3231,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3322,7 +3400,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -3332,6 +3409,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3440,6 +3544,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
@@ -3451,6 +3584,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -3535,7 +3677,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3573,6 +3714,30 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3587,6 +3752,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3816,13 +3999,21 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/component-emitter": {
@@ -3928,7 +4119,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3974,11 +4164,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4174,7 +4380,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4264,7 +4469,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4464,6 +4668,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/execa": {
@@ -4692,6 +4905,15 @@
         }
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4790,6 +5012,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4808,17 +5065,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5113,6 +5369,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -5129,7 +5397,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5142,9 +5409,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5180,6 +5447,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -5201,6 +5481,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5293,6 +5593,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5356,6 +5668,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -5368,6 +5692,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5469,7 +5814,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7043,7 +7387,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -7276,6 +7619,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -7411,6 +7763,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7439,9 +7800,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -7479,6 +7840,15 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -7807,11 +8177,48 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8427,6 +8834,20 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8448,6 +8869,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
@@ -8542,7 +8969,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8606,13 +9032,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8727,6 +9166,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -8766,7 +9211,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -8845,7 +9289,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -8946,6 +9389,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {
@@ -9135,7 +9599,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "load:spike": "k6 run scripts/load/spike.js"
   },
   "dependencies": {
+    "@stellar/stellar-sdk": "^15.1.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "pg": "^8.11.3",
@@ -51,6 +52,11 @@
     "swagger-ui-express": "^5.0.1",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
+  },
+  "overrides": {
+    "axios": "^1.18.0",
+    "form-data": "^4.0.6",
+    "qs": "^6.15.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/src/__tests__/reconciliation.integration.test.ts
+++ b/src/__tests__/reconciliation.integration.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { StrKey, nativeToScVal } from '@stellar/stellar-sdk';
 import { ReconciliationService, type OnChainCreditRecord, type SorobanRpcClient } from '../services/reconciliationService.js';
 import { ReconciliationWorker } from '../services/reconciliationWorker.js';
 import { InMemoryCreditLineRepository } from '../repositories/memory/InMemoryCreditLineRepository.js';
 import { InMemoryJobQueue } from '../services/jobQueue.js';
-import { CreditLineStatus } from '../models/CreditLine.js';
+import { StellarSorobanClient } from '../services/sorobanClient.js';
+
+const TEST_PUBLIC_KEY = `G${'A'.repeat(55)}`;
+const TEST_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 1));
+
+function pageXdr(value: unknown): string {
+  return nativeToScVal(value).toXDR('base64');
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, statusText: 'OK' });
+}
 
 class TestSorobanClient implements SorobanRpcClient {
   private records: OnChainCreditRecord[] = [];
@@ -100,6 +112,59 @@ describe('Reconciliation Integration', () => {
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining('completed successfully')
     );
+  });
+
+  it('end-to-end: real Soroban client output flows through reconciliation', async () => {
+    const creditLine = await repository.create({
+      walletAddress: TEST_PUBLIC_KEY,
+      creditLimit: '10000.00',
+      interestRateBps: 500,
+    });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        result: {
+          results: [
+            {
+              xdr: pageXdr([
+                [
+                  0,
+                  {
+                    borrower: TEST_PUBLIC_KEY,
+                    credit_limit: creditLine.creditLimit,
+                    utilized_amount: '0.00',
+                    interest_rate_bps: creditLine.interestRateBps,
+                    status: 'active',
+                  },
+                ],
+              ]),
+            },
+          ],
+        },
+      }),
+    );
+    const realSorobanClient = new StellarSorobanClient(
+      {
+        rpcUrl: 'https://soroban-testnet.stellar.org',
+        contractId: TEST_CONTRACT_ID,
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      },
+      {
+        rpcUrl: 'https://soroban-testnet.stellar.org',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+        timeoutMs: 50,
+        maxRetries: 0,
+        retryJitterMs: 0,
+      },
+      fetchImpl as unknown as typeof fetch,
+      { sleep: vi.fn().mockResolvedValue(undefined), random: () => 0 },
+    );
+    const realService = new ReconciliationService(repository, realSorobanClient, jobQueue);
+
+    const result = await realService.reconcile();
+
+    expect(result.mismatches).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('end-to-end: handles warning-level mismatches without failing', async () => {

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -27,7 +27,7 @@ import { CreditLineService } from "../services/CreditLineService.js";
 import { RiskEvaluationService } from "../services/RiskEvaluationService.js";
 import { ReconciliationService } from "../services/reconciliationService.js";
 import { ReconciliationWorker } from "../services/reconciliationWorker.js";
-import { MockSorobanClient, resolveSorobanConfig } from "../services/sorobanClient.js";
+import { createSorobanClient, resolveSorobanConfig } from "../services/sorobanClient.js";
 import { defaultJobQueue } from "../services/jobQueue.js";
 
 export class Container {
@@ -60,7 +60,7 @@ export class Container {
     
     // Initialize Soroban client and reconciliation services
     const sorobanConfig = resolveSorobanConfig();
-    const sorobanClient = new MockSorobanClient(sorobanConfig);
+    const sorobanClient = createSorobanClient(sorobanConfig);
     this._reconciliationService = new ReconciliationService(
       this._creditLineRepository,
       sorobanClient,

--- a/src/services/__tests__/reconciliationService.test.ts
+++ b/src/services/__tests__/reconciliationService.test.ts
@@ -65,7 +65,7 @@ describe('ReconciliationService', () => {
       };
 
       const chainRecord: OnChainCreditRecord = {
-        id: 'cl-1',
+        id: '7',
         walletAddress: 'GTEST123',
         creditLimit: '10000.00',
         availableCredit: '10000.00',
@@ -81,6 +81,36 @@ describe('ReconciliationService', () => {
       expect(result.mismatches).toHaveLength(0);
       expect(result.totalChecked).toBe(1);
       expect(result.errors).toHaveLength(0);
+    });
+
+    it('matches records by borrower wallet instead of mismatching DB UUIDs with contract ids', async () => {
+      const creditLine: CreditLine = {
+        id: '7e5f5b84-e325-4a27-bf2a-241a2f12fd66',
+        walletAddress: 'GTEST123',
+        creditLimit: '10000.00',
+        availableCredit: '7500.00',
+        interestRateBps: 500,
+        status: CreditLineStatus.ACTIVE,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const chainRecord: OnChainCreditRecord = {
+        id: '0',
+        walletAddress: 'GTEST123',
+        creditLimit: '10000.00',
+        availableCredit: '7500.00',
+        interestRateBps: 500,
+        status: 'active',
+      };
+
+      mockRepo.setCreditLines([creditLine]);
+      mockClient.setRecords([chainRecord]);
+
+      const result = await service.reconcile();
+
+      expect(result.mismatches).toEqual([]);
+      expect(result.errors).toEqual([]);
     });
 
     it('detects credit limit mismatch', async () => {

--- a/src/services/__tests__/sorobanClient.test.ts
+++ b/src/services/__tests__/sorobanClient.test.ts
@@ -1,100 +1,206 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MockSorobanClient, resolveSorobanConfig } from '../sorobanClient.js';
+import { StrKey, nativeToScVal } from '@stellar/stellar-sdk';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSorobanClient,
+  MockSorobanClient,
+  parseEnumeratedCreditLinesScVal,
+  resolveSorobanConfig,
+  SorobanCreditRecordDecodeError,
+  StellarSorobanClient,
+} from '../sorobanClient.js';
 
-describe('MockSorobanClient', () => {
-  let client: MockSorobanClient;
+const TEST_PUBLIC_KEY = `G${'A'.repeat(55)}`;
+const TEST_SECRET_KEY = `S${'C'.repeat(55)}`;
+const TEST_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 1));
+const TEST_CONFIG = {
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  contractId: TEST_CONTRACT_ID,
+  networkPassphrase: 'Test SDF Network ; September 2015',
+};
+const TEST_RPC_CONFIG = {
+  rpcUrl: TEST_CONFIG.rpcUrl,
+  networkPassphrase: TEST_CONFIG.networkPassphrase,
+  timeoutMs: 50,
+  maxRetries: 0,
+  retryJitterMs: 0,
+};
 
-  beforeEach(() => {
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-    
-    client = new MockSorobanClient({
-      rpcUrl: 'https://soroban-testnet.stellar.org',
-      contractId: 'CTEST123',
-      networkPassphrase: 'Test SDF Network ; September 2015',
-    });
-  });
+function pageXdr(value: unknown): string {
+  return nativeToScVal(value).toXDR('base64');
+}
 
-  describe('fetchAllCreditRecords()', () => {
-    it('returns empty array in mock implementation', async () => {
-      const records = await client.fetchAllCreditRecords();
-      expect(records).toEqual([]);
-    });
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, statusText: status === 200 ? 'OK' : 'failed' });
+}
 
-    it('logs fetch attempt with config details', async () => {
-      await client.fetchAllCreditRecords();
-      
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Fetching credit records')
-      );
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('CTEST123')
-      );
-    });
-
-    it('completes without throwing', async () => {
-      await expect(client.fetchAllCreditRecords()).resolves.not.toThrow();
-    });
-  });
-});
-
-describe('resolveSorobanConfig()', () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    process.env = { ...originalEnv };
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
-  it('returns default config when no env vars set', () => {
+describe('resolveSorobanConfig', () => {
+  it('uses documented defaults when env vars are absent', () => {
+    const previousEnv = { ...process.env };
     delete process.env['SOROBAN_RPC_URL'];
     delete process.env['CREDIT_CONTRACT_ID'];
     delete process.env['STELLAR_NETWORK_PASSPHRASE'];
 
-    const config = resolveSorobanConfig();
+    try {
+      expect(resolveSorobanConfig()).toEqual({
+        rpcUrl: 'https://soroban-testnet.stellar.org',
+        contractId: '',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      });
+    } finally {
+      process.env = previousEnv;
+    }
+  });
+});
 
-    expect(config.rpcUrl).toBe('https://soroban-testnet.stellar.org');
-    expect(config.contractId).toBe('');
-    expect(config.networkPassphrase).toBe('Test SDF Network ; September 2015');
+describe('createSorobanClient', () => {
+  it('falls back to MockSorobanClient when CREDIT_CONTRACT_ID is empty', () => {
+    expect(createSorobanClient({ ...TEST_CONFIG, contractId: '   ' }, TEST_RPC_CONFIG)).toBeInstanceOf(
+      MockSorobanClient,
+    );
   });
 
-  it('reads SOROBAN_RPC_URL from env', () => {
-    process.env['SOROBAN_RPC_URL'] = 'https://custom-rpc.example.com';
-
-    const config = resolveSorobanConfig();
-
-    expect(config.rpcUrl).toBe('https://custom-rpc.example.com');
+  it('selects StellarSorobanClient when CREDIT_CONTRACT_ID is set', () => {
+    expect(createSorobanClient(TEST_CONFIG, TEST_RPC_CONFIG)).toBeInstanceOf(StellarSorobanClient);
   });
+});
 
-  it('reads CREDIT_CONTRACT_ID from env', () => {
-    process.env['CREDIT_CONTRACT_ID'] = 'CCONTRACT123';
+describe('MockSorobanClient', () => {
+  it('returns an empty record set for local and test environments', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
-    const config = resolveSorobanConfig();
-
-    expect(config.contractId).toBe('CCONTRACT123');
+    try {
+      await expect(new MockSorobanClient({ ...TEST_CONFIG, contractId: '' }).fetchAllCreditRecords()).resolves.toEqual(
+        [],
+      );
+      expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('CREDIT_CONTRACT_ID is empty'), {
+        rpcUrl: TEST_CONFIG.rpcUrl,
+      });
+    } finally {
+      consoleLog.mockRestore();
+    }
   });
+});
 
-  it('reads STELLAR_NETWORK_PASSPHRASE from env', () => {
-    process.env['STELLAR_NETWORK_PASSPHRASE'] = 'Public Global Stellar Network ; September 2015';
-
-    const config = resolveSorobanConfig();
-
-    expect(config.networkPassphrase).toBe('Public Global Stellar Network ; September 2015');
-  });
-
-  it('reads all config values from env simultaneously', () => {
-    process.env['SOROBAN_RPC_URL'] = 'https://mainnet-rpc.stellar.org';
-    process.env['CREDIT_CONTRACT_ID'] = 'CMAINNET456';
-    process.env['STELLAR_NETWORK_PASSPHRASE'] = 'Public Global Stellar Network ; September 2015';
-
-    const config = resolveSorobanConfig();
-
-    expect(config).toEqual({
-      rpcUrl: 'https://mainnet-rpc.stellar.org',
-      contractId: 'CMAINNET456',
-      networkPassphrase: 'Public Global Stellar Network ; September 2015',
+describe('StellarSorobanClient', () => {
+  it('simulates enumerate_credit_lines and decodes the contract-native page shape', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        result: {
+          results: [
+            {
+              xdr: pageXdr([
+                [
+                  0,
+                  {
+                    borrower: TEST_PUBLIC_KEY,
+                    credit_limit: '10000.0000000',
+                    utilized_amount: '2500.0000000',
+                    interest_rate_bps: 425,
+                    status: 'Active',
+                  },
+                ],
+              ]),
+            },
+          ],
+        },
+      }),
+    );
+    const client = new StellarSorobanClient(TEST_CONFIG, TEST_RPC_CONFIG, fetchImpl as unknown as typeof fetch, {
+      sleep: vi.fn().mockResolvedValue(undefined),
+      random: () => 0,
     });
+
+    await expect(client.fetchAllCreditRecords()).resolves.toEqual([
+      {
+        id: '0',
+        walletAddress: TEST_PUBLIC_KEY,
+        creditLimit: '10000.0000000',
+        availableCredit: '7500.0000000',
+        interestRateBps: 425,
+        status: 'active',
+      },
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body))).toMatchObject({
+      method: 'simulateTransaction',
+    });
+  });
+
+  it('rejects invalid contract ids before posting RPC', async () => {
+    const fetchImpl = vi.fn();
+    const client = new StellarSorobanClient(
+      { ...TEST_CONFIG, contractId: 'CINVALID' },
+      TEST_RPC_CONFIG,
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    await expect(client.fetchAllCreditRecords()).rejects.toThrow('Invalid CREDIT_CONTRACT_ID');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('redacts Stellar public and secret keys from thrown error strings', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ error: `failed for ${TEST_PUBLIC_KEY} using ${TEST_SECRET_KEY}` }));
+    const client = new StellarSorobanClient(TEST_CONFIG, TEST_RPC_CONFIG, fetchImpl as unknown as typeof fetch);
+
+    await expect(client.fetchAllCreditRecords()).rejects.toThrow('[REDACTED_STELLAR_PUBLIC_KEY]');
+    await expect(client.fetchAllCreditRecords()).rejects.toThrow('[REDACTED_STELLAR_SECRET_KEY]');
+  });
+});
+
+describe('parseEnumeratedCreditLinesScVal', () => {
+  it('maps CreditLineData fields and computes availableCredit from utilized_amount', () => {
+    expect(
+      parseEnumeratedCreditLinesScVal(
+        nativeToScVal([
+          [
+            7,
+            {
+              borrower: TEST_PUBLIC_KEY,
+              credit_limit: '999999999999999999.0000001',
+              utilized_amount: '0.0000001',
+              interest_rate_bps: 700,
+              status: { tag: 'Suspended' },
+            },
+          ],
+        ]),
+      ),
+    ).toEqual([
+      {
+        id: '7',
+        walletAddress: TEST_PUBLIC_KEY,
+        creditLimit: '999999999999999999.0000001',
+        availableCredit: '999999999999999999.0000000',
+        interestRateBps: 700,
+        status: 'suspended',
+      },
+    ]);
+  });
+
+  it('accepts tuple CreditLineData in contract field order', () => {
+    expect(
+      parseEnumeratedCreditLinesScVal(nativeToScVal([[1, [TEST_PUBLIC_KEY, 1000n, 250n, 300, 70, 0]]])),
+    ).toEqual([
+      {
+        id: '1',
+        walletAddress: TEST_PUBLIC_KEY,
+        creditLimit: '1000',
+        availableCredit: '750',
+        interestRateBps: 300,
+        status: 'active',
+      },
+    ]);
+  });
+
+  it('rejects duplicate borrowers instead of letting reconciliation hide them', () => {
+    expect(() =>
+      parseEnumeratedCreditLinesScVal(
+        nativeToScVal([
+          [0, [TEST_PUBLIC_KEY, 1000n, 0n, 300, 70, 'Active']],
+          [1, [TEST_PUBLIC_KEY, 2000n, 0n, 300, 70, 'Active']],
+        ]),
+      ),
+    ).toThrow(SorobanCreditRecordDecodeError);
   });
 });

--- a/src/services/reconciliationService.ts
+++ b/src/services/reconciliationService.ts
@@ -7,6 +7,7 @@
 
 import type { CreditLineRepository } from '../repositories/interfaces/CreditLineRepository.js';
 import type { JobQueue } from './jobQueue.js';
+import { sanitizeJsonForStellarDiagnostics, sanitizeStellarDiagnostic } from './stellarDiagnostics.js';
 
 export interface OnChainCreditRecord {
   /** Contract-level credit line identifier */
@@ -83,15 +84,16 @@ export class ReconciliationService {
       // Fetch all credit records from on-chain contract
       const chainRecords = await this.sorobanClient.fetchAllCreditRecords();
 
-      // Create lookup maps
-      const dbMap = new Map(dbCreditLines.map(cl => [cl.id, cl]));
-      const chainMap = new Map(chainRecords.map(cr => [cr.id, cr]));
+      // The credit contract enumerates stable numeric ids, while the backend DB
+      // owns UUID credit-line ids. Borrower wallet address is the shared natural key.
+      const dbMap = new Map(dbCreditLines.map(cl => [walletKey(cl.walletAddress), cl]));
+      const chainMap = new Map(chainRecords.map(cr => [walletKey(cr.walletAddress), cr]));
 
       result.totalChecked = Math.max(dbCreditLines.length, chainRecords.length);
 
       // Check for records in DB but not on chain
       for (const dbLine of dbCreditLines) {
-        const chainRecord = chainMap.get(dbLine.id);
+        const chainRecord = chainMap.get(walletKey(dbLine.walletAddress));
         
         if (!chainRecord) {
           result.mismatches.push({
@@ -111,7 +113,7 @@ export class ReconciliationService {
 
       // Check for records on chain but not in DB
       for (const chainRecord of chainRecords) {
-        if (!dbMap.has(chainRecord.id)) {
+        if (!dbMap.has(walletKey(chainRecord.walletAddress))) {
           result.mismatches.push({
             creditLineId: chainRecord.id,
             walletAddress: chainRecord.walletAddress,
@@ -127,7 +129,7 @@ export class ReconciliationService {
       if (result.mismatches.length > 0) {
         console.error(
           `[ReconciliationService] Found ${result.mismatches.length} mismatches:`,
-          JSON.stringify(result.mismatches, null, 2)
+          sanitizeJsonForStellarDiagnostics(result.mismatches)
         );
       } else {
         console.log(
@@ -136,9 +138,9 @@ export class ReconciliationService {
       }
 
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = sanitizeStellarDiagnostic(error);
       result.errors.push(errorMessage);
-      console.error('[ReconciliationService] Reconciliation failed:', error);
+      console.error('[ReconciliationService] Reconciliation failed:', errorMessage);
     }
 
     return result;
@@ -209,4 +211,8 @@ export class ReconciliationService {
       });
     }
   }
+}
+
+function walletKey(walletAddress: string): string {
+  return walletAddress.trim();
 }

--- a/src/services/sorobanClient.ts
+++ b/src/services/sorobanClient.ts
@@ -1,11 +1,38 @@
-/**
- * Soroban RPC Client for interacting with on-chain Credit contracts.
- * 
- * This is a skeleton implementation that simulates RPC calls.
- * In production, replace with actual Soroban SDK calls.
- */
-
+import {
+  Account,
+  BASE_FEE,
+  Contract,
+  StrKey,
+  TransactionBuilder,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
 import type { OnChainCreditRecord, SorobanRpcClient } from './reconciliationService.js';
+import { resolveSorobanRpcConfig, type SorobanRpcConfig } from './sorobanRpcClient.js';
+import { sanitizeStellarDiagnostic } from './stellarDiagnostics.js';
+
+const DEFAULT_RPC_URL = 'https://soroban-testnet.stellar.org';
+const DEFAULT_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+const ENUMERATE_CREDIT_LINES_METHOD = 'enumerate_credit_lines';
+const SIMULATION_SOURCE_ACCOUNT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const ENUMERATION_PAGE_LIMIT = 100;
+const BASE_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_POWER = 10;
+
+interface JsonRpcResponse<T> {
+  result?: T;
+  error?: unknown;
+}
+
+interface RetryRuntime {
+  sleep(ms: number): Promise<void>;
+  random(): number;
+}
+
+interface EnumeratedCreditRecord extends OnChainCreditRecord {
+  cursor: number;
+}
 
 export interface SorobanClientConfig {
   rpcUrl: string;
@@ -13,38 +40,570 @@ export interface SorobanClientConfig {
   networkPassphrase: string;
 }
 
+export class SorobanCreditRecordDecodeError extends Error {
+  constructor(message: string) {
+    super(sanitizeStellarDiagnostic(message));
+    this.name = 'SorobanCreditRecordDecodeError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+class SorobanCreditRecordFetchError extends Error {
+  constructor(
+    message: string,
+    readonly retryable = true,
+  ) {
+    super(sanitizeStellarDiagnostic(message));
+    this.name = 'SorobanCreditRecordFetchError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Test and local-development fallback used when CREDIT_CONTRACT_ID is empty. */
 export class MockSorobanClient implements SorobanRpcClient {
-  constructor(private config: SorobanClientConfig) {}
+  constructor(private readonly config: SorobanClientConfig) {}
 
-  /**
-   * Fetch all credit records from the on-chain contract.
-   * 
-   * TODO: Replace with actual Soroban RPC calls using @stellar/stellar-sdk
-   * Example:
-   * - Use SorobanRpc.Server to connect
-   * - Call contract method to list all credit lines
-   * - Parse XDR responses into OnChainCreditRecord format
-   */
   async fetchAllCreditRecords(): Promise<OnChainCreditRecord[]> {
-    console.log(
-      `[SorobanClient] Fetching credit records from ${this.config.rpcUrl} ` +
-      `(contract: ${this.config.contractId})`
-    );
+    console.log('[MockSorobanClient] CREDIT_CONTRACT_ID is empty; returning no on-chain credit records.', {
+      rpcUrl: sanitizeStellarDiagnostic(this.config.rpcUrl),
+    });
 
-    // Simulated response - replace with actual RPC call
-    // In production:
-    // const server = new SorobanRpc.Server(this.config.rpcUrl);
-    // const contract = new Contract(this.config.contractId);
-    // const result = await server.getContractData(...);
-    
     return [];
   }
 }
 
-export function resolveSorobanConfig(): SorobanClientConfig {
-  const rpcUrl = process.env['SOROBAN_RPC_URL'] ?? 'https://soroban-testnet.stellar.org';
-  const contractId = process.env['CREDIT_CONTRACT_ID'] ?? '';
-  const networkPassphrase = process.env['STELLAR_NETWORK_PASSPHRASE'] ?? 'Test SDF Network ; September 2015';
+export class StellarSorobanClient implements SorobanRpcClient {
+  private readonly config: SorobanClientConfig;
+  private readonly rpcConfig: Required<Pick<SorobanRpcConfig, 'timeoutMs' | 'maxRetries' | 'retryJitterMs'>>;
+  private readonly fetchImpl: typeof fetch;
+  private readonly runtime: RetryRuntime;
 
-  return { rpcUrl, contractId, networkPassphrase };
+  constructor(
+    config: SorobanClientConfig = resolveSorobanConfig(),
+    rpcConfig: SorobanRpcConfig = resolveSorobanRpcConfig(),
+    fetchImpl: typeof fetch = fetch,
+    runtime: RetryRuntime = defaultRetryRuntime,
+  ) {
+    this.config = normalizeSorobanClientConfig(config);
+    this.rpcConfig = {
+      timeoutMs: positiveIntegerOrDefault(rpcConfig.timeoutMs, 30_000),
+      maxRetries: nonNegativeIntegerOrDefault(rpcConfig.maxRetries, 3),
+      retryJitterMs: nonNegativeIntegerOrDefault(rpcConfig.retryJitterMs, 1_000),
+    };
+    this.fetchImpl = fetchImpl;
+    this.runtime = runtime;
+  }
+
+  async fetchAllCreditRecords(): Promise<OnChainCreditRecord[]> {
+    if (!this.config.contractId) {
+      return [];
+    }
+
+    if (!StrKey.isValidContract(this.config.contractId)) {
+      throw new SorobanCreditRecordFetchError('Invalid CREDIT_CONTRACT_ID; expected a C... contract id', false);
+    }
+
+    const records: EnumeratedCreditRecord[] = [];
+    let startAfter: number | undefined;
+
+    for (;;) {
+      const page = await this.fetchCreditRecordPage(startAfter);
+      records.push(...page);
+
+      if (page.length < ENUMERATION_PAGE_LIMIT) {
+        break;
+      }
+
+      startAfter = page[page.length - 1]?.cursor;
+      if (startAfter === undefined) {
+        throw new SorobanCreditRecordDecodeError('Soroban enumeration page did not expose a cursor');
+      }
+    }
+
+    assertUniqueBorrowers(records);
+    return records.map(({ cursor: _cursor, ...record }) => record);
+  }
+
+  private async fetchCreditRecordPage(startAfter: number | undefined): Promise<EnumeratedCreditRecord[]> {
+    const returnValue = await this.withRetry(async () => {
+      const simulation = await this.postJsonRpc('simulateTransaction', {
+        transaction: this.buildEnumerationTransaction(startAfter).toXDR(),
+      });
+      return extractSimulationReturnValue(simulation);
+    });
+
+    return parseEnumeratedCreditLineEntriesScVal(returnValue);
+  }
+
+  private buildEnumerationTransaction(startAfter: number | undefined) {
+    const source = new Account(SIMULATION_SOURCE_ACCOUNT, '0');
+    const startAfterArg = startAfter === undefined
+      ? nativeToScVal(null)
+      : nativeToScVal(startAfter, { type: 'u32' });
+
+    return new TransactionBuilder(source, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(
+        new Contract(this.config.contractId).call(
+          ENUMERATE_CREDIT_LINES_METHOD,
+          startAfterArg,
+          nativeToScVal(ENUMERATION_PAGE_LIMIT, { type: 'u32' }),
+        ),
+      )
+      .setTimeout(Math.max(1, Math.ceil(this.rpcConfig.timeoutMs / 1_000)))
+      .build();
+  }
+
+  private async postJsonRpc(method: string, params: Record<string, unknown>): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.rpcConfig.timeoutMs);
+
+    try {
+      const response = await this.fetchImpl(this.config.rpcUrl, {
+        method: 'POST',
+        headers: { accept: 'application/json', 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+        signal: controller.signal,
+      });
+      const responseBody = await response.text();
+
+      if (!response.ok) {
+        throw new SorobanCreditRecordFetchError(
+          `Soroban RPC HTTP ${response.status} ${response.statusText}: ${responseBody}`,
+          isRetryableHttpStatus(response.status),
+        );
+      }
+
+      const payload = parseJsonRpcResponse(responseBody, method);
+      if (payload.error !== undefined) {
+        throw new SorobanCreditRecordFetchError(
+          `Soroban RPC ${method} failed: ${sanitizeStellarDiagnostic(payload.error)}`,
+          isRetryableJsonRpcError(payload.error),
+        );
+      }
+
+      if (!Object.prototype.hasOwnProperty.call(payload, 'result')) {
+        throw new SorobanCreditRecordFetchError(`Soroban RPC ${method} response missing result`, false);
+      }
+
+      return payload.result;
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new SorobanCreditRecordFetchError(`Soroban RPC timed out after ${this.rpcConfig.timeoutMs}ms`);
+      }
+
+      throw toSorobanError(error);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async withRetry<T>(operation: () => Promise<T>): Promise<T> {
+    let lastError: Error = new SorobanCreditRecordFetchError('Unknown Soroban RPC failure');
+
+    for (let attempt = 0; attempt <= this.rpcConfig.maxRetries; attempt += 1) {
+      try {
+        return await operation();
+      } catch (error) {
+        lastError = toSorobanError(error);
+
+        if (lastError instanceof SorobanCreditRecordDecodeError) {
+          throw lastError;
+        }
+
+        if (lastError instanceof SorobanCreditRecordFetchError && !lastError.retryable) {
+          throw lastError;
+        }
+
+        if (attempt === this.rpcConfig.maxRetries) {
+          throw lastError;
+        }
+
+        await this.runtime.sleep(calculateRetryDelayMs(attempt, this.rpcConfig.retryJitterMs, this.runtime));
+      }
+    }
+
+    throw lastError;
+  }
 }
+
+export function createSorobanClient(
+  config: SorobanClientConfig = resolveSorobanConfig(),
+  rpcConfig: SorobanRpcConfig = resolveSorobanRpcConfig(),
+): SorobanRpcClient {
+  const normalizedConfig = normalizeSorobanClientConfig(config);
+
+  if (!normalizedConfig.contractId) {
+    return new MockSorobanClient(normalizedConfig);
+  }
+
+  return new StellarSorobanClient(normalizedConfig, rpcConfig);
+}
+
+export function resolveSorobanConfig(): SorobanClientConfig {
+  return {
+    rpcUrl: process.env['SOROBAN_RPC_URL'] ?? DEFAULT_RPC_URL,
+    contractId: process.env['CREDIT_CONTRACT_ID'] ?? '',
+    networkPassphrase: process.env['STELLAR_NETWORK_PASSPHRASE'] ?? DEFAULT_NETWORK_PASSPHRASE,
+  };
+}
+
+export function parseEnumeratedCreditLinesScVal(scVal: xdr.ScVal | string): OnChainCreditRecord[] {
+  const records = parseEnumeratedCreditLineEntriesScVal(scVal);
+  assertUniqueBorrowers(records);
+  return records.map(({ cursor: _cursor, ...record }) => record);
+}
+
+function parseEnumeratedCreditLineEntriesScVal(scVal: xdr.ScVal | string): EnumeratedCreditRecord[] {
+  const nativeValue = decodeScVal(scVal);
+
+  if (!Array.isArray(nativeValue)) {
+    throw new SorobanCreditRecordDecodeError('enumerate_credit_lines result must be an array');
+  }
+
+  return nativeValue.map((entry, index) => parseEnumeratedEntry(entry, index));
+}
+
+function decodeScVal(scVal: xdr.ScVal | string): unknown {
+  try {
+    const value = typeof scVal === 'string' ? xdr.ScVal.fromXDR(scVal, 'base64') : scVal;
+    return scValToNative(value);
+  } catch (error) {
+    throw new SorobanCreditRecordDecodeError(
+      `Could not decode enumerate_credit_lines ScVal: ${sanitizeStellarDiagnostic(error)}`,
+    );
+  }
+}
+
+function parseEnumeratedEntry(entry: unknown, index: number): EnumeratedCreditRecord {
+  const tuple = readEnumerationTuple(entry, index);
+  const cursor = toSafeInteger(tuple[0], index, 'cursor');
+  const record = parseCreditLineData(tuple[1], index);
+
+  return {
+    id: String(cursor),
+    walletAddress: record.walletAddress,
+    creditLimit: record.creditLimit,
+    availableCredit: subtractDecimalStrings(record.creditLimit, record.utilizedAmount),
+    interestRateBps: record.interestRateBps,
+    status: record.status,
+    cursor,
+  };
+}
+
+function readEnumerationTuple(entry: unknown, index: number): [unknown, unknown] {
+  if (Array.isArray(entry) && entry.length >= 2) {
+    return [entry[0], entry[1]];
+  }
+
+  if (isRecord(entry)) {
+    const cursor = readOptionalField(entry, ['id', 'cursor', 'creditLineId', 'credit_line_id']);
+    const record = readOptionalField(entry, ['record', 'line', 'creditLine', 'credit_line']);
+
+    if (cursor !== undefined && record !== undefined) {
+      return [cursor, record];
+    }
+  }
+
+  throw new SorobanCreditRecordDecodeError(`enumerate_credit_lines entry ${index} must be an id/record tuple`);
+}
+
+function parseCreditLineData(value: unknown, index: number): {
+  walletAddress: string;
+  creditLimit: string;
+  utilizedAmount: string;
+  interestRateBps: number;
+  status: string;
+} {
+  return {
+    walletAddress: toNonEmptyString(
+      readField(value, ['borrower', 'walletAddress', 'wallet_address'], 0, index),
+      index,
+      'borrower',
+    ),
+    creditLimit: toPreciseString(
+      readField(value, ['credit_limit', 'creditLimit', 'limit'], 1, index),
+      index,
+      'creditLimit',
+    ),
+    utilizedAmount: toPreciseString(
+      readField(value, ['utilized_amount', 'utilizedAmount', 'utilized'], 2, index),
+      index,
+      'utilizedAmount',
+    ),
+    interestRateBps: toSafeInteger(
+      readField(value, ['interest_rate_bps', 'interestRateBps', 'interestRate'], 3, index),
+      index,
+      'interestRateBps',
+    ),
+    status: normalizeCreditStatus(readField(value, ['status'], 5, index), index),
+  };
+}
+
+function readField(value: unknown, fieldNames: string[], tupleIndex: number, recordIndex: number): unknown {
+  if (Array.isArray(value) && tupleIndex < value.length) {
+    return value[tupleIndex];
+  }
+
+  const namedValue = readOptionalField(value, fieldNames);
+  if (namedValue !== undefined) {
+    return namedValue;
+  }
+
+  throw new SorobanCreditRecordDecodeError(
+    `Credit line ${recordIndex} is missing ${fieldNames[0] ?? 'required field'}`,
+  );
+}
+
+function readOptionalField(value: unknown, fieldNames: string[]): unknown {
+  if (value instanceof Map) {
+    for (const [key, entryValue] of value.entries()) {
+      if (fieldNames.includes(String(key))) {
+        return entryValue;
+      }
+    }
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const fieldName of fieldNames) {
+    if (Object.prototype.hasOwnProperty.call(value, fieldName)) {
+      return value[fieldName];
+    }
+  }
+
+  return undefined;
+}
+
+function toNonEmptyString(value: unknown, index: number, field: string): string {
+  const stringValue = toPreciseString(value, index, field);
+
+  if (stringValue.length === 0) {
+    throw new SorobanCreditRecordDecodeError(`Credit line ${index} field ${field} must be non-empty`);
+  }
+
+  return stringValue;
+}
+
+function toPreciseString(value: unknown, index: number, field: string): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'number' && Number.isSafeInteger(value)) {
+    return value.toString();
+  }
+
+  if (hasUsefulToString(value)) {
+    return value.toString();
+  }
+
+  throw new SorobanCreditRecordDecodeError(
+    `Credit line ${index} field ${field} was not a string, bigint, safe integer, or stringable value`,
+  );
+}
+
+function toSafeInteger(value: unknown, index: number, field: string): number {
+  let parsed: number | undefined;
+
+  if (typeof value === 'number' && Number.isSafeInteger(value)) {
+    parsed = value;
+  } else if (typeof value === 'bigint') {
+    parsed = value <= BigInt(Number.MAX_SAFE_INTEGER) && value >= BigInt(Number.MIN_SAFE_INTEGER)
+      ? Number(value)
+      : undefined;
+  } else if (typeof value === 'string' && /^-?\d+$/.test(value)) {
+    const asNumber = Number(value);
+    parsed = Number.isSafeInteger(asNumber) ? asNumber : undefined;
+  }
+
+  if (parsed === undefined) {
+    throw new SorobanCreditRecordDecodeError(`Credit line ${index} field ${field} must be a safe integer`);
+  }
+
+  return parsed;
+}
+
+function normalizeCreditStatus(value: unknown, index: number): string {
+  if (typeof value === 'number') {
+    return ['active', 'suspended', 'defaulted', 'closed', 'restricted'][value] ?? String(value);
+  }
+
+  if (isRecord(value) && typeof value['tag'] === 'string') {
+    return normalizeStatusString(value['tag']);
+  }
+
+  return normalizeStatusString(toNonEmptyString(value, index, 'status'));
+}
+
+function normalizeStatusString(value: string): string {
+  return value.replace(/([a-z0-9])([A-Z])/g, '$1_$2').replace(/[\s-]+/g, '_').toLowerCase();
+}
+
+function subtractDecimalStrings(left: string, right: string): string {
+  const leftParts = parseDecimal(left);
+  const rightParts = parseDecimal(right);
+  const scale = Math.max(leftParts.scale, rightParts.scale);
+  const leftValue = leftParts.value * 10n ** BigInt(scale - leftParts.scale);
+  const rightValue = rightParts.value * 10n ** BigInt(scale - rightParts.scale);
+  const difference = leftValue - rightValue;
+  const negative = difference < 0n;
+  const magnitude = negative ? -difference : difference;
+  const raw = magnitude.toString().padStart(scale + 1, '0');
+
+  if (scale === 0) {
+    return `${negative ? '-' : ''}${raw}`;
+  }
+
+  const whole = raw.slice(0, -scale);
+  const fraction = raw.slice(-scale);
+  return `${negative ? '-' : ''}${whole}.${fraction}`;
+}
+
+function parseDecimal(value: string): { value: bigint; scale: number } {
+  if (!/^-?\d+(?:\.\d+)?$/.test(value)) {
+    throw new SorobanCreditRecordDecodeError(`Cannot subtract non-decimal value ${value}`);
+  }
+
+  const negative = value.startsWith('-');
+  const unsigned = negative ? value.slice(1) : value;
+  const [whole, fraction = ''] = unsigned.split('.');
+  const magnitude = BigInt(`${whole}${fraction}`);
+  return {
+    value: negative ? -magnitude : magnitude,
+    scale: fraction.length,
+  };
+}
+
+function extractSimulationReturnValue(simulation: unknown): xdr.ScVal | string {
+  const direct = readOptionalField(simulation, ['retval', 'returnValue', 'xdr']);
+  if (isScValOrXdrString(direct)) {
+    return direct;
+  }
+
+  const result = readOptionalField(simulation, ['result']);
+  const nested = readOptionalField(result, ['retval', 'returnValue', 'xdr']);
+  if (isScValOrXdrString(nested)) {
+    return nested;
+  }
+
+  const results = readOptionalField(simulation, ['results']);
+  if (Array.isArray(results) && results.length > 0) {
+    const firstResult = results[0];
+    const resultXdr = readOptionalField(firstResult, ['xdr', 'retval']);
+    if (isScValOrXdrString(resultXdr)) {
+      return resultXdr;
+    }
+  }
+
+  throw new SorobanCreditRecordDecodeError('Soroban simulation did not return enumerate_credit_lines XDR');
+}
+
+function isScValOrXdrString(value: unknown): value is xdr.ScVal | string {
+  return typeof value === 'string' || value instanceof xdr.ScVal;
+}
+
+function parseJsonRpcResponse(responseBody: string, method: string): JsonRpcResponse<unknown> {
+  try {
+    return JSON.parse(responseBody) as JsonRpcResponse<unknown>;
+  } catch (error) {
+    throw new SorobanCreditRecordFetchError(
+      `Soroban RPC ${method} returned malformed JSON: ${sanitizeStellarDiagnostic(error)}`,
+      false,
+    );
+  }
+}
+
+function isRetryableJsonRpcError(error: unknown): boolean {
+  const code = isRecord(error) ? error['code'] : undefined;
+  return typeof code === 'number' ? code === -32000 || code === -32001 || code === -32002 : true;
+}
+
+function isRetryableHttpStatus(status: number): boolean {
+  return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+}
+
+function calculateRetryDelayMs(attempt: number, retryJitterMs: number, runtime: RetryRuntime): number {
+  const boundedAttempt = Math.min(attempt, MAX_RETRY_POWER);
+  const jitterMs = Math.floor(runtime.random() * retryJitterMs);
+  return BASE_RETRY_DELAY_MS * 2 ** boundedAttempt + jitterMs;
+}
+
+function toSorobanError(error: unknown): Error {
+  if (error instanceof SorobanCreditRecordDecodeError || error instanceof SorobanCreditRecordFetchError) {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return new SorobanCreditRecordFetchError(error.message, isRetryableError(error));
+  }
+
+  return new SorobanCreditRecordFetchError(sanitizeStellarDiagnostic(error), false);
+}
+
+function isRetryableError(error: Error): boolean {
+  const code = (error as Error & { code?: unknown }).code;
+  const nameOrCode = typeof code === 'string' ? code.toUpperCase() : error.name.toUpperCase();
+  return ['ABORTERROR', 'ECONNABORTED', 'ECONNRESET', 'ETIMEDOUT', 'EPIPE', 'ENETDOWN', 'ENETRESET'].includes(
+    nameOrCode,
+  );
+}
+
+function assertUniqueBorrowers(records: OnChainCreditRecord[]): void {
+  const seen = new Set<string>();
+
+  for (const record of records) {
+    if (seen.has(record.walletAddress)) {
+      throw new SorobanCreditRecordDecodeError(`Duplicate borrower ${record.walletAddress} in Soroban enumeration`);
+    }
+
+    seen.add(record.walletAddress);
+  }
+}
+
+function normalizeSorobanClientConfig(config: SorobanClientConfig): SorobanClientConfig {
+  return {
+    rpcUrl: trimOrDefault(config.rpcUrl, DEFAULT_RPC_URL),
+    contractId: config.contractId.trim(),
+    networkPassphrase: trimOrDefault(config.networkPassphrase, DEFAULT_NETWORK_PASSPHRASE),
+  };
+}
+
+function trimOrDefault(value: string, fallback: string): string {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function positiveIntegerOrDefault(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+function nonNegativeIntegerOrDefault(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : fallback;
+}
+
+function hasUsefulToString(value: unknown): value is { toString(): string } {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as { toString?: unknown }).toString === 'function' &&
+    (value as { toString(): string }).toString() !== '[object Object]'
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+const defaultRetryRuntime: RetryRuntime = {
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  random: () => Math.random(),
+};

--- a/src/services/stellarDiagnostics.ts
+++ b/src/services/stellarDiagnostics.ts
@@ -1,0 +1,39 @@
+const STELLAR_PUBLIC_KEY_REGEX = /\bG[A-Z2-7]{55}\b/g;
+const STELLAR_SECRET_KEY_REGEX = /\bS[A-Z2-7]{55}\b/g;
+
+const REDACTED_PUBLIC_KEY = '[REDACTED_STELLAR_PUBLIC_KEY]';
+const REDACTED_SECRET_KEY = '[REDACTED_STELLAR_SECRET_KEY]';
+
+export function sanitizeStellarDiagnostic(value: unknown): string {
+  return stringifyForDiagnostic(value)
+    .replace(STELLAR_SECRET_KEY_REGEX, REDACTED_SECRET_KEY)
+    .replace(STELLAR_PUBLIC_KEY_REGEX, REDACTED_PUBLIC_KEY);
+}
+
+export function sanitizeJsonForStellarDiagnostics(value: unknown): string {
+  try {
+    return sanitizeStellarDiagnostic(JSON.stringify(value, diagnosticJsonReplacer, 2));
+  } catch {
+    return sanitizeStellarDiagnostic(value);
+  }
+}
+
+function stringifyForDiagnostic(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value, diagnosticJsonReplacer);
+  } catch {
+    return String(value);
+  }
+}
+
+function diagnosticJsonReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value;
+}


### PR DESCRIPTION
## Summary

- replace the reconciliation-only mock path with a Stellar SDK backed Soroban read client
- read the Credit contract's `enumerate_credit_lines(start_after, limit)` query in pages and map `(u32, CreditLineData)` into `OnChainCreditRecord`
- compute `availableCredit` from `credit_limit - utilized_amount` and reconcile DB UUID rows to contract cursor rows by borrower wallet address
- keep the mock fallback when `CREDIT_CONTRACT_ID` is empty, sanitize Stellar diagnostics, and document the env/config path

Closes #228

## Testing

- `npm install --package-lock-only --ignore-scripts`
- `npm audit --production --audit-level=moderate --json`
- `git diff --check`
- `./node_modules/.bin/eslint src/__tests__/reconciliation.integration.test.ts src/services/sorobanClient.ts src/services/stellarDiagnostics.ts src/services/reconciliationService.ts src/services/__tests__/sorobanClient.test.ts src/services/__tests__/reconciliationService.test.ts`
- SDK smoke check for ScVal option encoding, page XDR round-trip, and contract id validation

Full test, coverage, typecheck, and build are left for CI on this draft PR.
