### PR TITLE
docs: add webhook subscriber guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Full machine-readable spec: [`src/openapi.yaml`](./src/openapi.yaml). Human-read
 - **`ReconciliationService` / `ReconciliationWorker`** — periodic diff of DB credit lines vs on-chain state. Severity levels: `critical` (identity, limit, status) and `warning` (available credit, rate). Runs every hour by default (`RECONCILIATION_INTERVAL_MS`).
 - **`HorizonListener`** — Stellar Horizon poller with cursor persistence, exponential backoff + jitter, gap recovery, and SHA-256 idempotency cache (10k entries, LRU). Metrics exposed via `getMetrics()`.
 - **`SorobanRpcClient`** — read/submit wrapper with AbortController timeouts, retry budget, and Stellar key sanitization in error messages.
-- **`drawWebhookService`** — multi-URL HMAC-SHA256 webhook fan-out with retry/backoff and connectivity probe.
+- **`drawWebhookService`** — multi-URL HMAC-SHA256 webhook fan-out with retry/backoff and connectivity probe. Subscriber onboarding: [`docs/webhook-subscribers.md`](./docs/webhook-subscribers.md).
 - **`jobQueue`** — in-process at-least-once queue with visibility timeout, attempt tracking, and dead-letter list.
 
 Implementation files: [`src/services/`](./src/services/), entry composition in [`src/container/Container.ts`](./src/container/Container.ts).

--- a/docs/API.md
+++ b/docs/API.md
@@ -286,6 +286,8 @@ HMAC is computed over the **raw JSON body** with `WEBHOOK_SECRET`. Subscribers m
 
 Server retries up to `WEBHOOK_MAX_RETRIES + 1` times with exponential backoff — implement idempotency on receive.
 
+Subscriber onboarding, verification code, and operator endpoint details are documented in [`webhook-subscribers.md`](./webhook-subscribers.md).
+
 ---
 
 ### Reconciliation

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This directory holds the long-form documentation for the Creditra backend. The t
 |---|---|
 | [`SIGNALS_INGEST.md`](./SIGNALS_INGEST.md) | The behavioral-signal pipeline — Creditra's differentiator. |
 | [`INDEXER.md`](./INDEXER.md) | Stellar Horizon listener, cursor model, gap recovery, reconciliation runbook. |
+| [`webhook-subscribers.md`](./webhook-subscribers.md) | Outbound draw webhook payload, HMAC verification, retries, and subscriber onboarding. |
 | [`SECURITY.md`](./SECURITY.md) | Threat model and in-tree mitigations. |
 | [`OBSERVABILITY.md`](./OBSERVABILITY.md) | Structured logging, metrics, health probes, tracing strategy. |
 | [`TESTING.md`](./TESTING.md) | Test pyramid, file counts, coverage gate, run commands. |

