### PR TITLE
docs(webhooks): add subscriber onboarding guide with HMAC verification sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Full machine-readable spec: [`src/openapi.yaml`](./src/openapi.yaml). Human-read
 - **`ReconciliationService` / `ReconciliationWorker`** — periodic diff of DB credit lines vs on-chain state. Severity levels: `critical` (identity, limit, status) and `warning` (available credit, rate). Runs every hour by default (`RECONCILIATION_INTERVAL_MS`).
 - **`HorizonListener`** — Stellar Horizon poller with cursor persistence, exponential backoff + jitter, gap recovery, and SHA-256 idempotency cache (10k entries, LRU). Metrics exposed via `getMetrics()`.
 - **`SorobanRpcClient`** — read/submit wrapper with AbortController timeouts, retry budget, and Stellar key sanitization in error messages.
-- **`drawWebhookService`** — multi-URL HMAC-SHA256 webhook fan-out with retry/backoff and connectivity probe.
+- **`drawWebhookService`** — multi-URL HMAC-SHA256 webhook fan-out with delivery settings and connectivity probe.
 - **`jobQueue`** — in-process at-least-once queue with visibility timeout, attempt tracking, and dead-letter list.
 
 Implementation files: [`src/services/`](./src/services/), entry composition in [`src/container/Container.ts`](./src/container/Container.ts).
@@ -254,6 +254,7 @@ Creditra-Backend/
 | [`docs/API.md`](./docs/API.md) | Endpoint inventory, request/response shapes, error envelope, pagination |
 | [`docs/SIGNALS_INGEST.md`](./docs/SIGNALS_INGEST.md) | Behavioral signal pipeline → on-chain underwriting |
 | [`docs/SECURITY.md`](./docs/SECURITY.md) | Auth model, RBAC, validation, rate limiting, HMAC, secrets |
+| [`docs/webhook-subscribers.md`](./docs/webhook-subscribers.md) | Subscriber onboarding for outbound draw webhooks, HMAC verification, delivery settings, and idempotency |
 | [`docs/INDEXER.md`](./docs/INDEXER.md) | Horizon listener cursor model, reorg/gap handling, reconciliation |
 | [`docs/OBSERVABILITY.md`](./docs/OBSERVABILITY.md) | Logs, metrics, health probes, tracing strategy |
 | [`docs/TESTING.md`](./docs/TESTING.md) | Test pyramid, file counts, integration vs unit |

--- a/docs/API.md
+++ b/docs/API.md
@@ -243,6 +243,10 @@ Implemented in [`src/routes/webhook.ts`](../src/routes/webhook.ts). These descri
 
 Returns subscriber URLs, retry/backoff settings, and timeout — never the secret.
 
+Subscriber implementation details, HMAC verification code, timestamp checks,
+and idempotency guidance are documented in
+[`webhook-subscribers.md`](./webhook-subscribers.md).
+
 #### `POST /api/webhooks/test`
 
 Reachability probe for every configured URL. Returns `{ total, reachable, unreachable, results[] }`.
@@ -258,7 +262,7 @@ Reachability probe for every configured URL. Returns `{ total, reachable, unreac
 ```http
 Content-Type: application/json
 X-Webhook-Signature: sha256=<hex HMAC>
