### PR TITLE
feat(repositories): Postgres RiskEvaluation and Transaction repositories

### DIFF
--- a/docs/REPOSITORY_ARCHITECTURE.md
+++ b/docs/REPOSITORY_ARCHITECTURE.md
@@ -30,6 +30,19 @@ Current in-memory implementations:
 - `InMemoryRiskEvaluationRepository.ts` - Memory-based risk evaluation storage
 - `InMemoryTransactionRepository.ts` - Memory-based transaction storage
 
+Postgres implementations (`src/repositories/postgres/`), selected by the
+`Container` whenever `DATABASE_URL` is set and `NODE_ENV !== 'test'`:
+- `PostgresCreditLineRepository.ts` - Credit lines joined to `borrowers`
+- `PostgresRiskEvaluationRepository.ts` - Risk evaluations (`creditLimit` <-> `suggested_limit`, `factors` <-> `inputs`, plus `expires_at`)
+- `PostgresTransactionRepository.ts` - Draws/repayments; `walletAddress` resolved via `credit_lines -> borrowers`
+
+In-memory repositories remain the default for development and tests.
+
+**Available-credit calculation.** `PostgresCreditLineRepository.calculateAvailableCredit`
+now reflects persisted draws: `credit_limit - SUM(borrows) + SUM(repays)` over
+the credit line's non-`failed`/`cancelled` transactions, clamped at zero. This
+replaces the previous behavior of always returning the full limit.
+
 ### 4. Services (`src/services/`)
 Business logic layer that uses repositories:
 - `CreditLineService.ts` - Credit line management and validation

--- a/migrations/004_repository_columns.sql
+++ b/migrations/004_repository_columns.sql
@@ -1,0 +1,19 @@
+-- Add columns required by the model layer so that PostgresRiskEvaluationRepository
+-- and PostgresTransactionRepository can persist every field the in-memory
+-- repositories track (see src/models/Transaction.ts and src/models/RiskEvaluation.ts).
+
+-- Transactions: lifecycle status, settlement time and the on-chain tx hash.
+ALTER TABLE transactions
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS processed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS blockchain_tx_hash TEXT;
+
+COMMENT ON COLUMN transactions.status IS 'Lifecycle status: pending, confirmed, failed, cancelled';
+
+CREATE INDEX IF NOT EXISTS transactions_status_idx ON transactions (status);
+
+-- Risk evaluations: expiry timestamp drives the isValid()/deleteExpired() paths.
+ALTER TABLE risk_evaluations
+  ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS risk_evaluations_expires_at_idx ON risk_evaluations (expires_at);

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -24,6 +24,8 @@ import { InMemoryCreditLineRepository } from "../repositories/memory/InMemoryCre
 import { InMemoryRiskEvaluationRepository } from "../repositories/memory/InMemoryRiskEvaluationRepository.js";
 import { InMemoryTransactionRepository } from "../repositories/memory/InMemoryTransactionRepository.js";
 import { PostgresCreditLineRepository } from "../repositories/postgres/PostgresCreditLineRepository.js";
+import { PostgresRiskEvaluationRepository } from "../repositories/postgres/PostgresRiskEvaluationRepository.js";
+import { PostgresTransactionRepository } from "../repositories/postgres/PostgresTransactionRepository.js";
 import { CreditLineService } from "../services/CreditLineService.js";
 import { RiskEvaluationService } from "../services/RiskEvaluationService.js";
 import { createRiskProvider } from "../services/providers/providerFactory.js";
@@ -96,9 +98,8 @@ export class Container {
       // Use PostgreSQL repositories
       this._dbClient = getConnection();
       this._creditLineRepository = new PostgresCreditLineRepository(this._dbClient);
-      // TODO: Implement PostgreSQL versions of other repositories
-      this._riskEvaluationRepository = new InMemoryRiskEvaluationRepository();
-      this._transactionRepository = new InMemoryTransactionRepository();
+      this._riskEvaluationRepository = new PostgresRiskEvaluationRepository(this._dbClient);
+      this._transactionRepository = new PostgresTransactionRepository(this._dbClient);
     } else {
       // Use in-memory repositories (for development/testing)
       this._creditLineRepository = new InMemoryCreditLineRepository();

--- a/src/repositories/postgres/PostgresCreditLineRepository.ts
+++ b/src/repositories/postgres/PostgresCreditLineRepository.ts
@@ -318,15 +318,35 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
   }
 
   /**
-   * Calculate available credit by subtracting total draws from credit limit.
-   * For now, returns the full credit limit since we don't have transaction tracking yet.
+   * Calculate available credit by subtracting net utilization (draws minus
+   * repayments) from the credit limit. Draws (borrows) reduce available
+   * credit; repayments restore it. Failed/cancelled transactions are excluded.
    */
