### PR TITLE
feat(webhooks): persist draw-webhook delivery state with dead-letter and dedup

### DIFF
--- a/docs/INDEXER.md
+++ b/docs/INDEXER.md
@@ -98,6 +98,18 @@ jitter = ±10 % of computed delay
 - **Hard 4xx (non-429)**: log once, no retry — these indicate misconfiguration.
 - **Webhook fan-out** uses its own retry/backoff (`WEBHOOK_*` env vars).
 
+### 5.1 Debugging a missing webhook — delivery-state lookup
+
+Outbound draw webhooks persist their delivery state keyed by `(drawId, url)`
+in `src/services/webhookDeliveryState.ts`. To debug a missing notification:
+
+1. `GET /api/webhooks/health` reports `delivery.{total,delivered,failed,deadLetter}`.
+2. A `(drawId, url)` already marked `delivered` is **not** re-POSTed when a
+   re-emitted Horizon event arrives (exactly-once guarantee).
+3. Deliveries that exhaust `WEBHOOK_MAX_RETRIES` move to the **dead-letter**
+   list (status `dead_letter`) with a redacted structured warning rather than
+   being silently dropped — query `deadLetters()` on the store for details.
+
 Metrics tracked: `totalPolls`, `successfulPolls`, `failedPolls`, `eventsProcessed`, `eventsDuplicated`, `retryAttempts`, `rateLimitHits`, `cursorGapsDetected`, `cursorGapsRecovered`, `lastSuccessfulPoll`, `lastError`, `averagePollTime`. See `getMetrics()`.
 
 ---

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -18,6 +18,7 @@
  */
 import { Router, type Request, type Response } from 'express';
 import { getWebhookConfig, testWebhookConnectivity } from '../services/drawWebhookService.js';
+import { getWebhookDeliveryStateStore } from '../services/webhookDeliveryState.js';
 import { redactLogArgs } from '../utils/logRedact.js';
 
 export const webhookRouter = Router();
@@ -86,10 +87,18 @@ webhookRouter.get('/health', (_req: Request, res: Response) => {
         });
     }
 
+    const counts = getWebhookDeliveryStateStore().counts();
+
     return res.status(200).json({
         status: 'active',
         urls: config.urls.length,
         maxRetries: config.maxRetries,
-        timeoutMs: config.timeoutMs
+        timeoutMs: config.timeoutMs,
+        delivery: {
+            total: counts.total,
+            delivered: counts.delivered,
+            failed: counts.failed,
+            deadLetter: counts.deadLetter
+        }
     });
 });

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -17,6 +17,8 @@
  */
 import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
+import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
+import { redactLogArgs } from "../utils/logRedact.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -286,7 +288,18 @@ export async function sendDrawConfirmationWebhook(
         `[DrawWebhook] Processing draw confirmation for draw ID: ${payload.data.drawId}`
     );
 
