### PR TITLE
chore(backend): UTC-only time handling helpers, tests and docs

### DIFF
--- a/docs/time.md
+++ b/docs/time.md
@@ -1,0 +1,40 @@
+# Time Handling (UTC-only)
+
+The backend standardises on **UTC** for every persisted, logged, and
+API-facing timestamp. This prevents the time-zone drift bugs that would
+otherwise corrupt reconciliation diffs and audit trails when the server,
+database, and chain disagree on "now".
+
+## Rules
+
+1. **Always UTC.** Emit timestamps as ISO-8601 with a `Z` suffix and
+   millisecond precision (`2026-06-29T12:34:56.789Z`).
+2. **Use the helpers in [`src/utils/time.ts`](../src/utils/time.ts):**
+   - `nowUtcIso()` — current instant as a UTC ISO string (server-derived).
+   - `toUtcIso(date)` — normalise a `Date` to a UTC ISO string.
+   - `parseUtc(value)` — parse an ISO string or epoch-ms number as UTC,
+     returning `null` on invalid input. Offset-less and date-only strings are
+     interpreted as UTC, never local time.
+   - `isUtcIso(value)` — assert a string is a `Z`-suffixed UTC ISO timestamp
+     (used at API/persistence boundaries and in tests).
+3. **Never use locale-aware formatters** (`toLocaleString`, `toDateString`,
+   `toString`) for any timestamp that is stored, logged, compared, or returned
+   to a client. They render in the host's local zone and silently drift.
+
+## Timestamp sources: chain vs server
+
+| Timestamp | Source | Notes |
+|---|---|---|
+| Horizon event `created_at` / ledger close time | **Chain** | Already UTC; normalise via `parseUtc` / `toUtcIso` before use. |
+| `WebhookPayload.data.horizonTimestamp` | **Chain** | Passed through from the Horizon event. |
+| `WebhookPayload.timestamp` (envelope) | **Server** | When the webhook was generated (`nowUtcIso()`). |
+| DB `TIMESTAMPTZ` columns (`created_at`, `evaluated_at`, …) | **Server** | Postgres stores instants in UTC; `DEFAULT now()` is UTC. |
+| `Transaction.processedAt`, `RiskEvaluation.expiresAt` | **Server** | Derived from server clock. |
+| Reconciliation comparisons | **Both** | Chain and server timestamps are compared only after both are normalised to UTC ISO. |
+
+## Testing
+
+`src/utils/__tests__/time.test.ts` asserts UTC formatting, stable round-trip
+parsing independent of the host time zone, rejection of offset-bearing
+timestamps, and `null`-on-invalid parsing — guarding against accidental
+local-time usage.

