### PR TITLE
security: harden admin auth and log redaction

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -175,6 +175,7 @@ Subscriber expectation (documented in [`docs/API.md`](./API.md) §Webhooks):
 - **Rotation.** `loadApiKeys()` is invoked per-request via a resolver closure so partner keys can be rotated by updating the env source (e.g. Kubernetes Secret + restart-free reload) without redeploying.
 - **Out of logs.** The Pino-based [`logger`](../src/utils/logger.ts) is paired with [`logRedact.ts`](../src/utils/logRedact.ts) which:
   - Redacts Stellar pubkeys (`G[A-Z2-7]{55}`) to `Gxxxxx...xxxx` form.
+  - Masks Stellar secret seeds, muxed accounts, and email addresses.
   - Walks nested objects and `Error.message`.
   - Is opt-out via `LOG_REDACTION_DEBUG` for incident response.
 - **Sanitized errors.** [`sorobanRpcClient`](../src/services/sorobanRpcClient.ts) strips Stellar keys from any thrown error before propagation.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -9,10 +9,10 @@ This document is the backend's threat model and the catalogue of in-tree mitigat
 | Asset | Threat | In-tree mitigation |
 |---|---|---|
 | Risk evaluations | Forgery / replay of risk inputs | Server-derived only — never trust client-supplied factors. `RiskEvaluationService` ignores anything but `walletAddress` + `forceRefresh`. |
-| Credit-line state transitions | Unauthorised suspend/close | `X-Admin-Api-Key` gate ([`adminAuth.ts`](../src/middleware/adminAuth.ts)) + 503 fail-closed when key unset |
+| Credit-line state transitions | Unauthorised suspend/close | `X-Admin-Api-Key` gate with constant-time comparison ([`adminAuth.ts`](../src/middleware/adminAuth.ts)) + 503 fail-closed when key unset |
 | Outbound webhooks | Spoofed delivery / replay | HMAC-SHA256 signature, monotonic `X-Webhook-Timestamp`, `drawId` for dedup |
 | API keys | Timing leaks during comparison | `crypto.timingSafeEqual` in [`auth.ts`](../src/middleware/auth.ts) |
-| Logs | PII / secret exfiltration | `redactLogArgs` + `sanitizeWallet` truncation |
+| Logs | PII / secret exfiltration | `redactLogArgs`, Stellar public/secret/muxed account masking, email masking, and `sanitizeWallet` truncation |
 | DB | Drift from on-chain truth | `ReconciliationWorker` runs every `RECONCILIATION_INTERVAL_MS` |
 | Service availability | Brute force / abusive scrapers | Token-bucket rate limit with `Retry-After` |
 | Service availability | Large body payloads | 100 kB body cap, 413 mapped to envelope |

