### PR TITLE
feat(db): optimistic locking on credit line updates (409 conflicts)

### DIFF
--- a/migrations/004_credit_line_version.sql
+++ b/migrations/004_credit_line_version.sql
@@ -1,0 +1,8 @@
+-- Optimistic-locking version column for credit_lines.
+-- Incremented on every successful update so concurrent writers can detect
+-- lost-update conflicts (PostgresCreditLineRepository.update). See issue #223.
+
+ALTER TABLE credit_lines
+  ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN credit_lines.version IS 'Optimistic-locking version; incremented on each update';

--- a/src/models/CreditLine.ts
+++ b/src/models/CreditLine.ts
@@ -6,6 +6,11 @@ export interface CreditLine {
   utilized: string;
   interestRateBps: number; // Basis points (e.g., 500 = 5%)
   status: CreditLineStatus;
+  /**
+   * Optimistic-locking version. Incremented on every successful update so
+   * concurrent writers can detect lost-update conflicts. Starts at 1.
+   */
+  version?: number;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -28,4 +33,11 @@ export interface UpdateCreditLineRequest {
   interestRateBps?: number;
   status?: CreditLineStatus;
   utilized?: string;
+  /**
+   * Optimistic-locking guard. When provided, the update only succeeds if the
+   * stored {@link CreditLine.version} equals this value; otherwise the
+   * repository signals a conflict (mapped to HTTP 409). Omit to update
+   * unconditionally (last-write-wins, legacy behavior).
+   */
+  expectedVersion?: number;
 }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -94,6 +94,14 @@ components:
           type: string
           enum: [active, suspended, closed]
           description: Credit line status
+        expectedVersion:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking guard. When provided, the update only succeeds
+            if it equals the stored `version`; otherwise the server returns
+            `409 Conflict`. Omit for unconditional (last-write-wins) updates.
+          example: 3
       additionalProperties: false
 
     CreditLine:
@@ -127,6 +135,14 @@ components:
           type: string
           enum: [active, suspended, closed]
           description: Current credit line status
+        version:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking version, incremented on each update. Pass the
+            value you read back as `expectedVersion` on a subsequent update to
+            guard against lost writes.
+          example: 1
         createdAt:
           type: string
           format: date-time
@@ -735,6 +751,7 @@ paths:
               creditLimit: "1500.00"
               interestRateBps: 640
               status: active
+              expectedVersion: 3
       responses:
         "200":
           description: Credit line updated successfully
@@ -750,6 +767,16 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Optimistic-locking conflict. The supplied `expectedVersion` did not
+            match the stored `version`, meaning a concurrent update won the
+            race. Re-read the credit line to get the current `version` and
+            retry the update with it.
           content:
             application/json:
               schema:

--- a/src/repositories/memory/InMemoryCreditLineRepository.ts
+++ b/src/repositories/memory/InMemoryCreditLineRepository.ts
@@ -1,5 +1,6 @@
 import{ type CreditLine, type CreateCreditLineRequest, type UpdateCreditLineRequest, CreditLineStatus } from '../../models/CreditLine.js';
 import type{ CreditLineRepository, CursorPaginationResult } from '../interfaces/CreditLineRepository.js';
+import { VersionConflictError } from '../../services/creditService.js';
 import { randomUUID } from 'crypto';
 
 export class InMemoryCreditLineRepository implements CreditLineRepository {
@@ -25,6 +26,7 @@ export class InMemoryCreditLineRepository implements CreditLineRepository {
       utilized: '0',
       interestRateBps: request.interestRateBps,
       status: CreditLineStatus.ACTIVE,
+      version: 1,
       createdAt: now,
       updatedAt: now
     };
@@ -104,9 +106,20 @@ export class InMemoryCreditLineRepository implements CreditLineRepository {
       return null;
     }
 
+    const currentVersion = existing.version ?? 1;
+
+    // Optimistic locking: when the caller supplies the version it read,
+    // reject the write if another update advanced it in the meantime.
+    if (request.expectedVersion !== undefined && request.expectedVersion !== currentVersion) {
+      throw new VersionConflictError(id, request.expectedVersion, currentVersion);
+    }
+
+    const { expectedVersion: _expectedVersion, ...patch } = request;
+
     const updated: CreditLine = {
       ...existing,
-      ...request,
+      ...patch,
+      version: currentVersion + 1,
       updatedAt: new Date()
     };
 

--- a/src/repositories/memory/__tests__/InMemoryCreditLineRepository.test.ts
+++ b/src/repositories/memory/__tests__/InMemoryCreditLineRepository.test.ts
@@ -418,10 +418,63 @@ describe('InMemoryCreditLineRepository', () => {
 
     it('should return empty result for empty repository', async () => {
       const result = await repository.findAllWithCursor(undefined, 10);
-      
+
       expect(result.items).toHaveLength(0);
       expect(result.hasMore).toBe(false);
       expect(result.nextCursor).toBeNull();
+    });
+  });
+
+  describe('optimistic locking', () => {
+    const baseRequest = {
+      walletAddress: 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1',
+      creditLimit: '1000.00',
+      interestRateBps: 500,
+    };
+
+    it('starts new credit lines at version 1', async () => {
+      const created = await repository.create(baseRequest);
+      expect(created.version).toBe(1);
+    });
+
+    it('increments version on every successful update', async () => {
+      const created = await repository.create(baseRequest);
+      const updated = await repository.update(created.id, { interestRateBps: 600 });
+      expect(updated?.version).toBe(2);
+      const again = await repository.update(created.id, { interestRateBps: 700 });
+      expect(again?.version).toBe(3);
+    });
+
+    it('allows a conditional update when expectedVersion matches', async () => {
+      const created = await repository.create(baseRequest);
+      const updated = await repository.update(created.id, {
+        interestRateBps: 600,
+        expectedVersion: 1,
+      });
+      expect(updated?.interestRateBps).toBe(600);
+      expect(updated?.version).toBe(2);
+    });
+
+    it('throws VersionConflictError on a stale expectedVersion (concurrent update)', async () => {
+      const created = await repository.create(baseRequest);
+      // First writer wins and advances the version to 2.
+      await repository.update(created.id, { interestRateBps: 600, expectedVersion: 1 });
+
+      // Second writer still holds the stale version 1 it originally read.
+      await expect(
+        repository.update(created.id, { interestRateBps: 999, expectedVersion: 1 }),
+      ).rejects.toMatchObject({ name: 'VersionConflictError', code: 'version_conflict' });
+
+      // The losing write did not take effect.
+      const current = await repository.findById(created.id);
+      expect(current?.interestRateBps).toBe(600);
+    });
+
+    it('updates unconditionally when expectedVersion is omitted', async () => {
+      const created = await repository.create(baseRequest);
+      const updated = await repository.update(created.id, { interestRateBps: 600 });
+      expect(updated?.interestRateBps).toBe(600);
+      expect(updated?.version).toBe(2);
     });
   });
 });