--- a/docs/webhook-subscribers.md
+++ b/docs/webhook-subscribers.md
@@ -1,0 +1,152 @@
+# Webhook Subscriber Guide
+
+Creditra can fan out `draw_confirmed` events to subscriber URLs configured with `WEBHOOK_URLS`. The backend signs each outbound request with an HMAC-SHA256 signature generated from the exact JSON string sent on the wire.
+
+Implementation references:
+
+- [`src/services/drawWebhookService.ts`](../src/services/drawWebhookService.ts)
+- [`src/routes/webhook.ts`](../src/routes/webhook.ts)
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---:|---|
+| `WEBHOOK_URLS` | empty | Comma-separated subscriber URLs. Empty disables outbound delivery. |
+| `WEBHOOK_SECRET` | empty | Shared HMAC secret. Required when `WEBHOOK_URLS` has at least one URL. |
+| `WEBHOOK_MAX_RETRIES` | `3` | Number of retries after the first delivery attempt. |
+| `WEBHOOK_INITIAL_BACKOFF_MS` | `1000` | Initial retry delay in milliseconds. |
+| `WEBHOOK_BACKOFF_MULTIPLIER` | `2.0` | Multiplier applied after each retry delay. |
+| `WEBHOOK_TIMEOUT_MS` | `10000` | Per-request timeout in milliseconds. |
+
+The service attempts delivery once, then retries up to `WEBHOOK_MAX_RETRIES` additional times with exponential backoff.
+
+## Request
+
+Creditra sends a `POST` request to each configured subscriber URL.
+
+```http
+Content-Type: application/json
+X-Webhook-Signature: sha256=<hex HMAC>
+X-Webhook-Timestamp: <payload timestamp>
+User-Agent: Creditra-Webhook/1.0
+```
+
+The signature is computed as:
+
+```text
+hex(hmac_sha256(WEBHOOK_SECRET, raw_json_body))
+```
+
+Verify the signature before parsing JSON. Any change to whitespace, key order, or encoding changes the HMAC input.
+
+## Payload
+
+```json
+{
+  "event": "draw_confirmed",
+  "timestamp": "2026-01-01T00:00:00.000Z",
+  "data": {
+    "ledger": 123456,
+    "contractId": "contract-1",
+    "drawAmount": "100.00",
+    "drawId": "draw-1",
+    "borrowerWallet": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "creditLineId": "credit-line-1",
+    "horizonTimestamp": "2026-01-01T00:00:00Z"
+  }
+}
+```
+
+Fields:
+
+| Field | Type | Source |
+|---|---|---|
+| `event` | `"draw_confirmed"` | Fixed event type emitted by this service. |
+| `timestamp` | ISO-8601 string | Time Creditra generated the webhook payload. |
+| `data.ledger` | number | Horizon ledger number. |
+| `data.contractId` | string | Contract ID from the Horizon event. |
+| `data.drawAmount` | string | Draw amount parsed from the Horizon event JSON. Defaults to `"0"` if absent. |
+| `data.drawId` | string | Stable draw identifier parsed from the Horizon event JSON. |
+| `data.borrowerWallet` | string | Borrower wallet parsed from the Horizon event JSON. |
+| `data.creditLineId` | string | Credit line identifier parsed from the Horizon event JSON. |
+| `data.horizonTimestamp` | string | Timestamp on the original Horizon event. |
+
+Use `data.drawId` as your idempotency key. If the same `drawId` arrives twice, return a 2xx response after confirming the first delivery was already processed.
+
+## Node.js Verification
+
+This Express example keeps the raw body for HMAC verification, compares signatures in constant time, rejects stale timestamps, and deduplicates on `data.drawId`.
+
+```ts
+import crypto from "node:crypto";
+import express from "express";
+
+const app = express();
+const secret = process.env.WEBHOOK_SECRET ?? "";
+const processedDrawIds = new Set<string>();
+const toleranceMs = 5 * 60 * 1000;
+
+app.post(
+  "/creditra/webhook",
+  express.raw({ type: "application/json", limit: "100kb" }),
+  (req, res) => {
+    const rawBody = req.body as Buffer;
+    const signatureHeader = req.header("x-webhook-signature") ?? "";
+    const timestampHeader = req.header("x-webhook-timestamp") ?? "";
+
+    if (!signatureHeader.startsWith("sha256=")) {
+      return res.status(401).json({ error: "missing signature" });
+    }
+
+    const expectedHex = crypto
+      .createHmac("sha256", secret)
+      .update(rawBody)
+      .digest("hex");
+    const providedHex = signatureHeader.slice("sha256=".length);
+
+    const expected = Buffer.from(expectedHex, "hex");
+    const provided = Buffer.from(providedHex, "hex");
+    if (
+      expected.length !== provided.length ||
+      !crypto.timingSafeEqual(expected, provided)
+    ) {
+      return res.status(401).json({ error: "invalid signature" });
+    }
+
+    const sentAt = Date.parse(timestampHeader);
+    if (!Number.isFinite(sentAt) || Math.abs(Date.now() - sentAt) > toleranceMs) {
+      return res.status(401).json({ error: "stale webhook" });
+    }
+
+    const payload = JSON.parse(rawBody.toString("utf8")) as {
+      event: "draw_confirmed";
+      data: { drawId: string };
+    };
+
+    if (processedDrawIds.has(payload.data.drawId)) {
+      return res.status(200).json({ duplicate: true });
+    }
+
+    processedDrawIds.add(payload.data.drawId);
+    return res.status(200).json({ ok: true });
+  },
+);
+```
+
+## Operator Endpoints
+
+These endpoints are mounted under `/api/webhooks` and describe the server's outbound webhook fan-out.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/webhooks/config` | Returns sanitized webhook configuration: URLs, retry knobs, timeout, and configured state. It never returns `WEBHOOK_SECRET`. |
+| `POST` | `/api/webhooks/test` | Sends a connectivity probe to each configured URL and returns `{ total, reachable, unreachable, results }`. |
+| `GET` | `/api/webhooks/health` | Returns `disabled` when no URLs are configured, otherwise `active` with URL count and retry settings. |
+
+## Subscriber Checklist
+
+- Verify `X-Webhook-Signature` against the raw request body before JSON parsing.
+- Compare HMACs with `crypto.timingSafeEqual` or an equivalent constant-time primitive.
+- Reject missing, malformed, or stale `X-Webhook-Timestamp` values.
+- Deduplicate successful processing by `data.drawId`.
+- Return any 2xx status only after the event is durably accepted or already known as a duplicate.

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -8,7 +8,7 @@
  *
  * Signature contract sent to subscribers:
  * - `X-Webhook-Signature: sha256=<hex HMAC over raw body>`
- * - `X-Webhook-Timestamp: <ms since epoch>`
+ * - `X-Webhook-Timestamp: <payload ISO timestamp>`
  * - `User-Agent: Creditra-Webhook/1.0`
  *
  * Subscribers must (a) re-compute the HMAC and compare in constant time,


### PR DESCRIPTION
## Summary
- add a subscriber onboarding guide for draw webhook delivery
- document HMAC verification, timestamp handling, idempotency, retries, and operator endpoints
- link the guide from the README and API docs

Closes #237