--- a/docs/security-checklist-backend.md
+++ b/docs/security-checklist-backend.md
@@ -18,6 +18,7 @@ For **external penetration-test preparation** (scope, auth bypass checks, rate l
 - [ ] Role-based access control (RBAC) is implemented where needed
 - [ ] Users can only access their own credit lines and data
 - [ ] Admin endpoints have separate authorization checks
+- [ ] Admin shared-secret comparisons use constant-time equality checks
 - [ ] Authorization checks occur on every request (not cached insecurely)
 - [ ] Principle of least privilege is applied to all roles
 
@@ -61,7 +62,7 @@ For **external penetration-test preparation** (scope, auth bypass checks, rate l
 ### Log Content
 - [ ] Logs include timestamp, user ID, IP address, endpoint, and action
 - [ ] Logs DO NOT contain sensitive data (passwords, tokens, PII)
-- [ ] Logs DO NOT contain full credit card or wallet private keys
+- [ ] Logs DO NOT contain full credit card numbers, wallet private keys, Stellar secret seeds, muxed accounts, or email addresses
 - [ ] Error messages to clients are generic (detailed errors only in logs)
 
 ### Log Security

--- a/src/__test__/adminAuth.test.ts
+++ b/src/__test__/adminAuth.test.ts
@@ -17,7 +17,7 @@ function buildApp() {
 }
 
 let originalKey: string | undefined;
-    
+
 beforeEach(() => {
     originalKey = process.env["ADMIN_API_KEY"];
     process.env["ADMIN_API_KEY"] = SECRET;
@@ -38,102 +38,102 @@ afterEach(() => {
 describe("adminAuth middleware", () => {
     describe("when ADMIN_API_KEY env var is configured", () => {
         it("calls next() and returns 200 when the correct key is supplied", async () => {
-        const res = await request(buildApp())
-            .post("/protected")
-            .set(ADMIN_KEY_HEADER, SECRET);
+            const res = await request(buildApp())
+                .post("/protected")
+                .set(ADMIN_KEY_HEADER, SECRET);
 
-        expect(res.status).toBe(200);
-        expect(res.body).toEqual({ ok: true });
+            expect(res.status).toBe(200);
+            expect(res.body).toEqual({ ok: true });
         });
 
         it("returns 401 when the X-Admin-Api-Key header is missing", async () => {
-        const res = await request(buildApp()).post("/protected");
+            const res = await request(buildApp()).post("/protected");
 
-        expect(res.status).toBe(401);
-        expect(res.body.error).toContain("Unauthorized");
+            expect(res.status).toBe(401);
+            expect(res.body.error).toContain("Unauthorized");
         });
 
         it("returns 401 when the header value is wrong", async () => {
-        const res = await request(buildApp())
-            .post("/protected")
-            .set(ADMIN_KEY_HEADER, "wrong-key");
+            const res = await request(buildApp())
+                .post("/protected")
+                .set(ADMIN_KEY_HEADER, "wrong-key");
 
-        expect(res.status).toBe(401);
-        expect(res.body.error).toContain("Unauthorized");
+            expect(res.status).toBe(401);
+            expect(res.body.error).toContain("Unauthorized");
         });
 
         it("returns 401 when duplicate header values are provided as an array", () => {
-        const req = {
-            headers: {
-            [ADMIN_KEY_HEADER]: [SECRET],
-            },
-        } as unknown as Request;
-        const res = {
-            status: vi.fn().mockReturnThis(),
-            json: vi.fn(),
-        } as unknown as Response;
-        const next = vi.fn();
+            const req = {
+                headers: {
+                    [ADMIN_KEY_HEADER]: [SECRET],
+                },
+            } as unknown as Request;
+            const res = {
+                status: vi.fn().mockReturnThis(),
+                json: vi.fn(),
+            } as unknown as Response;
+            const next = vi.fn();
 
-        adminAuth(req, res, next);
+            adminAuth(req, res, next);
 
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(next).not.toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(401);
+            expect(next).not.toHaveBeenCalled();
         });
 
         it("returns 401 when the header is an empty string", async () => {
-        const res = await request(buildApp())
-            .post("/protected")
-            .set(ADMIN_KEY_HEADER, "");
+            const res = await request(buildApp())
+                .post("/protected")
+                .set(ADMIN_KEY_HEADER, "");
 
-        expect(res.status).toBe(401);
+            expect(res.status).toBe(401);
         });
 
         it("returns 401 when the header is close but not equal to the secret", async () => {
-        const res = await request(buildApp())
-            .post("/protected")
-            .set(ADMIN_KEY_HEADER, SECRET + " ");
+            const res = await request(buildApp())
+                .post("/protected")
+                .set(ADMIN_KEY_HEADER, SECRET + " ");
 
-        expect(res.status).toBe(401);
+            expect(res.status).toBe(401);
         });
 
         it("response body includes X-Admin-Api-Key in the error hint", async () => {
-        const res = await request(buildApp()).post("/protected");
+            const res = await request(buildApp()).post("/protected");
 
-        expect(res.body.error).toMatch(/X-Admin-Api-Key/);
+            expect(res.body.error).toMatch(/X-Admin-Api-Key/);
         });
 
         it("returns JSON content-type on 401", async () => {
-        const res = await request(buildApp()).post("/protected");
-        expect(res.headers["content-type"]).toMatch(/application\/json/);
+            const res = await request(buildApp()).post("/protected");
+            expect(res.headers["content-type"]).toMatch(/application\/json/);
         });
     });
 
     describe("when ADMIN_API_KEY env var is NOT configured", () => {
         beforeEach(() => {
-        delete process.env["ADMIN_API_KEY"];
+            delete process.env["ADMIN_API_KEY"];
         });
 
         it("returns 503 regardless of what header is sent", async () => {
-        const res = await request(buildApp())
-            .post("/protected")
-            .set(ADMIN_KEY_HEADER, "anything");
+            const res = await request(buildApp())
+                .post("/protected")
+                .set(ADMIN_KEY_HEADER, "anything");
 
-        expect(res.status).toBe(503);
+            expect(res.status).toBe(503);
         });
 
         it("returns 503 even without a header", async () => {
-        const res = await request(buildApp()).post("/protected");
-        expect(res.status).toBe(503);
+            const res = await request(buildApp()).post("/protected");
+            expect(res.status).toBe(503);
         });
 
         it("body error mentions admin authentication is not configured", async () => {
-        const res = await request(buildApp()).post("/protected");
-        expect(res.body.error).toMatch(/not configured/i);
+            const res = await request(buildApp()).post("/protected");
+            expect(res.body.error).toMatch(/not configured/i);
         });
 
         it("returns JSON content-type on 503", async () => {
-        const res = await request(buildApp()).post("/protected");
-        expect(res.headers["content-type"]).toMatch(/application\/json/);
+            const res = await request(buildApp()).post("/protected");
+            expect(res.headers["content-type"]).toMatch(/application\/json/);
         });
     });
 });

--- a/src/__test__/adminAuth.test.ts
+++ b/src/__test__/adminAuth.test.ts
@@ -62,6 +62,15 @@ describe("adminAuth middleware", () => {
             expect(res.body.error).toContain("Unauthorized");
         });
 
+        it("returns 401 when the header length differs from the configured key", async () => {
+            const res = await request(buildApp())
+                .post("/protected")
+                .set(ADMIN_KEY_HEADER, `${SECRET}-extra`);
+
+            expect(res.status).toBe(401);
+            expect(res.body.error).toContain("Unauthorized");
+        });
+
         it("returns 401 when duplicate header values are provided as an array", () => {
             const req = {
                 headers: {

--- a/src/__test__/adminAuth.test.ts
+++ b/src/__test__/adminAuth.test.ts
@@ -1,7 +1,8 @@
 import express from "express";
 import request from "supertest";
 import { adminAuth, ADMIN_KEY_HEADER } from "../middleware/adminAuth.js";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Request, Response } from "express";
 
 const SECRET = "test-admin-secret-key";
 
@@ -59,6 +60,24 @@ describe("adminAuth middleware", () => {
 
         expect(res.status).toBe(401);
         expect(res.body.error).toContain("Unauthorized");
+        });
+
+        it("returns 401 when duplicate header values are provided as an array", () => {
+        const req = {
+            headers: {
+            [ADMIN_KEY_HEADER]: [SECRET],
+            },
+        } as unknown as Request;
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn(),
+        } as unknown as Response;
+        const next = vi.fn();
+
+        adminAuth(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(next).not.toHaveBeenCalled();
         });
 
         it("returns 401 when the header is an empty string", async () => {

--- a/src/__test__/logRedact.test.ts
+++ b/src/__test__/logRedact.test.ts
@@ -66,6 +66,19 @@ describe("logRedact", () => {
     expect(output.list[2]).toBe("[REDACTED_MUXED_ACCOUNT]");
   });
 
+  it("does not return original cyclic objects during redaction", () => {
+    const payload: { walletAddress: string; self?: unknown } = {
+      walletAddress: STELLAR_ADDRESS,
+    };
+    payload.self = payload;
+
+    const output = redactLogValue(payload, false);
+
+    expect(output.walletAddress).toBe("GCKFBE...EKJA");
+    expect(output.self).toBe("[Circular]");
+    expect(output.self).not.toBe(payload);
+  });
+
   it("redacts Error message and stack", () => {
     const error = new Error(`failed for ${STELLAR_ADDRESS} and ${EMAIL}`);
     error.stack = `Error: failed for ${STELLAR_ADDRESS} and ${STELLAR_SECRET_SEED}`;

--- a/src/__test__/logRedact.test.ts
+++ b/src/__test__/logRedact.test.ts
@@ -79,6 +79,16 @@ describe("logRedact", () => {
     expect(output.self).not.toBe(payload);
   });
 
+  it("redacts cyclic arrays without recursing indefinitely", () => {
+    const payload: unknown[] = [STELLAR_ADDRESS];
+    payload.push(payload);
+
+    const output = redactLogValue(payload, false);
+
+    expect(output[0]).toBe("GCKFBE...EKJA");
+    expect(output[1]).toBe("[Circular]");
+  });
+
   it("redacts Error message and stack", () => {
     const error = new Error(`failed for ${STELLAR_ADDRESS} and ${EMAIL}`);
     error.stack = `Error: failed for ${STELLAR_ADDRESS} and ${STELLAR_SECRET_SEED}`;
@@ -91,6 +101,16 @@ describe("logRedact", () => {
     expect(output.stack).toContain("GCKFBE...EKJA");
     expect(output.stack).not.toContain(STELLAR_ADDRESS);
     expect(output.stack).not.toContain(STELLAR_SECRET_SEED);
+  });
+
+  it("redacts cyclic Error properties without recursing indefinitely", () => {
+    const error = new Error(`failed for ${EMAIL}`);
+    (error as Error & { cause?: unknown }).cause = error;
+
+    const output = redactLogValue(error, false) as Error & { cause?: unknown };
+
+    expect(output.message).toBe("failed for [REDACTED_EMAIL]");
+    expect(output.cause).toBe("[Circular]");
   });
 
   it("returns original log args when debug mode is enabled", () => {

--- a/src/__test__/logRedact.test.ts
+++ b/src/__test__/logRedact.test.ts
@@ -8,6 +8,9 @@ import {
 
 const STELLAR_ADDRESS = "GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGZBW3JXDC55CYIXB5NAXMCEKJA";
 const STELLAR_ADDRESS_2 = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNB";
+const STELLAR_SECRET_SEED = `S${"A".repeat(55)}`;
+const STELLAR_MUXED_ACCOUNT = `M${"B".repeat(68)}`;
+const EMAIL = "borrower@example.com";
 
 const originalDebugFlag = process.env.LOG_REDACTION_DEBUG;
 
@@ -35,38 +38,52 @@ describe("logRedact", () => {
     expect(output).toBe("GCKFBE...EKJA -> GAAZI4...CWNB");
   });
 
+  it("redacts Stellar secret seeds, muxed accounts, and email addresses", () => {
+    const input = `${STELLAR_SECRET_SEED} ${STELLAR_MUXED_ACCOUNT} ${EMAIL}`;
+    const output = redactLogString(input, false);
+
+    expect(output).toBe("[REDACTED_STELLAR_SECRET] [REDACTED_MUXED_ACCOUNT] [REDACTED_EMAIL]");
+    expect(output).not.toContain(STELLAR_SECRET_SEED);
+    expect(output).not.toContain(STELLAR_MUXED_ACCOUNT);
+    expect(output).not.toContain(EMAIL);
+  });
+
   it("redacts nested objects and arrays", () => {
     const payload = {
       walletAddress: STELLAR_ADDRESS,
       nested: {
-        message: `from ${STELLAR_ADDRESS_2}`,
+        message: `from ${STELLAR_ADDRESS_2} to ${EMAIL}`,
       },
-      list: [STELLAR_ADDRESS],
+      list: [STELLAR_ADDRESS, STELLAR_SECRET_SEED, STELLAR_MUXED_ACCOUNT],
     };
 
     const output = redactLogValue(payload, false);
 
     expect(output.walletAddress).toBe("GCKFBE...EKJA");
-    expect(output.nested.message).toBe("from GAAZI4...CWNB");
+    expect(output.nested.message).toBe("from GAAZI4...CWNB to [REDACTED_EMAIL]");
     expect(output.list[0]).toBe("GCKFBE...EKJA");
+    expect(output.list[1]).toBe("[REDACTED_STELLAR_SECRET]");
+    expect(output.list[2]).toBe("[REDACTED_MUXED_ACCOUNT]");
   });
 
   it("redacts Error message and stack", () => {
-    const error = new Error(`failed for ${STELLAR_ADDRESS}`);
-    error.stack = `Error: failed for ${STELLAR_ADDRESS}`;
+    const error = new Error(`failed for ${STELLAR_ADDRESS} and ${EMAIL}`);
+    error.stack = `Error: failed for ${STELLAR_ADDRESS} and ${STELLAR_SECRET_SEED}`;
 
     const output = redactLogValue(error, false);
 
     expect(output.message).toContain("GCKFBE...EKJA");
     expect(output.message).not.toContain(STELLAR_ADDRESS);
+    expect(output.message).not.toContain(EMAIL);
     expect(output.stack).toContain("GCKFBE...EKJA");
     expect(output.stack).not.toContain(STELLAR_ADDRESS);
+    expect(output.stack).not.toContain(STELLAR_SECRET_SEED);
   });
 
   it("returns original log args when debug mode is enabled", () => {
     const args = [
       `wallet=${STELLAR_ADDRESS}`,
-      { walletAddress: STELLAR_ADDRESS_2 },
+      { walletAddress: STELLAR_ADDRESS_2, email: EMAIL, seed: STELLAR_SECRET_SEED },
     ];
 
     const output = redactLogArgs(args, true);

--- a/src/__test__/requestLogger.test.ts
+++ b/src/__test__/requestLogger.test.ts
@@ -1,0 +1,54 @@
+import { EventEmitter } from "node:events";
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+
+const { infoMock } = vi.hoisted(() => ({
+  infoMock: vi.fn(),
+}));
+
+vi.mock("../utils/logger.js", () => ({
+  logger: {
+    info: infoMock,
+  },
+}));
+
+function createResponse(): Response & EventEmitter {
+  const res = new EventEmitter() as Response & EventEmitter;
+  res.statusCode = 200;
+  res.setHeader = vi.fn();
+  return res;
+}
+
+describe("requestLogger", () => {
+  it("redacts sensitive query values from start and end path logs", async () => {
+    infoMock.mockReset();
+    const { requestLogger } = await import("../middleware/requestLogger.js");
+    const seed = `S${"A".repeat(55)}`;
+    const muxed = `M${"B".repeat(68)}`;
+    const req = {
+      headers: {},
+      method: "GET",
+      originalUrl: `/api/credit/lines?email=borrower@example.com&seed=${seed}&muxed=${muxed}`,
+      body: {},
+    } as Request;
+    const res = createResponse();
+    const next = vi.fn();
+
+    requestLogger(req, res, next);
+    res.emit("finish");
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(infoMock).toHaveBeenCalledTimes(2);
+
+    const startPayload = infoMock.mock.calls[0]?.[0] as { path: string };
+    const endPayload = infoMock.mock.calls[1]?.[0] as { path: string };
+
+    expect(startPayload.path).toContain("[REDACTED_EMAIL]");
+    expect(startPayload.path).toContain("[REDACTED_STELLAR_SECRET]");
+    expect(startPayload.path).toContain("[REDACTED_MUXED_ACCOUNT]");
+    expect(startPayload.path).not.toContain("borrower@example.com");
+    expect(startPayload.path).not.toContain(seed);
+    expect(startPayload.path).not.toContain(muxed);
+    expect(endPayload.path).toBe(startPayload.path);
+  });
+});

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -1,6 +1,14 @@
 import type { Request, Response, NextFunction } from "express";
+import { timingSafeEqual } from "node:crypto";
 
 export const ADMIN_KEY_HEADER = "x-admin-api-key" as const;
+
+function timingSafeStringEqual(left: string, right: string): boolean {
+    const leftBytes = Buffer.from(left, "utf8");
+    const rightBytes = Buffer.from(right, "utf8");
+
+    return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+}
 
 export function adminAuth(
     req: Request,
@@ -18,7 +26,7 @@ export function adminAuth(
 
     const providedKey = req.headers[ADMIN_KEY_HEADER];
 
-    if (!providedKey || providedKey !== expectedKey) {
+    if (typeof providedKey !== "string" || !timingSafeStringEqual(providedKey, expectedKey)) {
         res.status(401).json({
         error: "Unauthorized: valid X-Admin-Api-Key header is required.",
         });

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -1,25 +1,25 @@
 import type { Request, Response, NextFunction } from "express";
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 export const ADMIN_KEY_HEADER = "x-admin-api-key" as const;
 
 function timingSafeStringEqual(left: string, right: string): boolean {
-    const leftBytes = Buffer.from(left, "utf8");
-    const rightBytes = Buffer.from(right, "utf8");
+    const leftDigest = createHash("sha256").update(left, "utf8").digest();
+    const rightDigest = createHash("sha256").update(right, "utf8").digest();
 
-    return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+    return timingSafeEqual(leftDigest, rightDigest) && left.length === right.length;
 }
 
 export function adminAuth(
     req: Request,
     res: Response,
     next: NextFunction,
-    ): void {
+): void {
     const expectedKey = process.env["ADMIN_API_KEY"];
 
     if (!expectedKey) {
         res.status(503).json({
-        error: "Admin authentication is not configured on this server.",
+            error: "Admin authentication is not configured on this server.",
         });
         return;
     }

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -28,7 +28,7 @@ export function adminAuth(
 
     if (typeof providedKey !== "string" || !timingSafeStringEqual(providedKey, expectedKey)) {
         res.status(401).json({
-        error: "Unauthorized: valid X-Admin-Api-Key header is required.",
+            error: "Unauthorized: valid X-Admin-Api-Key header is required.",
         });
         return;
     }

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from "express";
 import { randomUUID } from "crypto";
 import { logger } from "../utils/logger.js";
+import { redactLogString } from "../utils/logRedact.js";
 
 export const REQUEST_ID_HEADER = "x-request-id";
 
@@ -38,11 +39,12 @@ export function requestLogger(
   res.setHeader(REQUEST_ID_HEADER, requestId);
 
   // 4. Log request start
+  const path = redactLogString(req.originalUrl, false);
   logger.info(
     {
       requestId,
       method: req.method,
-      path: req.originalUrl,
+      path,
     },
     "request:start",
   );
@@ -60,7 +62,7 @@ export function requestLogger(
       {
         requestId,
         method: req.method,
-        path: req.originalUrl,
+        path,
         statusCode: res.statusCode,
         durationMs: duration,
         walletAddress: wallet, // sanitized

--- a/src/utils/logRedact.ts
+++ b/src/utils/logRedact.ts
@@ -1,4 +1,7 @@
 const STELLAR_ADDRESS_REGEX = /\bG[A-Z2-7]{55}\b/g;
+const STELLAR_SECRET_SEED_REGEX = /\bS[A-Z2-7]{55}\b/g;
+const STELLAR_MUXED_ACCOUNT_REGEX = /\bM[A-Z2-7]{68}\b/g;
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 
 function truncateAddress(address: string): string {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -33,7 +36,11 @@ export function redactLogString(
     return value;
   }
 
-  return value.replace(STELLAR_ADDRESS_REGEX, truncateAddress);
+  return value
+    .replace(STELLAR_SECRET_SEED_REGEX, '[REDACTED_STELLAR_SECRET]')
+    .replace(STELLAR_MUXED_ACCOUNT_REGEX, '[REDACTED_MUXED_ACCOUNT]')
+    .replace(EMAIL_REGEX, '[REDACTED_EMAIL]')
+    .replace(STELLAR_ADDRESS_REGEX, truncateAddress);
 }
 
 function redactValueInternal(

--- a/src/utils/logRedact.ts
+++ b/src/utils/logRedact.ts
@@ -73,7 +73,7 @@ function redactValueInternal(
 
   if (isPlainObject(value)) {
     if (seen.has(value)) {
-      return value;
+      return '[Circular]';
     }
 
     seen.add(value);

--- a/src/utils/logRedact.ts
+++ b/src/utils/logRedact.ts
@@ -51,6 +51,13 @@ function redactValueInternal(
     return redactLogString(value, false);
   }
 
+  if (typeof value === 'object' && value !== null) {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+  }
+
   if (value instanceof Error) {
     const redactedError = new Error(redactLogString(value.message, false));
     redactedError.name = value.name;
@@ -72,11 +79,6 @@ function redactValueInternal(
   }
 
   if (isPlainObject(value)) {
-    if (seen.has(value)) {
-      return '[Circular]';
-    }
-
-    seen.add(value);
     const redacted: Record<string, unknown> = {};
     for (const [key, nested] of Object.entries(value)) {
       redacted[key] = redactValueInternal(nested, seen);


### PR DESCRIPTION
## Summary
- compare the admin API key with constant-time equality and reject duplicate header arrays
- redact Stellar secret seeds, muxed accounts, email addresses, and sensitive request paths from logs
- handle cyclic objects, arrays, and errors during log redaction without recursing indefinitely
- update security docs and checklist entries for the hardened behavior

Closes #234

## Validation
- `git diff --check`
- Node/Vitest checks not run locally because `node_modules` is not installed in this Termux checkout