--- a/src/repositories/postgres/PostgresCreditLineRepository.ts
+++ b/src/repositories/postgres/PostgresCreditLineRepository.ts
@@ -1,6 +1,7 @@
 import type { CreditLine, CreateCreditLineRequest, UpdateCreditLineRequest, CreditLineStatus } from '../../models/CreditLine.js';
 import type { CreditLineRepository, CursorPaginationResult } from '../interfaces/CreditLineRepository.js';
 import type { DbClient } from '../../db/client.js';
+import { VersionConflictError } from '../../services/creditService.js';
 
 interface CreditLineRow {
   id: string;
@@ -8,6 +9,7 @@ interface CreditLineRow {
   currency: string;
   status: string;
   interest_rate_bps: number;
+  version: number;
   created_at: Date;
   updated_at: Date;
   wallet_address: string;
@@ -23,7 +25,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
     const query = `
       INSERT INTO credit_lines (borrower_id, credit_limit, currency, status, interest_rate_bps)
       VALUES ($1, $2, $3, $4, $5)
-      RETURNING id, borrower_id, credit_limit, currency, status, interest_rate_bps, created_at, updated_at
+      RETURNING id, borrower_id, credit_limit, currency, status, interest_rate_bps, version, created_at, updated_at
     `;
 
     const values = [
@@ -42,6 +44,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
       currency: string;
       status: string;
       interest_rate_bps: number;
+      version: number;
       created_at: Date;
       updated_at: Date;
     };
@@ -57,6 +60,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
       utilized: '0',
       interestRateBps: row.interest_rate_bps,
       status: row.status as CreditLineStatus,
+      version: row.version,
       createdAt: row.created_at,
       updatedAt: row.updated_at
     };
@@ -70,6 +74,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
         cl.currency,
         cl.status,
         cl.interest_rate_bps,
+        cl.version,
         cl.created_at,
         cl.updated_at,
         b.wallet_address
@@ -100,6 +105,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
         cl.currency,
         cl.status,
         cl.interest_rate_bps,
+        cl.version,
         cl.created_at,
         cl.updated_at,
         b.wallet_address
@@ -128,6 +134,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
         cl.currency,
         cl.status,
         cl.interest_rate_bps,
+        cl.version,
         cl.created_at,
         cl.updated_at,
         b.wallet_address
@@ -181,6 +188,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
         cl.currency,
         cl.status,
         cl.interest_rate_bps,
+        cl.version,
         cl.created_at,
         cl.updated_at,
         b.wallet_address
@@ -239,18 +247,34 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
     }
 
     setParts.push(`updated_at = now()`);
