### PR TITLE
refactor: route service logs through Pino

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -8,7 +8,7 @@ The backend is built to be debuggable from a single correlation ID. This documen
 
 ### 1.1 Logger
 
-A single Pino logger lives in [`src/utils/logger.ts`](../src/utils/logger.ts) and is reused everywhere. JSON-by-default, ISO timestamps, silent in `NODE_ENV=test`. Plug a `pino-pretty` sidecar in dev only.
+A single Pino logger lives in [`src/utils/logger.ts`](../src/utils/logger.ts) and is reused by request middleware and service-layer diagnostics. JSON-by-default, ISO timestamps, silent in `NODE_ENV=test`. Plug a `pino-pretty` sidecar in dev only.
 
 ### 1.2 Correlation IDs
 
@@ -25,7 +25,7 @@ Notice `walletAddress` is **sanitized** to `first6...last4` so logs are useful w
 
 ### 1.3 Redaction
 
-[`src/utils/logRedact.ts`](../src/utils/logRedact.ts) walks string args, object values, and `Error.message`, redacting any Stellar address (`G[A-Z2-7]{55}`) to `Gxxxxx...xxxx`. Call sites should prefer the helpers `redactLogArgs(...)` or `redactObject(...)` when constructing log lines from external strings.
+[`src/utils/logRedact.ts`](../src/utils/logRedact.ts) walks string args, object values, and `Error.message`, redacting any Stellar address (`G[A-Z2-7]{55}`) to `Gxxxxx...xxxx`. Service code logs through [`src/utils/serviceLogger.ts`](../src/utils/serviceLogger.ts), which applies the same redaction before handing diagnostics to Pino.
 
 Set `LOG_REDACTION_DEBUG=1` to suppress redaction temporarily during incident response.
 

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -16,6 +16,7 @@
  * (c) deduplicate by `data.drawId`. See `docs/API.md` §Webhooks.
  */
 import { createHmac } from "node:crypto";
+import { serviceLogger } from "../utils/serviceLogger.js";
 import type { HorizonEvent } from "./horizonListener.js";
 
 // ---------------------------------------------------------------------------
@@ -190,7 +191,7 @@ async function retryWithBackoff<T>(
             lastError = error as Error;
             
             if (attempt <= maxRetries) {
-                console.warn(
+                serviceLogger.warn(
                     `[DrawWebhook] Attempt ${attempt} failed, retrying in ${delay}ms:`,
                     lastError.message
                 );
@@ -230,7 +231,7 @@ function parseDrawConfirmedEvent(event: HorizonEvent): WebhookPayload | null {
             }
         };
     } catch (error) {
-        console.error("[DrawWebhook] Failed to parse event data:", error);
+        serviceLogger.error("[DrawWebhook] Failed to parse event data:", error);
         return null;
     }
 }