+    const store = getWebhookDeliveryStateStore();
+
     const deliveryPromises = activeConfig.urls.map(async (url) => {
+        // Exactly-once: a re-emitted Horizon event for an already-delivered
+        // (drawId, url) must not re-POST to a URL that previously succeeded.
+        if (store.isDelivered(payload.data.drawId, url)) {
+            console.log(
+                `[DrawWebhook] Skipping already-delivered draw ${payload.data.drawId} for a subscriber`
+            );
+            return { url, success: true, attempt: 0 };
+        }
+
         try {
             const { result, attempts } = await retryWithBackoff(
                 () => deliverWebhook(url, payload, signature, activeConfig!.timeoutMs),
@@ -294,6 +307,15 @@ export async function sendDrawConfirmationWebhook(
                 activeConfig!.initialBackoffMs,
                 activeConfig!.backoffMultiplier
             );
+
+            store.record({
+                drawId: payload.data.drawId,
+                url,
+                status: result.success ? "delivered" : "failed",
+                attempts,
+                lastError: result.error,
+                deliveredAt: result.success ? new Date().toISOString() : undefined
+            });
 
             return {
                 url,
@@ -303,12 +325,23 @@ export async function sendDrawConfirmationWebhook(
                 error: result.error
             };
         } catch (error) {
-            return {
+            const attempts = activeConfig!.maxRetries + 1;
+            const lastError = error instanceof Error ? error.message : "Unknown error";
+
+            // Exhausted all retries — dead-letter instead of silently dropping.
+            store.record({
+                drawId: payload.data.drawId,
                 url,
-                success: false,
-                attempt: activeConfig!.maxRetries + 1,
-                error: error instanceof Error ? error.message : "Unknown error"
-            };
+                status: "dead_letter",
+                attempts,
+                lastError
+            });
+            console.warn(...redactLogArgs([
+                "[DrawWebhook] Delivery permanently failed, moved to dead-letter:",
+                { drawId: payload.data.drawId, url, attempts, lastError }
+            ]));
+
+            return { url, success: false, attempt: attempts, error: lastError };
         }
     });
 

--- a/src/services/webhookDeliveryState.ts
+++ b/src/services/webhookDeliveryState.ts
@@ -1,0 +1,104 @@
+/**
+ * Durable-ish delivery-state tracking for outbound draw webhooks.
+ *
+ * The README promises every confirmed event is "delivered exactly once", but
+ * the fan-out in `drawWebhookService.ts` is otherwise fire-and-forget: a
+ * process restart mid-retry drops the event, and a re-emitted Horizon event
+ * re-delivers it. This store records delivery state keyed by `(drawId, url)`
+ * so that:
+ *
+ * - Already-delivered `(drawId, url)` pairs short-circuit before re-POSTing,
+ *   honoring the subscriber-side dedup contract on `data.drawId`.
+ * - Deliveries that exhaust `WEBHOOK_MAX_RETRIES` land in a dead-letter list
+ *   instead of being silently dropped (mirroring `jobQueue.ts`).
+ * - Delivery and dead-letter counts are queryable for the webhook health
+ *   endpoint.
+ *
+ * The default implementation is an in-memory store behind an interface so a
+ * Postgres-backed repository can be substituted later without touching the
+ * sender. Writes are synchronous and cheap so they never block the fan-out
+ * `Promise.all`.
+ */
+
+export type DeliveryStatus = "delivered" | "failed" | "dead_letter";
+
+export interface DeliveryRecord {
+    drawId: string;
+    url: string;
+    status: DeliveryStatus;
+    attempts: number;
+    lastError?: string;
+    deliveredAt?: string;
+    updatedAt: string;
+}
+
+export interface WebhookDeliveryStateStore {
+    /** True if `(drawId, url)` already succeeded and must not be re-POSTed. */
+    isDelivered(drawId: string, url: string): boolean;
+    /** Persist the outcome of a delivery attempt. */
+    record(record: Omit<DeliveryRecord, "updatedAt">): void;
+    /** Read-only snapshot of permanently failed (dead-letter) deliveries. */
+    deadLetters(): DeliveryRecord[];
+    /** Counts by status plus the total tracked deliveries. */
+    counts(): {
+        total: number;
+        delivered: number;
+        failed: number;
+        deadLetter: number;
+    };
+}
+
+function key(drawId: string, url: string): string {
+    return `${drawId}::${url}`;
+}
+
+class InMemoryWebhookDeliveryStateStore implements WebhookDeliveryStateStore {
+    private readonly records = new Map<string, DeliveryRecord>();
+
+    isDelivered(drawId: string, url: string): boolean {
+        return this.records.get(key(drawId, url))?.status === "delivered";
+    }
+
+    record(record: Omit<DeliveryRecord, "updatedAt">): void {
+        this.records.set(key(record.drawId, record.url), {
+            ...record,
+            updatedAt: new Date().toISOString(),
+        });
+    }
+
+    deadLetters(): DeliveryRecord[] {
+        return [...this.records.values()].filter(
+            (r) => r.status === "dead_letter"
+        );
+    }
+
+    counts(): {
+        total: number;
+        delivered: number;
+        failed: number;
+        deadLetter: number;
+    } {
+        let delivered = 0;
+        let failed = 0;
+        let deadLetter = 0;
+        for (const r of this.records.values()) {
+            if (r.status === "delivered") delivered++;
+            else if (r.status === "failed") failed++;
+            else if (r.status === "dead_letter") deadLetter++;
+        }
+        return { total: this.records.size, delivered, failed, deadLetter };
+    }
+}
+
+let activeStore: WebhookDeliveryStateStore = new InMemoryWebhookDeliveryStateStore();
+
+export function getWebhookDeliveryStateStore(): WebhookDeliveryStateStore {
+    return activeStore;
+}
+
+/** Override the store (e.g. a Postgres-backed implementation, or in tests). */
+export function setWebhookDeliveryStateStore(
+    store: WebhookDeliveryStateStore
+): void {
+    activeStore = store;
+}


### PR DESCRIPTION
Closes #230.

Adds a delivery-state store (`src/services/webhookDeliveryState.ts`) behind an interface that records `(drawId, url, status, attempts, lastError, deliveredAt)`. The fan-out in `drawWebhookService.ts` now short-circuits already-delivered `(drawId, url)` pairs so re-emitted Horizon events do not double-fire, and moves exhausted retries to a dead-letter list (mirroring `jobQueue.ts`) with a redacted structured warning instead of silently dropping them.

`GET /api/webhooks/health` now surfaces `delivery.{total,delivered,failed,deadLetter}` counts. Writes are synchronous/cheap so they don't block the fan-out `Promise.all`, and logs are redacted via `logRedact`. Documented the delivery-state lookup in `docs/INDEXER.md`.