-X-Webhook-Timestamp: <epoch ms>
+X-Webhook-Timestamp: <payload ISO timestamp>
 User-Agent: Creditra-Webhook/1.0
 ```
 
@@ -281,10 +285,10 @@ User-Agent: Creditra-Webhook/1.0
 HMAC is computed over the **raw JSON body** with `WEBHOOK_SECRET`. Subscribers must:
 
 1. Re-compute `HMAC-SHA256(body, secret)` and compare in constant time.
-2. Reject when `now - X-Webhook-Timestamp` exceeds your tolerance window.
+2. Reject when `X-Webhook-Timestamp` falls outside your tolerance window.
 3. Deduplicate by `data.drawId`.
 
-Server retries up to `WEBHOOK_MAX_RETRIES + 1` times with exponential backoff — implement idempotency on receive.
+Webhook delivery settings expose retry and backoff knobs. Implement idempotency on receive so repeated deliveries are safe.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This directory holds the long-form documentation for the Creditra backend. The t
 | [`INDEXER.md`](./INDEXER.md) | Stellar Horizon listener, cursor model, gap recovery, reconciliation runbook. |
 | [`SECURITY.md`](./SECURITY.md) | Threat model and in-tree mitigations. |
 | [`DATA_RETENTION.md`](./DATA_RETENTION.md) | Retention windows, anonymization, and deletion tooling for logs, audit events, and wallet-linked data. |
+| [`webhook-subscribers.md`](./webhook-subscribers.md) | Subscriber onboarding for outbound draw webhooks, HMAC verification, delivery settings, and idempotency. |
 | [`OBSERVABILITY.md`](./OBSERVABILITY.md) | Structured logging, metrics, health probes, tracing strategy. |
 | [`TESTING.md`](./TESTING.md) | Test pyramid, file counts, coverage gate, run commands. |
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Commit conventions, PR / review checklists, migration discipline. |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,7 +10,7 @@ This document is the backend's threat model and the catalogue of in-tree mitigat
 |---|---|---|
 | Risk evaluations | Forgery / replay of risk inputs | Server-derived only — never trust client-supplied factors. `RiskEvaluationService` ignores anything but `walletAddress` + `forceRefresh`. |
 | Credit-line state transitions | Unauthorised suspend/close | `X-Admin-Api-Key` gate with constant-time comparison ([`adminAuth.ts`](../src/middleware/adminAuth.ts)) + 503 fail-closed when key unset |
-| Outbound webhooks | Spoofed delivery / replay | HMAC-SHA256 signature, monotonic `X-Webhook-Timestamp`, `drawId` for dedup |
+| Outbound webhooks | Spoofed delivery / replay | HMAC-SHA256 signature, `X-Webhook-Timestamp` freshness checks, `drawId` for dedup |
 | API keys | Timing leaks during comparison | `crypto.timingSafeEqual` in [`auth.ts`](../src/middleware/auth.ts) |
 | Logs | PII / secret exfiltration | `redactLogArgs`, Stellar public/secret/muxed account masking, email masking, and `sanitizeWallet` truncation |
 | DB | Drift from on-chain truth | `ReconciliationWorker` runs every `RECONCILIATION_INTERVAL_MS` |
@@ -151,7 +151,7 @@ The backend ships **outbound** webhooks (no inbound webhook surface today). Each
 
 ```http
 X-Webhook-Signature: sha256=<hex HMAC over raw body>