+    setParts.push(`version = version + 1`);
     values.push(id); // For WHERE clause
+    const idParam = paramIndex++;
+
+    // Optimistic locking: when expectedVersion is supplied, only update the
+    // row if its stored version still matches; a zero-row result with an
+    // existing row then signals a concurrent-write conflict (HTTP 409).
+    let versionClause = '';
+    if (request.expectedVersion !== undefined) {
+      versionClause = ` AND version = $${paramIndex++}`;
+      values.push(request.expectedVersion);
+    }
 
     const query = `
-      UPDATE credit_lines 
+      UPDATE credit_lines
       SET ${setParts.join(', ')}
-      WHERE id = $${paramIndex}
+      WHERE id = $${idParam}${versionClause}
       RETURNING id
     `;
 
     const result = await this.client.query(query, values);
-    
+
     if (result.rows.length === 0) {
+      // Distinguish "row missing" (404) from "version mismatch" (409).
+      if (request.expectedVersion !== undefined && (await this.exists(id))) {
+        const current = await this.findById(id);
+        throw new VersionConflictError(id, request.expectedVersion, current?.version ?? -1);
+      }
       return null;
     }
 
@@ -343,6 +367,7 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
       utilized: this.calculateUtilized(row.credit_limit, availableCredit),
       interestRateBps: row.interest_rate_bps,
       status: row.status as CreditLineStatus,
+      version: row.version,
       createdAt: row.created_at,
       updatedAt: row.updated_at
     };

--- a/src/repositories/postgres/__tests__/PostgresCreditLineRepository.test.ts
+++ b/src/repositories/postgres/__tests__/PostgresCreditLineRepository.test.ts
@@ -40,6 +40,7 @@ describe('PostgresCreditLineRepository', () => {
             currency: 'USDC',
             status: 'active',
             interest_rate_bps: 500,
+            version: 1,
             created_at: now,
             updated_at: now
           }]
@@ -63,6 +64,7 @@ describe('PostgresCreditLineRepository', () => {
         utilized: '0',
         interestRateBps: 500,
         status: CreditLineStatus.ACTIVE,
+        version: 1,
         createdAt: now,
         updatedAt: now
       });
@@ -87,6 +89,7 @@ describe('PostgresCreditLineRepository', () => {
             currency: 'USDC',
             status: 'active',
             interest_rate_bps: 750,
+            version: 1,
             created_at: now,
             updated_at: now
           }]