@@ -246,13 +247,13 @@ export function getWebhookConfig(): WebhookConfig | null {
 export function initializeWebhooks(): void {
     try {
         activeConfig = resolveWebhookConfig();
-        console.log("[DrawWebhook] Initialized with config:", {
+        serviceLogger.info("[DrawWebhook] Initialized with config:", {
             urls: activeConfig.urls.length,
             maxRetries: activeConfig.maxRetries,
             timeoutMs: activeConfig.timeoutMs
         });
     } catch (error) {
-        console.error("[DrawWebhook] Failed to initialize:", error);
+        serviceLogger.error("[DrawWebhook] Failed to initialize:", error);
         activeConfig = null;
     }
 }
@@ -261,20 +262,20 @@ export async function sendDrawConfirmationWebhook(
     event: HorizonEvent
 ): Promise<WebhookDeliveryResult[]> {
     if (!activeConfig || activeConfig.urls.length === 0) {
-        console.log("[DrawWebhook] No webhook URLs configured, skipping");
+        serviceLogger.info("[DrawWebhook] No webhook URLs configured, skipping");
         return [];
     }
 
     const payload = parseDrawConfirmedEvent(event);
     if (!payload) {
-        console.log("[DrawWebhook] Event is not a draw confirmation, skipping");
+        serviceLogger.info("[DrawWebhook] Event is not a draw confirmation, skipping");
         return [];
     }
 
     const payloadString = JSON.stringify(payload);
     const signature = generateSignature(payloadString, activeConfig.secret);
 
-    console.log(
+    serviceLogger.info(
         `[DrawWebhook] Processing draw confirmation for draw ID: ${payload.data.drawId}`
     );
 
@@ -309,7 +310,7 @@ export async function sendDrawConfirmationWebhook(
     const successCount = results.filter(r => r.success).length;
     const failureCount = results.length - successCount;
     
-    console.log(
+    serviceLogger.info(
         `[DrawWebhook] Delivery complete: ${successCount} successful, ${failureCount} failed`
     );
 

--- a/src/services/horizonListener.ts
+++ b/src/services/horizonListener.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { redactLogArgs } from "../utils/logRedact.js";
+import { serviceLogger } from "../utils/serviceLogger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -109,15 +110,15 @@ const retryState = {
 };
 
 function logInfo(...args: unknown[]): void {
-    console.log(...redactLogArgs(args));
+    serviceLogger.info(...redactLogArgs(args));
 }
 
 function logWarn(...args: unknown[]): void {
-    console.warn(...redactLogArgs(args));
+    serviceLogger.warn(...redactLogArgs(args));
 }
 
 function logError(...args: unknown[]): void {
-    console.error(...redactLogArgs(args));
+    serviceLogger.error(...redactLogArgs(args));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/jobQueue.ts
+++ b/src/services/jobQueue.ts
@@ -13,6 +13,8 @@
  * without changing call sites.
  */
 
+import { serviceLogger } from '../utils/serviceLogger.js';
+
 export interface Job<Data = unknown> {
   /** Stable job identifier (unique within a queue instance). */
   readonly id: string;
@@ -244,7 +246,7 @@ export class InMemoryJobQueue implements JobQueue {
 
         if (!handler) {
           // No handler registered — dead-letter immediately and alert operator.
-          console.error(
+          serviceLogger.error(
             `[JobQueue] No handler for type "${job.type}". Job ${job.id} moved to dead-letter.`,
           );
           this.failed.push(job);
@@ -267,7 +269,7 @@ export class InMemoryJobQueue implements JobQueue {
           } else {
             // Exceeded maxAttempts — move to dead-letter set.
             this.failed.push(job);
-            console.error(
+            serviceLogger.error(
               `[JobQueue] Job ${job.id} (type "${job.type}") exhausted ${job.attempts} attempts. ` +
               `Last error: ${job.lastError}`,
             );

--- a/src/services/reconciliationService.ts
+++ b/src/services/reconciliationService.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CreditLineRepository } from '../repositories/interfaces/CreditLineRepository.js';
+import { serviceLogger } from '../utils/serviceLogger.js';
 import type { JobQueue } from './jobQueue.js';
 
 export interface OnChainCreditRecord {
@@ -125,12 +126,12 @@ export class ReconciliationService {
 
       // Log results
       if (result.mismatches.length > 0) {
-        console.error(
+        serviceLogger.error(
           `[ReconciliationService] Found ${result.mismatches.length} mismatches:`,
           JSON.stringify(result.mismatches, null, 2)
         );
       } else {
-        console.log(
+        serviceLogger.info(
           `[ReconciliationService] Reconciliation complete. ${result.totalChecked} records checked, no mismatches found.`
         );
       }
@@ -138,7 +139,7 @@ export class ReconciliationService {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       result.errors.push(errorMessage);
-      console.error('[ReconciliationService] Reconciliation failed:', error);
+      serviceLogger.error('[ReconciliationService] Reconciliation failed:', error);
     }
 
     return result;

--- a/src/services/reconciliationWorker.ts
+++ b/src/services/reconciliationWorker.ts
@@ -6,6 +6,7 @@
  */
 
 import type { JobQueue, Job } from './jobQueue.js';
+import { serviceLogger } from '../utils/serviceLogger.js';
 import type { ReconciliationService } from './reconciliationService.js';
 
 export interface ReconciliationWorkerConfig {
@@ -25,7 +26,7 @@ export class ReconciliationWorker {
   ) {
     // Register the job handler
     this.jobQueue.registerHandler('credit-reconciliation', async (job: Job) => {
-      console.log(`[ReconciliationWorker] Processing job ${job.id} (attempt ${job.attempts + 1})`);
+      serviceLogger.info(`[ReconciliationWorker] Processing job ${job.id} (attempt ${job.attempts + 1})`);
       
       try {
         const result = await this.reconciliationService.reconcile();
@@ -35,7 +36,7 @@ export class ReconciliationWorker {
           const criticalCount = result.mismatches.filter(m => m.severity === 'critical').length;
           const warningCount = result.mismatches.filter(m => m.severity === 'warning').length;
           
-          console.error(
+          serviceLogger.error(
             `[ReconciliationWorker] ALERT: Reconciliation found ${result.mismatches.length} mismatches ` +
             `(${criticalCount} critical, ${warningCount} warnings)`
           );
@@ -50,19 +51,19 @@ export class ReconciliationWorker {
         }
         
         if (result.errors.length > 0) {
-          console.error(
+          serviceLogger.error(
             `[ReconciliationWorker] Reconciliation completed with errors:`,
             result.errors
           );
           throw new Error(`Reconciliation errors: ${result.errors.join(', ')}`);
         }
         
-        console.log(
+        serviceLogger.info(
           `[ReconciliationWorker] Job ${job.id} completed successfully. ` +
           `Checked ${result.totalChecked} records.`
         );
       } catch (error) {
-        console.error(`[ReconciliationWorker] Job ${job.id} failed:`, error);
+        serviceLogger.error(`[ReconciliationWorker] Job ${job.id} failed:`, error);
         throw error; // Re-throw to trigger job retry logic
       }
     });
@@ -73,7 +74,7 @@ export class ReconciliationWorker {
    */
   start(config: ReconciliationWorkerConfig = {}): void {
     if (this.running) {
-      console.warn('[ReconciliationWorker] Already running');
+      serviceLogger.warn('[ReconciliationWorker] Already running');
       return;
     }
 
@@ -84,16 +85,16 @@ export class ReconciliationWorker {
     this.jobQueue.start();
 
     if (runImmediately) {
-      console.log('[ReconciliationWorker] Scheduling immediate reconciliation');
+      serviceLogger.info('[ReconciliationWorker] Scheduling immediate reconciliation');
       this.reconciliationService.scheduleReconciliation(0);
     }
 
     this.intervalHandle = setInterval(() => {
-      console.log('[ReconciliationWorker] Scheduling periodic reconciliation');
+      serviceLogger.info('[ReconciliationWorker] Scheduling periodic reconciliation');
       this.reconciliationService.scheduleReconciliation(0);
     }, intervalMs);
 
-    console.log(
+    serviceLogger.info(
       `[ReconciliationWorker] Started. Running every ${intervalMs}ms ` +
       `(${Math.round(intervalMs / 60000)} minutes)`
     );
@@ -104,7 +105,7 @@ export class ReconciliationWorker {
    */
   stop(): void {
     if (!this.running) {
-      console.warn('[ReconciliationWorker] Not running');
+      serviceLogger.warn('[ReconciliationWorker] Not running');
       return;
     }
 
@@ -114,7 +115,7 @@ export class ReconciliationWorker {
     }
 
     this.running = false;
-    console.log('[ReconciliationWorker] Stopped');
+    serviceLogger.info('[ReconciliationWorker] Stopped');
   }
 
   isRunning(): boolean {

--- a/src/services/sorobanClient.ts
+++ b/src/services/sorobanClient.ts
@@ -6,6 +6,7 @@
  */
 
 import type { OnChainCreditRecord, SorobanRpcClient } from './reconciliationService.js';
+import { serviceLogger } from '../utils/serviceLogger.js';
 
 export interface SorobanClientConfig {
   rpcUrl: string;
@@ -26,7 +27,7 @@ export class MockSorobanClient implements SorobanRpcClient {
    * - Parse XDR responses into OnChainCreditRecord format
    */
   async fetchAllCreditRecords(): Promise<OnChainCreditRecord[]> {
-    console.log(
+    serviceLogger.info(
       `[SorobanClient] Fetching credit records from ${this.config.rpcUrl} ` +
       `(contract: ${this.config.contractId})`
     );

--- a/src/services/sorobanRpcClient.ts
+++ b/src/services/sorobanRpcClient.ts
@@ -21,6 +21,8 @@
  *
  * See `docs/INDEXER.md` for how reads, writes, and the listener combine.
  */
+import { serviceLogger } from '../utils/serviceLogger.js';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -204,7 +206,7 @@ class SorobanRpcClient {
     // In a real implementation, this would make an actual HTTP request to Soroban RPC
     // For now, we'll simulate the response structure
     
-    console.log(`[SorobanRpcClient] Simulating RPC call: ${method}`, {
+    serviceLogger.info(`[SorobanRpcClient] Simulating RPC call: ${method}`, {
       params: this.sanitizeParams(params),
     });
 

--- a/src/utils/serviceLogger.ts
+++ b/src/utils/serviceLogger.ts
@@ -1,0 +1,30 @@
+import { logger } from "./logger.js";
+import { redactLogArgs, redactLogValue } from "./logRedact.js";
+
+type LogLevel = "info" | "warn" | "error";
+
+function write(level: LogLevel, args: unknown[]): void {
+  const redactedArgs = redactLogArgs(args);
+
+  if (process.env.NODE_ENV === "test") {
+    const consoleMethod =
+      level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+    consoleMethod(...redactedArgs);
+    return;
+  }
+
+  const [message, meta] = redactedArgs;
+  const text = typeof message === "string" ? message : String(message);
+  if (meta === undefined) {
+    logger[level](text);
+    return;
+  }
+
+  logger[level](redactLogValue({ details: meta }), text);
+}
+
+export const serviceLogger = {
+  info: (...args: unknown[]) => write("info", args),
+  warn: (...args: unknown[]) => write("warn", args),
+  error: (...args: unknown[]) => write("error", args),
+};


### PR DESCRIPTION
## Summary
- add a service logger wrapper that applies existing log redaction before writing through Pino
- replace production service-layer console calls with structured service logging
- update observability docs to describe service-layer logger reuse

Closes #232