-X-Webhook-Timestamp: <ms epoch>
+X-Webhook-Timestamp: <payload ISO timestamp>
 User-Agent: Creditra-Webhook/1.0
 ```
 
@@ -159,9 +159,9 @@ Producer:
 
 - Secret loaded from `WEBHOOK_SECRET` — refuses to start (`getWebhookConfig()` returns `null`) when URLs are configured without a secret.
 - HMAC computed over the **raw JSON body** prior to send; subscribers should validate against the body bytes they received, not a re-serialized form.
-- Retries up to `WEBHOOK_MAX_RETRIES + 1` with `WEBHOOK_INITIAL_BACKOFF_MS × multiplier^attempt`.
+- Delivery settings expose `WEBHOOK_MAX_RETRIES`, `WEBHOOK_INITIAL_BACKOFF_MS`, and `WEBHOOK_BACKOFF_MULTIPLIER`.
 
-Subscriber expectation (documented in [`docs/API.md`](./API.md) §Webhooks):
+Subscriber expectation (documented in [`webhook-subscribers.md`](./webhook-subscribers.md)):
 
 1. Recompute `HMAC-SHA256(body, secret)` and compare in constant time.
 2. Reject deliveries older than your tolerance window (`X-Webhook-Timestamp`).

--- a/docs/webhook-subscribers.md
+++ b/docs/webhook-subscribers.md
@@ -1,0 +1,175 @@
+# Webhook Subscriber Onboarding
+
+Creditra sends outbound `draw_confirmed` webhooks to each URL configured in
+`WEBHOOK_URLS`. Every delivery is signed with HMAC-SHA256 so subscribers can
+verify that the raw request body came from a sender that knows
+`WEBHOOK_SECRET`.
+
+Implementation references:
+
+- [`src/services/drawWebhookService.ts`](../src/services/drawWebhookService.ts)
+- [`src/routes/webhook.ts`](../src/routes/webhook.ts)
+
+## Delivery Configuration
+
+| Environment variable | Default | Used for |
+|---|---:|---|
+| `WEBHOOK_URLS` | empty | Comma-separated subscriber URLs. No URLs means delivery is disabled. |
+| `WEBHOOK_SECRET` | empty | Shared HMAC secret. Required when `WEBHOOK_URLS` is configured. |
+| `WEBHOOK_MAX_RETRIES` | `3` | Retry attempts after the first delivery attempt. |
+| `WEBHOOK_INITIAL_BACKOFF_MS` | `1000` | Initial retry delay in milliseconds. |
+| `WEBHOOK_BACKOFF_MULTIPLIER` | `2.0` | Multiplier applied after each failed attempt. |
+| `WEBHOOK_TIMEOUT_MS` | `10000` | Per-request timeout in milliseconds. |
+
+Do not put real `WEBHOOK_SECRET` values in logs, docs, tickets, or sample
+payloads.
+
+## Request Contract
+
+Creditra sends a `POST` request to each configured subscriber URL.
+
+```http
+Content-Type: application/json
+X-Webhook-Signature: sha256=<hex HMAC over raw body>
+X-Webhook-Timestamp: <payload ISO timestamp>
+User-Agent: Creditra-Webhook/1.0
+```
+
+The signature is generated from the exact JSON string sent as the request body:
+
+```text
+hex(hmac_sha256(WEBHOOK_SECRET, raw_json_body))
+```
+
+Verify the signature before trusting any payload fields. Re-serializing the
+payload can change spacing, key order, or encoding and produce a different HMAC
+input. After signature verification, confirm the `X-Webhook-Timestamp` header
+matches the signed payload `timestamp`, then apply your freshness window.
+
+## Payload
+
+The outbound payload shape is defined by `WebhookPayload` in
+`drawWebhookService.ts`.
+
+```json
+{
+  "event": "draw_confirmed",
+  "timestamp": "2026-01-01T00:00:00.000Z",
+  "data": {
+    "ledger": 123456,
+    "contractId": "contract-1",
+    "drawAmount": "100.00",
+    "drawId": "draw-1",
+    "borrowerWallet": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "creditLineId": "credit-line-1",
+    "horizonTimestamp": "2026-01-01T00:00:00Z"
+  }
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `event` | `"draw_confirmed"` | Fixed event name emitted by the draw webhook service. |
+| `timestamp` | string | ISO timestamp created when Creditra builds the webhook payload. |
+| `data.ledger` | number | Ledger from the Horizon event. |
+| `data.contractId` | string | Contract id from the Horizon event. |
+| `data.drawAmount` | string | Draw amount parsed from the Horizon event data, or `"0"` when absent. |
+| `data.drawId` | string | Draw identifier parsed from the Horizon event data. |
+| `data.borrowerWallet` | string | Borrower wallet parsed from the Horizon event data. |
+| `data.creditLineId` | string | Credit line id parsed from the Horizon event data. |
+| `data.horizonTimestamp` | string | Timestamp from the original Horizon event. |
+
+Use `data.drawId` as the idempotency key. If the same draw id arrives again
+after a successful delivery, return a 2xx response after confirming it is
+already processed.
+
+## Node.js Verification Example
+
+This Express example keeps the raw body, verifies the HMAC in constant time,
+rejects stale timestamps, and deduplicates by `data.drawId`.
+
+```ts
+import crypto from "node:crypto";
+import express from "express";
+
+const app = express();
+const secret = process.env.WEBHOOK_SECRET;
+if (!secret) {
+  throw new Error("WEBHOOK_SECRET is required");
+}
+const processedDrawIds = new Set<string>();
+const timestampToleranceMs = 5 * 60 * 1000;
+
+app.post(
+  "/creditra/webhook",
+  express.raw({ type: "application/json", limit: "100kb" }),
+  (req, res) => {
+    const rawBody = req.body as Buffer;
+    const signatureHeader = req.header("x-webhook-signature") ?? "";
+    const timestampHeader = req.header("x-webhook-timestamp") ?? "";
+
+    if (!signatureHeader.startsWith("sha256=")) {
+      return res.status(401).json({ error: "missing signature" });
+    }
+
+    const expectedHex = crypto
+      .createHmac("sha256", secret)
+      .update(rawBody)
+      .digest("hex");
+    const providedHex = signatureHeader.slice("sha256=".length);
+
+    const expected = Buffer.from(expectedHex, "hex");
+    const provided = Buffer.from(providedHex, "hex");
+    if (
+      expected.length !== provided.length ||
+      !crypto.timingSafeEqual(expected, provided)
+    ) {
+      return res.status(401).json({ error: "invalid signature" });
+    }
+
+    const payload = JSON.parse(rawBody.toString("utf8")) as {
+      event: "draw_confirmed";
+      timestamp: string;
+      data: { drawId: string };
+    };
+
+    if (payload.timestamp !== timestampHeader) {
+      return res.status(401).json({ error: "timestamp mismatch" });
+    }
+
+    const sentAt = Date.parse(payload.timestamp);
+    if (
+      !Number.isFinite(sentAt) ||
+      Math.abs(Date.now() - sentAt) > timestampToleranceMs
+    ) {
+      return res.status(401).json({ error: "stale webhook" });
+    }
+
+    if (processedDrawIds.has(payload.data.drawId)) {
+      return res.status(200).json({ duplicate: true });
+    }
+
+    processedDrawIds.add(payload.data.drawId);
+    return res.status(200).json({ ok: true });
+  },
+);
+```
+
+## Operator Endpoints
+
+The management routes are mounted under `/api/webhooks`.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/webhooks/config` | Returns sanitized webhook configuration: URLs, retry knobs, timeout, and configured state. It never returns `WEBHOOK_SECRET`. |
+| `POST` | `/api/webhooks/test` | Sends a connectivity probe to every configured URL and returns `{ total, reachable, unreachable, results }`. |
+| `GET` | `/api/webhooks/health` | Returns `disabled` when no URLs are configured, otherwise `active` with URL count and retry settings. |
+
+## Subscriber Checklist
+
+- Verify `X-Webhook-Signature` over the raw request body before JSON parsing.
+- Compare HMACs with `crypto.timingSafeEqual` or an equivalent constant-time primitive.
+- Reject missing, malformed, mismatched, or stale `X-Webhook-Timestamp` values.
+- After signature verification, require `X-Webhook-Timestamp` to match the signed payload `timestamp`.
+- Process `draw_confirmed` payloads idempotently by `data.drawId`.
+- Return a 2xx status only after the event is durably accepted or already known as a duplicate.

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -3,17 +3,17 @@
  *
  * Drives the protocol's "the chain saw your draw" notification path.
  * Subscriber URLs come from `WEBHOOK_URLS` (comma-separated) and the HMAC
- * secret from `WEBHOOK_SECRET`. Retries follow exponential backoff bounded
- * by `WEBHOOK_MAX_RETRIES`.
+ * secret from `WEBHOOK_SECRET`. Delivery settings include retry/backoff
+ * controls exposed through the webhook config.
  *
  * Signature contract sent to subscribers:
  * - `X-Webhook-Signature: sha256=<hex HMAC over raw body>`
- * - `X-Webhook-Timestamp: <ms since epoch>`
+ * - `X-Webhook-Timestamp: <payload ISO timestamp>`
  * - `User-Agent: Creditra-Webhook/1.0`
  *
  * Subscribers must (a) re-compute the HMAC and compare in constant time,
  * (b) reject timestamps outside their tolerance window, and
- * (c) deduplicate by `data.drawId`. See `docs/API.md` §Webhooks.
+ * (c) deduplicate by `data.drawId`. See `docs/webhook-subscribers.md`.
  */
 import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";


### PR DESCRIPTION
## Summary
- Add a webhook subscriber onboarding guide for outbound draw webhooks.
- Document the payload, signed headers, HMAC verification, timestamp freshness checks, `data.drawId` idempotency, delivery settings, and operator endpoints.
- Link the guide from the top-level README, docs index, API docs, and webhook service/security references.

## Validation
- `git diff --check origin/main...HEAD`
- focused docs coverage check for signature, timestamp, env vars, idempotency, and webhook operator endpoints
- `npm.cmd run typecheck` currently fails on existing repository baseline TypeScript errors unrelated to these docs changes, including missing symbols in `Container.ts`, test fixture type mismatches, and pre-existing `drawWebhookService.test.ts` `result` references.

Closes #237