@@ -120,6 +123,7 @@ describe('PostgresCreditLineRepository', () => {
             currency: 'USDC',
             status: 'active',
             interest_rate_bps: 600,
+            version: 1,
             created_at: now,
             updated_at: now,
             wallet_address: 'GTEST789'
@@ -136,6 +140,7 @@ describe('PostgresCreditLineRepository', () => {
         utilized: '0',
         interestRateBps: 600,
         status: CreditLineStatus.ACTIVE,
+        version: 1,
         createdAt: now,
         updatedAt: now
       });

--- a/src/routes/credit.ts
+++ b/src/routes/credit.ts
@@ -36,6 +36,7 @@ import { ok, fail } from '../utils/response.js';
 import {
   CreditLineNotFoundError,
   InvalidTransitionError,
+  VersionConflictError,
   TransactionType,
   suspendCreditLine,
   closeCreditLine,
@@ -66,6 +67,10 @@ function handleServiceError(err: unknown, res: Response): void {
     return;
   }
   if (err instanceof InvalidTransitionError) {
+    fail(res, err.message, 409);
+    return;
+  }
+  if (err instanceof VersionConflictError) {
     fail(res, err.message, 409);
     return;
   }
@@ -143,17 +148,22 @@ creditRouter.post('/lines', validateBody(createCreditLineSchema), async (req, re
 
 creditRouter.put('/lines/:id', async (req, res) => {
   try {
-    const { creditLimit, interestRateBps, status } = req.body;
+    const { creditLimit, interestRateBps, status, expectedVersion } = req.body;
     const creditLine = await container.creditLineService.updateCreditLine(req.params.id, {
       creditLimit,
       interestRateBps,
       status,
+      expectedVersion,
     });
     if (!creditLine) {
       return fail(res, 'Credit line not found', 404);
     }
     return ok(res, creditLine);
   } catch (error) {
+    // Optimistic-locking conflicts surface as 409; other validation as 400.
+    if (error instanceof VersionConflictError) {
+      return handleServiceError(error, res);
+    }
     return fail(res, error instanceof Error ? error : undefined, 400);
   }
 });

--- a/src/services/creditService.ts
+++ b/src/services/creditService.ts
@@ -138,6 +138,28 @@ export class CreditLineNotFoundError extends Error {
   }
 }
 
+/**
+ * Thrown when an optimistic-locking update fails because the stored
+ * {@link CreditLine.version} no longer matches the `expectedVersion` the
+ * caller read. Indicates a concurrent write won the race; the caller should
+ * re-read the credit line and retry with the fresh version. Mapped to HTTP
+ * `409 Conflict` (error code `version_conflict`) by `routes/credit.ts`.
+ */
+export class VersionConflictError extends Error {
+  public readonly code = 'version_conflict';
+  constructor(
+    public readonly id: string,
+    public readonly expectedVersion: number,
+    public readonly actualVersion: number,
+  ) {
+    super(
+      `Credit line "${id}" was modified concurrently ` +
+        `(expected version ${expectedVersion}, found ${actualVersion}). Re-read and retry.`,
+    );
+    this.name = 'VersionConflictError';
+  }
+}
+
 export const _store = new Map<string, CreditLine>();
 export const _transactionStore = new Map<string, Transaction[]>();
 


### PR DESCRIPTION
Closes #223.

Adds a `version` column to credit lines (model + migration `004_credit_line_version.sql`) and an optional `expectedVersion` guard on `UpdateCreditLineRequest`. Both the in-memory and Postgres repositories check-and-increment: when `expectedVersion` is supplied and no longer matches the stored version, they throw `VersionConflictError`, which the credit route maps to HTTP 409 (`version_conflict`). Omitting `expectedVersion` preserves the existing last-write-wins behavior.

Retry strategy: on 409, re-GET the credit line to read the fresh `version`, then retry the PUT with it. Adds concurrency-conflict tests to `InMemoryCreditLineRepository.test.ts` and documents the new field plus the 409 response in `openapi.yaml`.