--- a/src/utils/__tests__/time.test.ts
+++ b/src/utils/__tests__/time.test.ts
@@ -6,6 +6,10 @@ import {
     ONE_DAY_MS,
     sleep,
     nowSeconds,
+    toUtcIso,
+    nowUtcIso,
+    parseUtc,
+    isUtcIso,
 } from '../time.js';
 
 describe('time utils', () => {
@@ -43,6 +47,46 @@ describe('time utils', () => {
             const value = nowSeconds();
             expect(Number.isInteger(value)).toBe(true);
             expect(value).toBeGreaterThan(0);
+        });
+    });
+
+    describe('UTC handling', () => {
+        const iso = '2026-06-29T12:34:56.789Z';
+
+        it('formats a Date as a UTC ISO-8601 string with Z suffix', () => {
+            expect(toUtcIso(new Date(iso))).toBe(iso);
+            expect(toUtcIso(new Date(iso)).endsWith('Z')).toBe(true);
+        });
+
+        it('nowUtcIso returns a valid UTC ISO string', () => {
+            expect(isUtcIso(nowUtcIso())).toBe(true);
+        });
+
+        it('parses ISO strings and epoch millis as UTC', () => {
+            expect(parseUtc(iso)?.toISOString()).toBe(iso);
+            expect(parseUtc(Date.parse(iso))?.toISOString()).toBe(iso);
+        });
+
+        it('parses a date-only string as UTC midnight (no local drift)', () => {
+            expect(parseUtc('2026-06-29')?.toISOString()).toBe('2026-06-29T00:00:00.000Z');
+        });
+
+        it('returns null for invalid input', () => {
+            expect(parseUtc('not-a-date')).toBeNull();
+            expect(parseUtc(Number.NaN)).toBeNull();
+        });
+
+        it('isUtcIso rejects offset-bearing or non-Z timestamps', () => {
+            expect(isUtcIso(iso)).toBe(true);
+            expect(isUtcIso('2026-06-29T12:34:56.789+02:00')).toBe(false);
+            expect(isUtcIso('2026-06-29T12:34:56.789')).toBe(false);
+            expect(isUtcIso('garbageZ')).toBe(false);
+        });
+
+        it('round-trips stably regardless of host time zone', () => {
+            const original = '2026-01-01T00:00:00.000Z';
+            const reparsed = parseUtc(original);
+            expect(reparsed && toUtcIso(reparsed)).toBe(original);
         });
     });
 });

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -24,3 +24,53 @@ export const sleep = (ms: number): Promise<void> => {
  * APIs (such as Stellar) that use second-resolution timestamps.
  */
 export const nowSeconds = (): number => Math.floor(Date.now() / 1000);
+
+// ---------------------------------------------------------------------------
+// UTC-only time handling
+// ---------------------------------------------------------------------------
+//
+// The backend standardises on UTC for every persisted, logged, and API-facing
+// timestamp. Server-derived timestamps come from `nowUtcIso()`; chain-derived
+// timestamps (e.g. Horizon `created_at`, ledger close time) are already UTC
+// and are normalised through `toUtcIso()`. Never format timestamps with
+// locale-aware helpers (`toLocaleString`, `toDateString`, …) — they introduce
+// time-zone drift that breaks reconciliation and audits. See `docs/time.md`.
+
+/**
+ * ISO-8601 UTC timestamp with millisecond precision and a `Z` suffix, e.g.
+ * `2026-06-29T12:34:56.789Z`. `Date.prototype.toISOString()` is always UTC,
+ * so this is the canonical, time-zone-stable representation.
+ */
+export const toUtcIso = (date: Date): string => date.toISOString();
+
+/**
+ * The current instant as a UTC ISO-8601 string. Prefer this over
+ * `new Date().toString()` or any locale-aware formatter for server-derived
+ * timestamps.
+ */
+export const nowUtcIso = (): string => new Date().toISOString();
+
+/**
+ * Parse a timestamp into a `Date`, treating the value as UTC. Accepts an
+ * ISO-8601 string or an epoch-millisecond number. Returns `null` for invalid
+ * input so callers can fail explicitly rather than propagate `Invalid Date`.
+ *
+ * A date-only string (`YYYY-MM-DD`) and an offset-less date-time are both
+ * interpreted as UTC per the ECMAScript spec, avoiding the "parsed in local
+ * time" footgun.
+ */
+export const parseUtc = (value: string | number): Date | null => {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/**
+ * True when `value` is a UTC ISO-8601 string (ends in `Z` and round-trips
+ * through `Date`). Useful for asserting that timestamps crossing a boundary
+ * (API response, persisted column) carry no local-time offset.
+ */
+export const isUtcIso = (value: string): boolean => {
+    if (!value.endsWith('Z')) return false;
+    const date = new Date(value);
+    return !Number.isNaN(date.getTime()) && date.toISOString() === value;
+};


### PR DESCRIPTION
Closes #224.

Adds UTC-only time helpers to `src/utils/time.ts` (`nowUtcIso`, `toUtcIso`, `parseUtc`, `isUtcIso`) so timestamps are formatted and parsed as UTC ISO-8601 (`Z`-suffixed) consistently, avoiding local-time drift in reconciliation and audits. Extends `time.test.ts` with cases asserting UTC formatting, host-zone-independent round-trip parsing, rejection of offset-bearing timestamps, and null-on-invalid parsing. Adds `docs/time.md` documenting the UTC rules and which timestamps are chain- vs server-derived.