-  private async calculateAvailableCredit(_creditLineId: string, creditLimit: string): Promise<string> {
-    // TODO: When transaction repository is implemented, calculate:
-    // creditLimit - SUM(transactions where type = 'draw' and credit_line_id = creditLineId)
-    
-    // For now, return full credit limit
-    return creditLimit;
+  private async calculateAvailableCredit(creditLineId: string, creditLimit: string): Promise<string> {
+    const query = `
+      SELECT COALESCE(SUM(
+        CASE
+          WHEN type = 'borrow' THEN amount
+          WHEN type = 'repay'  THEN -amount
+          ELSE 0
+        END
+      ), 0) AS utilized
+      FROM transactions
+      WHERE credit_line_id = $1
+        AND status NOT IN ('failed', 'cancelled')
+    `;
+
+    const result = await this.client.query(query, [creditLineId]);
+    const row = result.rows[0] as { utilized: string } | undefined;
+    const utilized = Number.parseFloat(row?.utilized ?? '0');
+    const limit = Number.parseFloat(creditLimit);
+
+    if (!Number.isFinite(utilized) || !Number.isFinite(limit)) {
+      return creditLimit;
+    }
+
+    const available = Math.max(0, limit - Math.max(0, utilized));
+    return available.toString();
   }
 
   private calculateUtilized(creditLimit: string, availableCredit: string): string {

--- a/src/repositories/postgres/PostgresRiskEvaluationRepository.ts
+++ b/src/repositories/postgres/PostgresRiskEvaluationRepository.ts
@@ -1,0 +1,133 @@
+import type { RiskEvaluation, RiskFactor } from '../../models/RiskEvaluation.js';
+import type { RiskEvaluationRepository } from '../interfaces/RiskEvaluationRepository.js';
+import type { DbClient } from '../../db/client.js';
+
+interface RiskEvaluationRow {
+  id: string;
+  wallet_address: string;
+  risk_score: number;
+  suggested_limit: string;
+  interest_rate_bps: number;
+  inputs: RiskFactor[] | null;
+  evaluated_at: Date;
+  expires_at: Date | null;
+}
+
+/**
+ * Postgres-backed RiskEvaluationRepository.
+ *
+ * Maps the {@link RiskEvaluation} model onto the `risk_evaluations` table
+ * (see `migrations/001_initial_schema.sql` + `004_repository_columns.sql`):
+ * - `creditLimit`  <-> `suggested_limit` (kept as a NUMERIC-as-string),
+ * - `factors`      <-> `inputs` JSONB snapshot,
+ * - `expiresAt`    <-> `expires_at`,
+ * - `walletAddress` is resolved through the `borrowers` join.
+ *
+ * All queries are parameterized; monetary columns stay typed as `string`.
+ */
+export class PostgresRiskEvaluationRepository implements RiskEvaluationRepository {
+  constructor(private client: DbClient) {}
+
+  async save(evaluation: Omit<RiskEvaluation, 'id'>): Promise<RiskEvaluation> {
+    const borrowerId = await this.ensureBorrower(evaluation.walletAddress);
+
+    const query = `
+      INSERT INTO risk_evaluations
+        (borrower_id, risk_score, suggested_limit, interest_rate_bps, inputs, evaluated_at, expires_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      RETURNING id, risk_score, suggested_limit, interest_rate_bps, inputs, evaluated_at, expires_at
+    `;
+    const values = [
+      borrowerId,
+      evaluation.riskScore,
+      evaluation.creditLimit,
+      evaluation.interestRateBps,
+      JSON.stringify(evaluation.factors ?? []),
+      evaluation.evaluatedAt,
+      evaluation.expiresAt,
+    ];
+
+    const result = await this.client.query(query, values);
+    const row = result.rows[0] as Omit<RiskEvaluationRow, 'wallet_address'>;
+    return this.toModel({ ...row, wallet_address: evaluation.walletAddress });
+  }
+
+  async findLatestByWalletAddress(walletAddress: string): Promise<RiskEvaluation | null> {
+    const rows = await this.select('WHERE b.wallet_address = $1', [walletAddress], 'ORDER BY re.evaluated_at DESC LIMIT 1');
+    return rows[0] ?? null;
+  }
+
+  async findById(id: string): Promise<RiskEvaluation | null> {
+    const rows = await this.select('WHERE re.id = $1', [id]);
+    return rows[0] ?? null;
+  }
+
+  async findByWalletAddress(walletAddress: string, offset = 0, limit = 100): Promise<RiskEvaluation[]> {
+    return this.select(
+      'WHERE b.wallet_address = $1',
+      [walletAddress, limit, offset],
+      'ORDER BY re.evaluated_at DESC LIMIT $2 OFFSET $3'
+    );
+  }
+
+  async deleteExpired(): Promise<number> {
+    const result = await this.client.query(
+      'DELETE FROM risk_evaluations WHERE expires_at IS NOT NULL AND expires_at < now()'
+    );
+    return (result as unknown as { rowCount: number }).rowCount ?? 0;
+  }
+
+  async isValid(walletAddress: string): Promise<boolean> {
+    const latest = await this.findLatestByWalletAddress(walletAddress);
+    if (!latest) return false;
+    return latest.expiresAt.getTime() > Date.now();
+  }
+
+  async findAll(offset = 0, limit = 100): Promise<RiskEvaluation[]> {
+    return this.select('', [limit, offset], 'ORDER BY re.evaluated_at DESC LIMIT $1 OFFSET $2');
+  }
+
+  async count(): Promise<number> {
+    const result = await this.client.query('SELECT COUNT(*) as count FROM risk_evaluations');
+    const row = result.rows[0] as { count: string };
+    return parseInt(row.count, 10);
+  }
+
+  private async select(where: string, values: unknown[], tail = ''): Promise<RiskEvaluation[]> {
+    const query = `
+      SELECT re.id, b.wallet_address, re.risk_score, re.suggested_limit,
+             re.interest_rate_bps, re.inputs, re.evaluated_at, re.expires_at
+      FROM risk_evaluations re
+      JOIN borrowers b ON re.borrower_id = b.id
+      ${where}
+      ${tail}
+    `;
+    const result = await this.client.query(query, values);
+    return (result.rows as RiskEvaluationRow[]).map((row) => this.toModel(row));
+  }
+
+  private async ensureBorrower(walletAddress: string): Promise<string> {
+    const found = await this.client.query('SELECT id FROM borrowers WHERE wallet_address = $1', [walletAddress]);
+    if (found.rows.length > 0) {
+      return (found.rows[0] as { id: string }).id;
+    }
+    const created = await this.client.query(
+      'INSERT INTO borrowers (wallet_address) VALUES ($1) RETURNING id',
+      [walletAddress]
+    );
+    return (created.rows[0] as { id: string }).id;
+  }
+
+  private toModel(row: RiskEvaluationRow): RiskEvaluation {
+    return {
+      id: row.id,
+      walletAddress: row.wallet_address,
+      riskScore: row.risk_score,
+      creditLimit: row.suggested_limit,
+      interestRateBps: row.interest_rate_bps,
+      factors: Array.isArray(row.inputs) ? row.inputs : [],
+      evaluatedAt: new Date(row.evaluated_at),
+      expiresAt: new Date(row.expires_at ?? row.evaluated_at),
+    };
+  }
+}

--- a/src/repositories/postgres/PostgresTransactionRepository.ts
+++ b/src/repositories/postgres/PostgresTransactionRepository.ts
@@ -1,0 +1,133 @@
+import {
+  type Transaction,
+  type CreateTransactionRequest,
+  TransactionStatus,
+  TransactionType,
+} from '../../models/Transaction.js';
+import type { TransactionRepository } from '../interfaces/TransactionRepository.js';
+import type { DbClient } from '../../db/client.js';
+
+interface TransactionRow {
+  id: string;
+  credit_line_id: string;
+  wallet_address: string;
+  amount: string;
+  type: string;
+  status: string;
+  blockchain_tx_hash: string | null;
+  created_at: Date;
+  processed_at: Date | null;
+}
+
+/**
+ * Postgres-backed TransactionRepository.
+ *
+ * Maps the {@link Transaction} model onto the `transactions` table (see
+ * `migrations/001_initial_schema.sql` + `004_repository_columns.sql`). The
+ * `walletAddress` is resolved through `credit_lines -> borrowers`. All queries
+ * are parameterized and the monetary `amount` column is preserved as `string`.
+ */
+export class PostgresTransactionRepository implements TransactionRepository {
+  constructor(private client: DbClient) {}
+
+  async create(request: CreateTransactionRequest): Promise<Transaction> {
+    const query = `
+      INSERT INTO transactions (credit_line_id, type, amount, currency, status, blockchain_tx_hash)
+      VALUES ($1, $2, $3, $4, $5, $6)
+      RETURNING id
+    `;
+    const values = [
+      request.creditLineId,
+      request.type,
+      request.amount,
+      'USDC',
+      TransactionStatus.PENDING,
+      request.blockchainTxHash ?? null,
+    ];
+    const result = await this.client.query(query, values);
+    const { id } = result.rows[0] as { id: string };
+    const created = await this.findById(id);
+    if (!created) {
+      throw new Error(`Failed to load created transaction: ${id}`);
+    }
+    return created;
+  }
+
+  async findById(id: string): Promise<Transaction | null> {
+    const rows = await this.select('WHERE t.id = $1', [id]);
+    return rows[0] ?? null;
+  }
+
+  async findByCreditLineId(creditLineId: string, offset = 0, limit = 100): Promise<Transaction[]> {
+    return this.select(
+      'WHERE t.credit_line_id = $1',
+      [creditLineId, limit, offset],
+      'ORDER BY t.created_at DESC LIMIT $2 OFFSET $3'
+    );
+  }
+
+  async findByWalletAddress(walletAddress: string, offset = 0, limit = 100): Promise<Transaction[]> {
+    return this.select(
+      'WHERE b.wallet_address = $1',
+      [walletAddress, limit, offset],
+      'ORDER BY t.created_at DESC LIMIT $2 OFFSET $3'
+    );
+  }
+
+  async updateStatus(id: string, status: TransactionStatus, processedAt?: Date): Promise<Transaction | null> {
+    const result = await this.client.query(
+      'UPDATE transactions SET status = $1, processed_at = $2 WHERE id = $3 RETURNING id',
+      [status, processedAt ?? new Date(), id]
+    );
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return this.findById(id);
+  }
+
+  async findAll(offset = 0, limit = 100): Promise<Transaction[]> {
+    return this.select('', [limit, offset], 'ORDER BY t.created_at DESC LIMIT $1 OFFSET $2');
+  }
+
+  async count(): Promise<number> {
+    const result = await this.client.query('SELECT COUNT(*) as count FROM transactions');
+    const row = result.rows[0] as { count: string };
+    return parseInt(row.count, 10);
+  }
+
+  async findByStatus(status: TransactionStatus, offset = 0, limit = 100): Promise<Transaction[]> {
+    return this.select(
+      'WHERE t.status = $1',
+      [status, limit, offset],
+      'ORDER BY t.created_at DESC LIMIT $2 OFFSET $3'
+    );
+  }
+
+  private async select(where: string, values: unknown[], tail = ''): Promise<Transaction[]> {
+    const query = `
+      SELECT t.id, t.credit_line_id, b.wallet_address, t.amount, t.type, t.status,
+             t.blockchain_tx_hash, t.created_at, t.processed_at
+      FROM transactions t
+      JOIN credit_lines cl ON t.credit_line_id = cl.id
+      JOIN borrowers b ON cl.borrower_id = b.id
+      ${where}
+      ${tail}
+    `;
+    const result = await this.client.query(query, values);
+    return (result.rows as TransactionRow[]).map((row) => this.toModel(row));
+  }
+
+  private toModel(row: TransactionRow): Transaction {
+    return {
+      id: row.id,
+      creditLineId: row.credit_line_id,
+      walletAddress: row.wallet_address,
+      amount: row.amount,
+      type: row.type as TransactionType,
+      status: row.status as TransactionStatus,
+      blockchainTxHash: row.blockchain_tx_hash ?? undefined,
+      createdAt: new Date(row.created_at),
+      processedAt: row.processed_at ? new Date(row.processed_at) : undefined,
+    };
+  }
+}

--- a/src/repositories/postgres/__tests__/PostgresTransactionRepository.test.ts
+++ b/src/repositories/postgres/__tests__/PostgresTransactionRepository.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DbClient } from '../../../db/client.js';
+import { PostgresTransactionRepository } from '../PostgresTransactionRepository.js';
+import { PostgresRiskEvaluationRepository } from '../PostgresRiskEvaluationRepository.js';
+import { TransactionStatus, TransactionType } from '../../../models/Transaction.js';
+
+function createMockClient(overrides: Partial<DbClient> = {}): DbClient {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+    end: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('PostgresTransactionRepository', () => {
+  let client: DbClient;
+  let repo: PostgresTransactionRepository;
+  const now = new Date();
+
+  beforeEach(() => {
+    client = createMockClient();
+    repo = new PostgresTransactionRepository(client);
+  });
+
+  it('creates a transaction with parameterized values', async () => {
+    vi.mocked(client.query)
+      // INSERT ... RETURNING id
+      .mockResolvedValueOnce({ rows: [{ id: 'tx-1' }] })
+      // findById select
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'tx-1',
+          credit_line_id: 'cl-1',
+          wallet_address: 'GTEST',
+          amount: '100.00',
+          type: 'borrow',
+          status: 'pending',
+          blockchain_tx_hash: null,
+          created_at: now,
+          processed_at: null,
+        }],
+      });
+
+    const result = await repo.create({
+      creditLineId: 'cl-1',
+      amount: '100.00',
+      type: TransactionType.BORROW,
+    });
+
+    expect(result.id).toBe('tx-1');
+    expect(result.walletAddress).toBe('GTEST');
+    expect(result.status).toBe(TransactionStatus.PENDING);
+    // No string interpolation: values are passed as a parameter array.
+    const insertCall = vi.mocked(client.query).mock.calls[0];
+    expect(Array.isArray(insertCall[1])).toBe(true);
+  });
+
+  it('updates status and returns null when not found', async () => {
+    vi.mocked(client.query).mockResolvedValueOnce({ rows: [] });
+    const result = await repo.updateStatus('missing', TransactionStatus.CONFIRMED);
+    expect(result).toBeNull();
+  });
+
+  it('counts transactions', async () => {
+    vi.mocked(client.query).mockResolvedValueOnce({ rows: [{ count: '7' }] });
+    expect(await repo.count()).toBe(7);
+  });
+
+  it('filters by status', async () => {
+    vi.mocked(client.query).mockResolvedValueOnce({ rows: [] });
+    await repo.findByStatus(TransactionStatus.FAILED);
+    const [, values] = vi.mocked(client.query).mock.calls[0];
+    expect(values?.[0]).toBe(TransactionStatus.FAILED);
+  });
+});
+
+describe('PostgresRiskEvaluationRepository', () => {
+  let client: DbClient;
+  let repo: PostgresRiskEvaluationRepository;
+  const evaluatedAt = new Date('2025-01-01T00:00:00.000Z');
+  const expiresAt = new Date('2025-01-02T00:00:00.000Z');
+
+  beforeEach(() => {
+    client = createMockClient();
+    repo = new PostgresRiskEvaluationRepository(client);
+  });
+
+  it('saves an evaluation, ensuring borrower exists', async () => {
+    vi.mocked(client.query)
+      // ensureBorrower lookup (found)
+      .mockResolvedValueOnce({ rows: [{ id: 'b-1' }] })
+      // INSERT ... RETURNING
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 're-1',
+          risk_score: 42,
+          suggested_limit: '5000.00',
+          interest_rate_bps: 500,
+          inputs: [{ name: 'utilization', value: 0.2, weight: 1 }],
+          evaluated_at: evaluatedAt,
+          expires_at: expiresAt,
+        }],
+      });
+
+    const result = await repo.save({
+      walletAddress: 'GTEST',
+      riskScore: 42,
+      creditLimit: '5000.00',
+      interestRateBps: 500,
+      factors: [{ name: 'utilization', value: 0.2, weight: 1 }],
+      evaluatedAt,
+      expiresAt,
+    });
+
+    expect(result.id).toBe('re-1');
+    expect(result.creditLimit).toBe('5000.00');
+    expect(result.factors).toHaveLength(1);
+    expect(result.expiresAt.toISOString()).toBe(expiresAt.toISOString());
+  });
+
+  it('isValid is false when no evaluation exists', async () => {
+    vi.mocked(client.query).mockResolvedValueOnce({ rows: [] });
+    expect(await repo.isValid('GTEST')).toBe(false);
+  });
+
+  it('deleteExpired returns affected row count', async () => {
+    vi.mocked(client.query).mockResolvedValueOnce({ rows: [], rowCount: 3 } as never);
+    expect(await repo.deleteExpired()).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #229.

Adds `PostgresRiskEvaluationRepository` and `PostgresTransactionRepository` (both satisfying the existing interfaces) under `src/repositories/postgres/`, using the shared `DbClient` with parameterized queries only and monetary columns kept as strings. `Container.initializeRepositories()` now wires both into the `useDatabase` branch instead of falling back to in-memory stores; in-memory remains the default for tests.

`PostgresCreditLineRepository.calculateAvailableCredit` is completed to subtract net utilization (SUM of borrows minus repays, excluding failed/cancelled) from the credit limit. Migration `004_repository_columns.sql` adds the columns the model needs (transaction status/processed_at/blockchain_tx_hash, risk_evaluations expires_at) using `ADD COLUMN IF NOT EXISTS` so `db:validate` stays green. Adds repository unit tests with a mocked `DbClient` and documents the implementations in `docs/REPOSITORY_ARCHITECTURE.md`.