### PR TITLE
chore: route service logs through structured logger

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -10,6 +10,8 @@ The backend is built to be debuggable from a single correlation ID. This documen
 
 A single Pino logger lives in [`src/utils/logger.ts`](../src/utils/logger.ts) and is reused everywhere. JSON-by-default, ISO timestamps, silent in `NODE_ENV=test`. Plug a `pino-pretty` sidecar in dev only.
 
+Service modules log through [`src/utils/serviceLogger.ts`](../src/utils/serviceLogger.ts), a thin wrapper around the shared Pino logger. It attaches a stable `service` field, emits fixed event-style messages such as `reconciliation-worker:job:complete`, and redacts structured context before it reaches Pino. Do not add bare `console.*` calls in `src/services`; use `createServiceLogger(...)` instead.
+
 ### 1.2 Correlation IDs
 
 Every inbound request is assigned a UUID (or honoured if a client supplies `x-request-id`) by [`src/middleware/requestLogger.ts`](../src/middleware/requestLogger.ts) and echoed back in the response. The same id is attached to `req.requestId` so downstream handlers can include it in domain logs.
@@ -26,6 +28,8 @@ Notice `walletAddress` is **sanitized** to `first6...last4` so logs are useful w
 ### 1.3 Redaction
 
 [`src/utils/logRedact.ts`](../src/utils/logRedact.ts) walks string args, object values, and `Error.message`, redacting any Stellar address (`G[A-Z2-7]{55}`) to `Gxxxxx...xxxx`. Call sites should prefer the helpers `redactLogArgs(...)` or `redactObject(...)` when constructing log lines from external strings.
+
+Service logger contexts are passed through `redactLogValue(...)`, so strings, nested objects, arrays, and `Error` instances are sanitized consistently before they are logged.
 
 Set `LOG_REDACTION_DEBUG=1` to suppress redaction temporarily during incident response.
 
@@ -201,6 +205,7 @@ node dist/index.js | npx pino-pretty
 ## 7. References
 
 - [`src/utils/logger.ts`](../src/utils/logger.ts)
+- [`src/utils/serviceLogger.ts`](../src/utils/serviceLogger.ts)
 - [`src/utils/logRedact.ts`](../src/utils/logRedact.ts)
 - [`src/middleware/requestLogger.ts`](../src/middleware/requestLogger.ts)
 - [`src/routes/health.ts`](../src/routes/health.ts)

--- a/src/__test__/horizonListener.test.ts
+++ b/src/__test__/horizonListener.test.ts
@@ -1,3 +1,15 @@
+import { vi } from "vitest";
+
+const serviceLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../utils/serviceLogger.js", () => ({
+  createServiceLogger: () => serviceLoggerMock,
+}));
+
 import {
   start,
   stop,
@@ -12,7 +24,6 @@ import {
   type HorizonEvent,
   type HorizonListenerConfig,
 } from "../services/horizonListener.js";
-import { vi, type Mock } from "vitest";
 
 const baseConfig: HorizonListenerConfig = {
   horizonUrl: "https://horizon-testnet.stellar.org",
@@ -24,19 +35,6 @@ const baseConfig: HorizonListenerConfig = {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Capture console output without cluttering test output. */
-function silenceConsole() {
-  vi.spyOn(console, "log").mockImplementation(() => {});
-  vi.spyOn(console, "warn").mockImplementation(() => {});
-  vi.spyOn(console, "error").mockImplementation(() => {});
-}
-
-function restoreConsole() {
-  (console.log as unknown as Mock).mockRestore?.();
-  (console.warn as unknown as Mock).mockRestore?.();
-  (console.error as unknown as Mock).mockRestore?.();
-}
 
 /** Save and restore env vars. */
 function withEnv(vars: Record<string, string>, fn: () => void) {
@@ -63,7 +61,9 @@ function withEnv(vars: Record<string, string>, fn: () => void) {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  silenceConsole();
+  serviceLoggerMock.info.mockReset();
+  serviceLoggerMock.warn.mockReset();
+  serviceLoggerMock.error.mockReset();
   // Ensure clean state before every test.
   if (isRunning()) stop();
   clearEventHandlers();
@@ -72,7 +72,6 @@ beforeEach(() => {
 afterEach(() => {
   if (isRunning()) stop();
   clearEventHandlers();
-  restoreConsole();
   vi.useRealTimers();
 });
 
@@ -225,18 +224,19 @@ describe("start()", () => {
   it("is a no-op (warns) if called when already running", async () => {
     vi.useFakeTimers();
     await start();
-    const warnSpy = console.warn as unknown as Mock;
+    const warnSpy = serviceLoggerMock.warn;
     warnSpy.mockClear();
     await start(); // second call
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Already running"),
+      undefined,
     );
     expect(isRunning()).toBe(true);
   });
 
   it("logs startup config information", async () => {
     vi.useFakeTimers();
-    const logSpy = console.log as unknown as Mock;
+    const logSpy = serviceLoggerMock.info;
     await start();
     const calls = logSpy.mock.calls.flat().join(" ");
     expect(calls).toContain("Starting with config");
@@ -276,20 +276,21 @@ describe("stop()", () => {
   });
 
   it("is a no-op (warns) if called when not running", () => {
-    const warnSpy = console.warn as unknown as Mock;
+    const warnSpy = serviceLoggerMock.warn;
     stop();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Not running"),
+      undefined,
     );
   });
 
   it("logs a stopped message", async () => {
     vi.useFakeTimers();
     await start();
-    const logSpy = console.log as unknown as Mock;
+    const logSpy = serviceLoggerMock.info;
     logSpy.mockClear();
     stop();
-    expect((console.log as unknown as Mock).mock.calls.flat().join(" ")).toContain(
+    expect(serviceLoggerMock.info.mock.calls.flat().join(" ")).toContain(
       "Stopped",
     );
   });
@@ -367,8 +368,8 @@ describe("onEvent() / clearEventHandlers()", () => {
 
       expect(goodEvents.length).toBe(1);
       expect(
-        (console.error as unknown as Mock).mock.calls.flat().join(" "),
-      ).toContain("handler threw an error");
+        serviceLoggerMock.error.mock.calls.flat().join(" "),
+      ).toContain("horizon:event-handler:failed");
     });
   });
 
@@ -399,10 +400,13 @@ describe("pollOnce()", () => {
   });
 
   it("logs a polling message on every call", async () => {
-    const logSpy = console.log as unknown as Mock;
+    const logSpy = serviceLoggerMock.info;
     logSpy.mockClear();
     await pollOnce(baseConfig);
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Polling"));
+    expect(logSpy).toHaveBeenCalledWith(
+      "horizon:poll:start",
+      expect.objectContaining({ horizonUrl: baseConfig.horizonUrl }),
+    );
   });
 
   it("emits a simulated event when contractIds is non-empty", async () => {
@@ -431,10 +435,13 @@ describe("pollOnce()", () => {
   });
 
   it("logs 'none' for contracts when contractIds is empty", async () => {
-    const logSpy = console.log as unknown as Mock;
+    const logSpy = serviceLoggerMock.info;
     logSpy.mockClear();
     await pollOnce(baseConfig);
-    expect((logSpy.mock.calls.flat() as string[]).join(" ")).toContain("none");
+    expect(logSpy).toHaveBeenCalledWith(
+      "horizon:poll:start",
+      expect.objectContaining({ contractCount: 0, contractIds: [] }),
+    );
   });
 
   it("includes simulated event data with a walletAddress field", async () => {
@@ -705,7 +712,7 @@ describe("Resilience Features", () => {
 
   describe("Structured Logging", () => {
     it("logs metrics when enabled", async () => {
-      const logSpy = console.log as unknown as Mock;
+      const logSpy = serviceLoggerMock.info;
       logSpy.mockClear();
       
       const config: HorizonListenerConfig = {
@@ -721,11 +728,11 @@ describe("Resilience Features", () => {
       
       // Should have logged metrics
       const logCalls = logSpy.mock.calls.flat().join(" ");
-      expect(logCalls).toContain("Metrics:");
+      expect(logCalls).toContain("horizon:metrics");
     });
 
     it("does not log metrics when disabled", async () => {
-      const logSpy = console.log as unknown as Mock;
+      const logSpy = serviceLoggerMock.info;
       logSpy.mockClear();
       
       const config: HorizonListenerConfig = {
@@ -738,7 +745,7 @@ describe("Resilience Features", () => {
       
       // Should not have logged detailed metrics
       const logCalls = logSpy.mock.calls.flat().join(" ");
-      expect(logCalls).not.toContain("Metrics:");
+      expect(logCalls).not.toContain("horizon:metrics");
     });
   });
 

--- a/src/__test__/jobQueue.test.ts
+++ b/src/__test__/jobQueue.test.ts
@@ -5,27 +5,35 @@ import {
   vi,
   beforeEach,
   afterEach,
-  type MockInstance,
 } from "vitest";
 import {
   InMemoryJobQueue,
   type Job,
 } from "../services/jobQueue.js";
 
+const serviceLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../utils/serviceLogger.js", () => ({
+  createServiceLogger: () => serviceLoggerMock,
+}));
+
 function createQueue(): InMemoryJobQueue {
   return new InMemoryJobQueue(10, 20);
 }
 
 describe("InMemoryJobQueue", () => {
-  let consoleErrorSpy: MockInstance;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    serviceLoggerMock.info.mockReset();
+    serviceLoggerMock.warn.mockReset();
+    serviceLoggerMock.error.mockReset();
   });
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore();
     vi.useRealTimers();
   });
 
@@ -130,7 +138,7 @@ describe("InMemoryJobQueue", () => {
     expect(failed[0]?.lastError).toBe("kaboom");
   });
 
-  it("surfaces dead-letter jobs to operators via console.error", async () => {
+  it("surfaces dead-letter jobs to operators via structured logger", async () => {
     const queue = createQueue();
     queue.registerHandler("fail-once", async () => {
       throw new Error("oops");
@@ -141,8 +149,13 @@ describe("InMemoryJobQueue", () => {
     await vi.advanceTimersByTimeAsync(100);
     await queue.drain();
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("exhausted"),
+    expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+      "job-queue:dead-letter:max-attempts-exhausted",
+      expect.objectContaining({
+        jobType: "fail-once",
+        attempts: 1,
+        lastError: "oops",
+      }),
     );
   });
 
@@ -161,8 +174,9 @@ describe("InMemoryJobQueue", () => {
     expect(queue.getFailedJobs()).toHaveLength(1);
     expect(queue.getFailedJobs()[0]?.type).toBe("no-handler");
     expect(queue.size()).toBe(0);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("No handler"),
+    expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+      "job-queue:dead-letter:no-handler",
+      expect.objectContaining({ jobType: "no-handler" }),
     );
   });
 

--- a/src/__tests__/reconciliation.integration.test.ts
+++ b/src/__tests__/reconciliation.integration.test.ts
@@ -6,6 +6,16 @@ import { InMemoryCreditLineRepository } from '../repositories/memory/InMemoryCre
 import { InMemoryJobQueue } from '../services/jobQueue.js';
 import { StellarSorobanClient } from '../services/sorobanClient.js';
 
+const serviceLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('../utils/serviceLogger.js', () => ({
+  createServiceLogger: () => serviceLoggerMock,
+}));
+
 const TEST_PUBLIC_KEY = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 1));
 const TEST_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 1));
 
@@ -38,6 +48,9 @@ describe('Reconciliation Integration', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    serviceLoggerMock.info.mockReset();
+    serviceLoggerMock.warn.mockReset();
+    serviceLoggerMock.error.mockReset();
     repository = new InMemoryCreditLineRepository();
     sorobanClient = new TestSorobanClient();
     jobQueue = new InMemoryJobQueue(10, 20);
@@ -79,8 +92,13 @@ describe('Reconciliation Integration', () => {
 
     // Verify: Job failed due to critical mismatch
     expect(jobQueue.getFailedJobs()).toHaveLength(1);
-    expect(console.error).toHaveBeenCalledWith(
-      '[ReconciliationWorker] ALERT: Reconciliation found 1 mismatches (1 critical, 0 warnings)'
+    expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+      'reconciliation-worker:mismatches-alert',
+      expect.objectContaining({
+        mismatchCount: 1,
+        criticalCount: 1,
+        warningCount: 0,
+      }),
     );
   });
 
@@ -109,8 +127,9 @@ describe('Reconciliation Integration', () => {
 
     // Verify: Job succeeded
     expect(jobQueue.getFailedJobs()).toHaveLength(0);
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('completed successfully')
+    expect(serviceLoggerMock.info).toHaveBeenCalledWith(
+      'reconciliation-worker:job:complete',
+      expect.objectContaining({ totalChecked: 1 }),
     );
   });
 
@@ -192,8 +211,13 @@ describe('Reconciliation Integration', () => {
 
     // Verify: Job succeeded despite warning
     expect(jobQueue.getFailedJobs()).toHaveLength(0);
-    expect(console.error).toHaveBeenCalledWith(
-      '[ReconciliationWorker] ALERT: Reconciliation found 1 mismatches (0 critical, 1 warnings)'
+    expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+      'reconciliation-worker:mismatches-alert',
+      expect.objectContaining({
+        mismatchCount: 1,
+        criticalCount: 0,
+        warningCount: 1,
+      }),
     );
   });
 

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -46,10 +46,11 @@ export class Container {
   private _transactionRepository!: TransactionRepository;
 
   // Services
-  private _creditLineService: CreditLineService;
-  private _riskEvaluationService: RiskEvaluationService;
-  private _reconciliationService: ReconciliationService;
-  private _reconciliationWorker: ReconciliationWorker;
+  private _creditLineService!: CreditLineService;
+  private _riskEvaluationService!: RiskEvaluationService;
+  private _sorobanClient!: SorobanRpcClient;
+  private _reconciliationService!: ReconciliationService;
+  private _reconciliationWorker!: ReconciliationWorker;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -92,12 +92,15 @@ describe('applyMigration', () => {
 describe('runPendingMigrations', () => {
   it('skips already applied migrations', async () => {
     const client = createMockClient();
-    vi.mocked(client.query)
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ version: '001_initial_schema' }, { version: '002_add_interest_rate_to_credit_lines' }] });
     const migrationsDir = await import('path').then((p) =>
       p.join(process.cwd(), 'migrations')
     );
+    const appliedVersions = (await listMigrationFiles(migrationsDir)).map(versionFromFilename);
+
+    vi.mocked(client.query)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: appliedVersions.map((version) => ({ version })) });
+
     const run = await runPendingMigrations(client, migrationsDir);
     expect(run).toEqual([]);
   });

--- a/src/repositories/memory/InMemoryCreditLineRepository.ts
+++ b/src/repositories/memory/InMemoryCreditLineRepository.ts
@@ -104,10 +104,16 @@ export class InMemoryCreditLineRepository implements CreditLineRepository {
       return null;
     }
 
+    const now = new Date();
+    const previousUpdatedAt = existing.updatedAt.getTime();
+    const updatedAt = now.getTime() <= previousUpdatedAt
+      ? new Date(previousUpdatedAt + 1)
+      : now;
+
     const updated: CreditLine = {
       ...existing,
       ...request,
-      updatedAt: new Date()
+      updatedAt
     };
 
     // Keep availableCredit in sync if utilized changes

--- a/src/services/__tests__/drawWebhookService.test.ts
+++ b/src/services/__tests__/drawWebhookService.test.ts
@@ -1,4 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const serviceLoggerMock = vi.hoisted(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+}));
+
+vi.mock("../../utils/serviceLogger.js", () => ({
+    createServiceLogger: () => serviceLoggerMock,
+}));
+
 import { 
     initializeWebhooks, 
     sendDrawConfirmationWebhook, 
@@ -12,14 +23,12 @@ import type { HorizonEvent } from "../horizonListener.js";
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-// Mock console methods to avoid noise in tests
-const mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-const mockConsoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-
 describe("DrawWebhookService", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        serviceLoggerMock.info.mockReset();
+        serviceLoggerMock.warn.mockReset();
+        serviceLoggerMock.error.mockReset();
         vi.useFakeTimers();
         
         // Clear environment variables
@@ -126,8 +135,8 @@ describe("DrawWebhookService", () => {
 
             initializeWebhooks();
 
-            expect(mockConsoleLog).toHaveBeenCalledWith(
-                "[DrawWebhook] Initialized with config:",
+            expect(serviceLoggerMock.info).toHaveBeenCalledWith(
+                "webhook:initialized",
                 expect.objectContaining({
                     urls: 2,
                     maxRetries: 3,
@@ -295,7 +304,11 @@ describe("DrawWebhookService", () => {
             });
 
             expect(mockFetch).toHaveBeenCalledTimes(3);
-            expect(mockConsoleWarn).toHaveBeenCalledTimes(2);
+            expect(serviceLoggerMock.warn).toHaveBeenCalledTimes(2);
+            expect(serviceLoggerMock.warn).toHaveBeenCalledWith(
+                "webhook:delivery:retry",
+                expect.objectContaining({ attempt: 1 }),
+            );
         });
 
         it("should handle malformed event data gracefully", async () => {
@@ -310,9 +323,9 @@ describe("DrawWebhookService", () => {
             const results = await sendDrawConfirmationWebhook(event);
 
             expect(results).toEqual([]);
-            expect(mockConsoleError).toHaveBeenCalledWith(
-                "[DrawWebhook] Failed to parse event data:",
-                expect.any(Error)
+            expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+                "webhook:event-parse:failed",
+                expect.objectContaining({ error: expect.any(Error) }),
             );
         });
 

--- a/src/services/__tests__/reconciliationService.test.ts
+++ b/src/services/__tests__/reconciliationService.test.ts
@@ -8,6 +8,16 @@ import { InMemoryCreditLineRepository } from '../../repositories/memory/InMemory
 import { InMemoryJobQueue } from '../jobQueue.js';
 import { SorobanCreditRecordDecodeError, StellarSorobanClient } from '../sorobanClient.js';
 
+const serviceLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('../../utils/serviceLogger.js', () => ({
+  createServiceLogger: () => serviceLoggerMock,
+}));
+
 const TEST_PUBLIC_KEY = `G${'A'.repeat(55)}`;
 const TEST_SECRET_KEY = `S${'C'.repeat(55)}`;
 const TEST_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 1));
@@ -63,6 +73,9 @@ describe('ReconciliationService', () => {
   let jobQueue: InMemoryJobQueue;
 
   beforeEach(() => {
+    serviceLoggerMock.info.mockReset();
+    serviceLoggerMock.warn.mockReset();
+    serviceLoggerMock.error.mockReset();
     mockRepo = new MockCreditLineRepository();
     mockClient = new MockSorobanClient();
     jobQueue = new InMemoryJobQueue(10, 20);
@@ -899,9 +912,9 @@ describe('ReconciliationService', () => {
 
       await service.reconcile();
 
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('Found 1 mismatches'),
-        expect.any(String)
+      expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+        'reconciliation:mismatches-found',
+        expect.objectContaining({ mismatchCount: 1 }),
       );
     });
 
@@ -911,8 +924,9 @@ describe('ReconciliationService', () => {
 
       await service.reconcile();
 
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('no mismatches found')
+      expect(serviceLoggerMock.info).toHaveBeenCalledWith(
+        'reconciliation:complete',
+        expect.objectContaining({ mismatchCount: 0 }),
       );
     });
   });

--- a/src/services/__tests__/reconciliationWorker.test.ts
+++ b/src/services/__tests__/reconciliationWorker.test.ts
@@ -6,6 +6,16 @@ import type { CreditLine } from '../../models/CreditLine.js';
 import { CreditLineStatus } from '../../models/CreditLine.js';
 import { InMemoryJobQueue } from '../jobQueue.js';
 
+const serviceLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('../../utils/serviceLogger.js', () => ({
+  createServiceLogger: () => serviceLoggerMock,
+}));
+
 class MockCreditLineRepository implements Partial<CreditLineRepository> {
   private creditLines: CreditLine[] = [];
 
@@ -39,6 +49,9 @@ describe('ReconciliationWorker', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    serviceLoggerMock.info.mockReset();
+    serviceLoggerMock.warn.mockReset();
+    serviceLoggerMock.error.mockReset();
     mockRepo = new MockCreditLineRepository();
     mockClient = new MockSorobanClient();
     jobQueue = new InMemoryJobQueue(10, 20);
@@ -104,9 +117,7 @@ describe('ReconciliationWorker', () => {
       worker.start({ runImmediately: false });
       
       expect(worker.isRunning()).toBe(true);
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Already running')
-      );
+      expect(serviceLoggerMock.warn).toHaveBeenCalledWith('reconciliation-worker:already-running');
     });
 
     it('starts the job queue', () => {
@@ -137,9 +148,7 @@ describe('ReconciliationWorker', () => {
       worker.stop();
       worker.stop();
       
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Not running')
-      );
+      expect(serviceLoggerMock.warn).toHaveBeenCalledWith('reconciliation-worker:not-running');
     });
   });
 
@@ -151,8 +160,9 @@ describe('ReconciliationWorker', () => {
       worker.start({ runImmediately: true });
       await jobQueue.drain();
 
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('completed successfully')
+      expect(serviceLoggerMock.info).toHaveBeenCalledWith(
+        'reconciliation-worker:job:complete',
+        expect.objectContaining({ totalChecked: 0 }),
       );
       expect(jobQueue.getFailedJobs()).toHaveLength(0);
     });
@@ -184,8 +194,13 @@ describe('ReconciliationWorker', () => {
       await vi.advanceTimersByTimeAsync(500);
       await jobQueue.drain();
 
-      expect(console.error).toHaveBeenCalledWith(
-        '[ReconciliationWorker] ALERT: Reconciliation found 1 mismatches (1 critical, 0 warnings)'
+      expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+        'reconciliation-worker:mismatches-alert',
+        expect.objectContaining({
+          mismatchCount: 1,
+          criticalCount: 1,
+          warningCount: 0,
+        }),
       );
       expect(jobQueue.getFailedJobs()).toHaveLength(1);
     });
@@ -218,8 +233,13 @@ describe('ReconciliationWorker', () => {
       worker.start({ runImmediately: true });
       await jobQueue.drain();
 
-      expect(console.error).toHaveBeenCalledWith(
-        '[ReconciliationWorker] ALERT: Reconciliation found 1 mismatches (0 critical, 1 warnings)'
+      expect(serviceLoggerMock.error).toHaveBeenCalledWith(
+        'reconciliation-worker:mismatches-alert',
+        expect.objectContaining({
+          mismatchCount: 1,
+          criticalCount: 0,
+          warningCount: 1,
+        }),
       );
       expect(jobQueue.getFailedJobs()).toHaveLength(0); // Should succeed
     });
@@ -261,8 +281,9 @@ describe('ReconciliationWorker', () => {
       worker.start({ runImmediately: true });
       await jobQueue.drain();
 
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('attempt 1')
+      expect(serviceLoggerMock.info).toHaveBeenCalledWith(
+        'reconciliation-worker:job:start',
+        expect.objectContaining({ attempt: 1 }),
       );
     });
   });

--- a/src/services/__tests__/sorobanClient.test.ts
+++ b/src/services/__tests__/sorobanClient.test.ts
@@ -1,5 +1,16 @@
 import { StrKey, TransactionBuilder, nativeToScVal, scValToNative } from '@stellar/stellar-sdk';
 import { describe, expect, it, vi } from 'vitest';
+
+const serviceLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('../../utils/serviceLogger.js', () => ({
+  createServiceLogger: () => serviceLoggerMock,
+}));
+
 import {
   createSorobanClient,
   MockSorobanClient,
@@ -96,18 +107,17 @@ describe('createSorobanClient', () => {
 
 describe('MockSorobanClient', () => {
   it('returns an empty record set for local and test environments', async () => {
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    serviceLoggerMock.info.mockReset();
 
-    try {
-      await expect(new MockSorobanClient({ ...TEST_CONFIG, contractId: '' }).fetchAllCreditRecords()).resolves.toEqual(
-        [],
-      );
-      expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('CREDIT_CONTRACT_ID is empty'), {
+    await expect(new MockSorobanClient({ ...TEST_CONFIG, contractId: '' }).fetchAllCreditRecords()).resolves.toEqual(
+      [],
+    );
+    expect(serviceLoggerMock.info).toHaveBeenCalledWith(
+      'soroban:mock-client:no-contract-id',
+      expect.objectContaining({
         rpcUrl: TEST_CONFIG.rpcUrl,
-      });
-    } finally {
-      consoleLog.mockRestore();
-    }
+      }),
+    );
   });
 });
 

--- a/src/services/dataRetentionWorker.ts
+++ b/src/services/dataRetentionWorker.ts
@@ -7,6 +7,9 @@
  */
 import type { JobQueue, Job } from './jobQueue.js';
 import type { DataRetentionService, DataRetentionConfig } from './dataRetentionService.js';
+import { createServiceLogger } from '../utils/serviceLogger.js';
+
+const log = createServiceLogger('DataRetentionWorker');
 
 export interface DataRetentionWorkerConfig {
   /** How often to run the retention sweep (in milliseconds). Default: 24 hours. */
@@ -28,24 +31,33 @@ export class DataRetentionWorker {
   ) {
     this.jobQueue.registerHandler('data-retention-sweep', async (job: Job) => {
       const config = job.payload as DataRetentionConfig;
-      console.log(`[DataRetentionWorker] Processing job ${job.id} (attempt ${job.attempts + 1})`);
+      log.info('data-retention:job:start', {
+        jobId: job.id,
+        attempt: job.attempts + 1,
+      });
 
       try {
         const result = await this.dataRetentionService.run(config);
 
         if (result.errors.length > 0) {
-          console.error('[DataRetentionWorker] Retention sweep completed with errors:', result.errors);
+          log.error('data-retention:job:errors', {
+            jobId: job.id,
+            errors: result.errors,
+          });
           throw new Error(`Data retention errors: ${result.errors.join(', ')}`);
         }
 
-        console.log(
-          `[DataRetentionWorker] Job ${job.id} completed. ` +
-          `Events deleted: ${result.eventsDeleted}, ` +
-          `risk evaluations deleted: ${result.riskEvaluationsDeleted}, ` +
-          `borrowers anonymized: ${result.borrowersAnonymized}.`,
-        );
+        log.info('data-retention:job:complete', {
+          jobId: job.id,
+          eventsDeleted: result.eventsDeleted,
+          riskEvaluationsDeleted: result.riskEvaluationsDeleted,
+          borrowersAnonymized: result.borrowersAnonymized,
+        });
       } catch (error) {
-        console.error(`[DataRetentionWorker] Job ${job.id} failed:`, error);
+        log.error('data-retention:job:failed', {
+          jobId: job.id,
+          error,
+        });
         throw error;
       }
     });
@@ -59,7 +71,7 @@ export class DataRetentionWorker {
   /** Start the worker with scheduled periodic sweeps. */
   start(config: DataRetentionWorkerConfig): void {
     if (this.running) {
-      console.warn('[DataRetentionWorker] Already running');
+      log.warn('data-retention-worker:already-running');
       return;
     }
 
@@ -71,27 +83,27 @@ export class DataRetentionWorker {
     this.jobQueue.start();
 
     if (runImmediately) {
-      console.log('[DataRetentionWorker] Scheduling immediate retention sweep');
+      log.info('data-retention:schedule:immediate');
       this.scheduleSweep(this.retentionConfig, 0);
     }
 
     this.intervalHandle = setInterval(() => {
-      console.log('[DataRetentionWorker] Scheduling periodic retention sweep');
+      log.info('data-retention:schedule:periodic');
       this.scheduleSweep(this.retentionConfig as DataRetentionConfig, 0);
     }, intervalMs);
 
-    console.log(
-      `[DataRetentionWorker] Started. Running every ${intervalMs}ms ` +
-      `(${Math.round(intervalMs / 3600000)} hours). ` +
-      `Operational retention: ${config.retentionConfig.operationalRetentionDays}d, ` +
-      `events retention: ${config.retentionConfig.eventsRetentionDays}d.`,
-    );
+    log.info('data-retention-worker:started', {
+      intervalMs,
+      intervalHours: Math.round(intervalMs / 3600000),
+      operationalRetentionDays: config.retentionConfig.operationalRetentionDays,
+      eventsRetentionDays: config.retentionConfig.eventsRetentionDays,
+    });
   }
 
   /** Stop the worker. */
   stop(): void {
     if (!this.running) {
-      console.warn('[DataRetentionWorker] Not running');
+      log.warn('data-retention-worker:not-running');
       return;
     }
 
@@ -101,7 +113,7 @@ export class DataRetentionWorker {
     }
 
     this.running = false;
-    console.log('[DataRetentionWorker] Stopped');
+    log.info('data-retention-worker:stopped');
   }
 
   isRunning(): boolean {

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -17,6 +17,9 @@
  */
 import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
+import { createServiceLogger } from "../utils/serviceLogger.js";
+
+const log = createServiceLogger("DrawWebhook");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -198,10 +201,11 @@ async function retryWithBackoff<T>(
             lastError = error as Error;
             
             if (attempt <= maxRetries) {
-                console.warn(
-                    `[DrawWebhook] Attempt ${attempt} failed, retrying in ${delay}ms:`,
-                    lastError.message
-                );
+                log.warn("webhook:delivery:retry", {
+                    attempt,
+                    retryInMs: delay,
+                    error: lastError,
+                });
                 await new Promise(resolve => setTimeout(resolve, delay));
                 delay = Math.floor(delay * backoffMultiplier);
             }
@@ -238,7 +242,7 @@ function parseDrawConfirmedEvent(event: HorizonEvent): WebhookPayload | null {
             }
         };
     } catch (error) {
-        console.error("[DrawWebhook] Failed to parse event data:", error);
+        log.error("webhook:event-parse:failed", { error });
         return null;
     }
 }
@@ -254,13 +258,13 @@ export function getWebhookConfig(): WebhookConfig | null {
 export function initializeWebhooks(): void {
     try {
         activeConfig = resolveWebhookConfig();
-        console.log("[DrawWebhook] Initialized with config:", {
+        log.info("webhook:initialized", {
             urls: activeConfig.urls.length,
             maxRetries: activeConfig.maxRetries,
             timeoutMs: activeConfig.timeoutMs
         });
     } catch (error) {
-        console.error("[DrawWebhook] Failed to initialize:", error);
+        log.error("webhook:initialize:failed", { error });
         activeConfig = null;
     }
 }
@@ -269,22 +273,26 @@ export async function sendDrawConfirmationWebhook(
     event: HorizonEvent
 ): Promise<WebhookDeliveryResult[]> {
     if (!activeConfig || activeConfig.urls.length === 0) {
-        console.log("[DrawWebhook] No webhook URLs configured, skipping");
+        log.info("webhook:delivery:disabled");
         return [];
     }
 
     const payload = parseDrawConfirmedEvent(event);
     if (!payload) {
-        console.log("[DrawWebhook] Event is not a draw confirmation, skipping");
+        log.info("webhook:delivery:skipped-non-draw-event", {
+            ledger: event.ledger,
+            contractId: event.contractId,
+        });
         return [];
     }
 
     const payloadString = JSON.stringify(payload);
     const signature = generateSignature(payloadString, activeConfig.secret);
 
-    console.log(
-        `[DrawWebhook] Processing draw confirmation for draw ID: ${payload.data.drawId}`
-    );
+    log.info("webhook:delivery:start", {
+        drawId: payload.data.drawId,
+        deliveryCount: activeConfig.urls.length,
+    });
 
     const deliveryPromises = activeConfig.urls.map(async (url) => {
         try {
@@ -317,9 +325,10 @@ export async function sendDrawConfirmationWebhook(
     const successCount = results.filter(r => r.success).length;
     const failureCount = results.length - successCount;
     
-    console.log(
-        `[DrawWebhook] Delivery complete: ${successCount} successful, ${failureCount} failed`
-    );
+    log.info("webhook:delivery:complete", {
+        successful: successCount,
+        failed: failureCount,
+    });
 
     return results;
 }

--- a/src/services/horizonListener.ts
+++ b/src/services/horizonListener.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { redactLogArgs } from "../utils/logRedact.js";
+import { createServiceLogger, type ServiceLogContext } from "../utils/serviceLogger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -108,16 +108,30 @@ const retryState = {
     nextRetryTime: 0,
 };
 
-function logInfo(...args: unknown[]): void {
-    console.log(...redactLogArgs(args));
+const log = createServiceLogger("HorizonListener");
+
+function toLogContext(value: unknown): ServiceLogContext | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (value !== null && typeof value === "object" && !(value instanceof Error) && !Array.isArray(value)) {
+        return value as ServiceLogContext;
+    }
+
+    return { value };
 }
 
-function logWarn(...args: unknown[]): void {
-    console.warn(...redactLogArgs(args));
+function logInfo(message: string, context?: unknown): void {
+    log.info(message, toLogContext(context));
 }
 
-function logError(...args: unknown[]): void {
-    console.error(...redactLogArgs(args));
+function logWarn(message: string, context?: unknown): void {
+    log.warn(message, toLogContext(context));
+}
+
+function logError(message: string, context?: unknown): void {
+    log.error(message, toLogContext(context));
 }
 
 // ---------------------------------------------------------------------------
@@ -295,7 +309,7 @@ function markEventProcessed(eventId: string): void {
 function logMetrics(config: HorizonListenerConfig): void {
     if (!config.enableMetrics) return;
     
-    logInfo("[HorizonListener] Metrics:", {
+    logInfo("horizon:metrics", {
         ...metrics,
         processedEventIdsCount: processedEventIds.size,
         currentLedgerCursor,
@@ -311,7 +325,7 @@ async function dispatchEvent(event: HorizonEvent): Promise<void> {
     if (isEventProcessed(eventId)) {
         metrics.eventsDuplicated++;
         if (activeConfig?.enableMetrics) {
-            logInfo("[HorizonListener] Skipping duplicate event:", eventId);
+            logInfo("horizon:event:duplicate", { eventId });
         }
         return;
     }
@@ -323,10 +337,7 @@ async function dispatchEvent(event: HorizonEvent): Promise<void> {
         try {
             await handler(event);
         } catch (err) {
-            logError(
-                "[HorizonListener] Event handler threw an error:",
-                err,
-            );
+            logError("horizon:event-handler:failed", err);
         }
     }
 }
@@ -442,7 +453,7 @@ async function handleCursorGap(config: HorizonListenerConfig, gapStart: string):
     const maxGap = config.maxCursorGap || 100;
     const startLedger = parseInt(gapStart);
     
-    logInfo(`[HorizonListener] Cursor gap detected at ledger ${gapStart}, attempting recovery`);
+    logInfo("horizon:cursor-gap:detected", { ledger: gapStart });
     
     // Try to fill the gap by querying individual ledgers
     for (let ledger = startLedger; ledger < startLedger + maxGap && ledger <= (currentLedgerCursor || startLedger) + maxGap; ledger++) {
@@ -451,13 +462,13 @@ async function handleCursorGap(config: HorizonListenerConfig, gapStart: string):
             await new Promise(resolve => setTimeout(resolve, 10)); // Simulate network delay
             
             if (Math.random() < 0.1) { // 10% chance of finding events in gap
-                logInfo(`[HorizonListener] Recovered events at ledger ${ledger}`);
+                logInfo("horizon:cursor-gap:recovered", { ledger });
                 metrics.cursorGapsRecovered++;
                 break;
             }
         } catch (error) {
             // If we can't recover from gap, skip ahead
-            logWarn(`[HorizonListener] Failed to recover ledger ${ledger}, skipping`);
+            logWarn("horizon:cursor-gap:recovery-failed", { ledger, error });
             break;
         }
     }
@@ -478,7 +489,9 @@ export async function pollOnce(config: HorizonListenerConfig): Promise<void> {
         // Check if we're in a backoff period
         if (retryState.nextRetryTime > Date.now()) {
             if (config.enableMetrics) {
-                logInfo(`[HorizonListener] In backoff period, next retry at ${new Date(retryState.nextRetryTime).toISOString()}`);
+                logInfo("horizon:backoff:waiting", {
+                    nextRetryAt: new Date(retryState.nextRetryTime).toISOString(),
+                });
             }
             return;
         }
@@ -492,11 +505,12 @@ export async function pollOnce(config: HorizonListenerConfig): Promise<void> {
         
         const cursor = currentLedgerCursor ? `${currentLedgerCursor}` : config.startLedger;
         
-        logInfo(
-            `[HorizonListener] Polling ${config.horizonUrl} ` +
-            `(contracts: ${config.contractIds.length > 0 ? config.contractIds.join(", ") : "none"}, ` +
-            `cursor: ${cursor})`,
-        );
+        logInfo("horizon:poll:start", {
+            horizonUrl: config.horizonUrl,
+            contractIds: config.contractIds,
+            contractCount: config.contractIds.length,
+            cursor,
+        });
         
         const { events } = await fetchHorizonEvents(config, cursor);
         
@@ -517,7 +531,7 @@ export async function pollOnce(config: HorizonListenerConfig): Promise<void> {
             const rateLimitDelay = config.rateLimitDelayMs || 60000;
             retryState.nextRetryTime = Date.now() + rateLimitDelay;
             
-            logWarn(`[HorizonListener] Rate limit hit, waiting ${rateLimitDelay}ms`);
+            logWarn("horizon:rate-limit", { rateLimitDelayMs: rateLimitDelay });
             return;
         }
         
@@ -537,17 +551,22 @@ export async function pollOnce(config: HorizonListenerConfig): Promise<void> {
                 
                 metrics.retryAttempts++;
                 
-                logWarn(`[HorizonListener] Transient error (attempt ${retryState.attempts}/${maxRetries}), retrying in ${delay}ms:`, classifiedError.message);
+                logWarn("horizon:transient-error", {
+                    attempt: retryState.attempts,
+                    maxRetries,
+                    retryInMs: delay,
+                    error: classifiedError,
+                });
                 return;
             } else {
-                logError(`[HorizonListener] Max retries exceeded for transient error:`, classifiedError);
+                logError("horizon:transient-error:max-retries-exceeded", classifiedError);
                 retryState.attempts = 0; // Reset for next time
                 return;
             }
         }
         
         // Non-transient error - log and continue
-        logError("[HorizonListener] Non-transient error occurred:", classifiedError);
+        logError("horizon:non-transient-error", classifiedError);
     }
 }
 

--- a/src/services/jobQueue.ts
+++ b/src/services/jobQueue.ts
@@ -12,6 +12,9 @@
  * public interface is kept narrow so a Redis or SQS backend can be swapped in
  * without changing call sites.
  */
+import { createServiceLogger } from '../utils/serviceLogger.js';
+
+const log = createServiceLogger('JobQueue');
 
 export interface Job<Data = unknown> {
   /** Stable job identifier (unique within a queue instance). */
@@ -244,9 +247,10 @@ export class InMemoryJobQueue implements JobQueue {
 
         if (!handler) {
           // No handler registered — dead-letter immediately and alert operator.
-          console.error(
-            `[JobQueue] No handler for type "${job.type}". Job ${job.id} moved to dead-letter.`,
-          );
+          log.error('job-queue:dead-letter:no-handler', {
+            jobId: job.id,
+            jobType: job.type,
+          });
           this.failed.push(job);
           continue;
         }
@@ -267,10 +271,12 @@ export class InMemoryJobQueue implements JobQueue {
           } else {
             // Exceeded maxAttempts — move to dead-letter set.
             this.failed.push(job);
-            console.error(
-              `[JobQueue] Job ${job.id} (type "${job.type}") exhausted ${job.attempts} attempts. ` +
-              `Last error: ${job.lastError}`,
-            );
+            log.error('job-queue:dead-letter:max-attempts-exhausted', {
+              jobId: job.id,
+              jobType: job.type,
+              attempts: job.attempts,
+              lastError: job.lastError,
+            });
           }
         }
       }

--- a/src/services/reconciliationService.ts
+++ b/src/services/reconciliationService.ts
@@ -9,9 +9,11 @@ import type { CreditLineRepository } from '../repositories/interfaces/CreditLine
 import type { CreditLine } from '../models/CreditLine.js';
 import type { JobQueue } from './jobQueue.js';
 import { sanitizeJsonForStellarDiagnostics, sanitizeStellarDiagnostic } from './stellarDiagnostics.js';
+import { createServiceLogger } from '../utils/serviceLogger.js';
 
 const RECONCILIATION_DB_PAGE_SIZE = 1_000;
 const RECONCILIATION_MAX_DB_RECORDS = 10_000;
+const log = createServiceLogger('ReconciliationService');
 
 export interface OnChainCreditRecord {
   /** Contract-level credit line identifier */
@@ -102,10 +104,9 @@ export class ReconciliationService {
       }
 
       if (result.errors.length > 0) {
-        console.error(
-          '[ReconciliationService] Reconciliation failed:',
-          sanitizeJsonForStellarDiagnostics(result.errors)
-        );
+        log.error('reconciliation:failed', {
+          errors: sanitizeJsonForStellarDiagnostics(result.errors),
+        });
         return result;
       }
 
@@ -150,20 +151,21 @@ export class ReconciliationService {
 
       // Log results
       if (result.mismatches.length > 0) {
-        console.error(
-          `[ReconciliationService] Found ${result.mismatches.length} mismatches:`,
-          sanitizeJsonForStellarDiagnostics(result.mismatches)
-        );
+        log.error('reconciliation:mismatches-found', {
+          mismatchCount: result.mismatches.length,
+          mismatches: sanitizeJsonForStellarDiagnostics(result.mismatches),
+        });
       } else {
-        console.log(
-          `[ReconciliationService] Reconciliation complete. ${result.totalChecked} records checked, no mismatches found.`
-        );
+        log.info('reconciliation:complete', {
+          totalChecked: result.totalChecked,
+          mismatchCount: 0,
+        });
       }
 
     } catch (error) {
       const errorMessage = sanitizeStellarDiagnostic(error);
       result.errors.push(errorMessage);
-      console.error('[ReconciliationService] Reconciliation failed:', errorMessage);
+      log.error('reconciliation:failed', { error: errorMessage });
     }
 
     return result;

--- a/src/services/reconciliationWorker.ts
+++ b/src/services/reconciliationWorker.ts
@@ -8,6 +8,9 @@
 import type { JobQueue, Job } from './jobQueue.js';
 import type { ReconciliationService } from './reconciliationService.js';
 import { sanitizeJsonForStellarDiagnostics, sanitizeStellarDiagnostic } from './stellarDiagnostics.js';
+import { createServiceLogger } from '../utils/serviceLogger.js';
+
+const log = createServiceLogger('ReconciliationWorker');
 
 export interface ReconciliationWorkerConfig {
   /** How often to run reconciliation (in milliseconds). Default: 1 hour */
@@ -26,7 +29,10 @@ export class ReconciliationWorker {
   ) {
     // Register the job handler
     this.jobQueue.registerHandler('credit-reconciliation', async (job: Job) => {
-      console.log(`[ReconciliationWorker] Processing job ${job.id} (attempt ${job.attempts + 1})`);
+      log.info('reconciliation-worker:job:start', {
+        jobId: job.id,
+        attempt: job.attempts + 1,
+      });
       
       try {
         const result = await this.reconciliationService.reconcile();
@@ -36,10 +42,11 @@ export class ReconciliationWorker {
           const criticalCount = result.mismatches.filter(m => m.severity === 'critical').length;
           const warningCount = result.mismatches.filter(m => m.severity === 'warning').length;
           
-          console.error(
-            `[ReconciliationWorker] ALERT: Reconciliation found ${result.mismatches.length} mismatches ` +
-            `(${criticalCount} critical, ${warningCount} warnings)`
-          );
+          log.error('reconciliation-worker:mismatches-alert', {
+            mismatchCount: result.mismatches.length,
+            criticalCount,
+            warningCount,
+          });
           
           // In production, send alerts via email, Slack, PagerDuty, etc.
           // For now, log to console and dead-letter queue via job failure
@@ -52,19 +59,21 @@ export class ReconciliationWorker {
         
         if (result.errors.length > 0) {
           const sanitizedErrors = result.errors.map(sanitizeStellarDiagnostic);
-          console.error(
-            `[ReconciliationWorker] Reconciliation completed with errors:`,
-            sanitizeJsonForStellarDiagnostics(sanitizedErrors)
-          );
+          log.error('reconciliation-worker:errors', {
+            errors: sanitizeJsonForStellarDiagnostics(sanitizedErrors),
+          });
           throw new Error(`Reconciliation errors: ${sanitizedErrors.join(', ')}`);
         }
         
-        console.log(
-          `[ReconciliationWorker] Job ${job.id} completed successfully. ` +
-          `Checked ${result.totalChecked} records.`
-        );
+        log.info('reconciliation-worker:job:complete', {
+          jobId: job.id,
+          totalChecked: result.totalChecked,
+        });
       } catch (error) {
-        console.error(`[ReconciliationWorker] Job ${job.id} failed:`, sanitizeStellarDiagnostic(error));
+        log.error('reconciliation-worker:job:failed', {
+          jobId: job.id,
+          error: sanitizeStellarDiagnostic(error),
+        });
         throw error; // Re-throw to trigger job retry logic
       }
     });
@@ -75,7 +84,7 @@ export class ReconciliationWorker {
    */
   start(config: ReconciliationWorkerConfig = {}): void {
     if (this.running) {
-      console.warn('[ReconciliationWorker] Already running');
+      log.warn('reconciliation-worker:already-running');
       return;
     }
 
@@ -86,19 +95,19 @@ export class ReconciliationWorker {
     this.jobQueue.start();
 
     if (runImmediately) {
-      console.log('[ReconciliationWorker] Scheduling immediate reconciliation');
+      log.info('reconciliation-worker:schedule:immediate');
       this.reconciliationService.scheduleReconciliation(0);
     }
 
     this.intervalHandle = setInterval(() => {
-      console.log('[ReconciliationWorker] Scheduling periodic reconciliation');
+      log.info('reconciliation-worker:schedule:periodic');
       this.reconciliationService.scheduleReconciliation(0);
     }, intervalMs);
 
-    console.log(
-      `[ReconciliationWorker] Started. Running every ${intervalMs}ms ` +
-      `(${Math.round(intervalMs / 60000)} minutes)`
-    );
+    log.info('reconciliation-worker:started', {
+      intervalMs,
+      intervalMinutes: Math.round(intervalMs / 60000),
+    });
   }
 
   /**
@@ -106,7 +115,7 @@ export class ReconciliationWorker {
    */
   stop(): void {
     if (!this.running) {
-      console.warn('[ReconciliationWorker] Not running');
+      log.warn('reconciliation-worker:not-running');
       return;
     }
 
@@ -116,7 +125,7 @@ export class ReconciliationWorker {
     }
 
     this.running = false;
-    console.log('[ReconciliationWorker] Stopped');
+    log.info('reconciliation-worker:stopped');
   }
 
   isRunning(): boolean {

--- a/src/services/sorobanClient.ts
+++ b/src/services/sorobanClient.ts
@@ -11,6 +11,7 @@ import {
 import type { OnChainCreditRecord, SorobanRpcClient } from './reconciliationService.js';
 import { resolveSorobanRpcConfig, type SorobanRpcConfig } from './sorobanRpcClient.js';
 import { sanitizeStellarDiagnostic } from './stellarDiagnostics.js';
+import { createServiceLogger } from '../utils/serviceLogger.js';
 
 const DEFAULT_RPC_URL = 'https://soroban-testnet.stellar.org';
 const DEFAULT_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
@@ -21,6 +22,7 @@ const MAX_ENUMERATED_CREDIT_RECORDS = 10_000;
 const BASE_RETRY_DELAY_MS = 1_000;
 const MAX_RETRY_POWER = 10;
 const DECIMAL_STRING_REGEX = /^-?\d+(?:\.\d+)?$/;
+const log = createServiceLogger('SorobanClient');
 // Must match the Credit contract enum discriminants for CreditLineStatus.
 const CREDIT_STATUS_BY_CONTRACT_DISCRIMINANT: Record<number, string> = {
   0: 'active',
@@ -74,7 +76,7 @@ export class MockSorobanClient implements SorobanRpcClient {
   constructor(private readonly config: SorobanClientConfig) {}
 
   async fetchAllCreditRecords(): Promise<OnChainCreditRecord[]> {
-    console.log('[MockSorobanClient] CREDIT_CONTRACT_ID is empty; returning no on-chain credit records.', {
+    log.info('soroban:mock-client:no-contract-id', {
       rpcUrl: sanitizeStellarDiagnostic(this.config.rpcUrl),
     });
 

--- a/src/utils/serviceLogger.ts
+++ b/src/utils/serviceLogger.ts
@@ -1,0 +1,52 @@
+import { logger } from './logger.js';
+import { redactLogValue } from './logRedact.js';
+
+export type ServiceLogContext = Record<string, unknown>;
+
+export interface ServiceLogger {
+  info(message: string, context?: ServiceLogContext): void;
+  warn(message: string, context?: ServiceLogContext): void;
+  error(message: string, context?: ServiceLogContext): void;
+}
+
+function redactContext(context: ServiceLogContext | undefined): ServiceLogContext | undefined {
+  return context === undefined
+    ? undefined
+    : redactLogValue(context, false);
+}
+
+export function createServiceLogger(service: string): ServiceLogger {
+  const child = logger.child({ service });
+
+  return {
+    info(message, context) {
+      const redacted = redactContext(context);
+      if (redacted === undefined) {
+        child.info(message);
+        return;
+      }
+
+      child.info(redacted, message);
+    },
+
+    warn(message, context) {
+      const redacted = redactContext(context);
+      if (redacted === undefined) {
+        child.warn(message);
+        return;
+      }
+
+      child.warn(redacted, message);
+    },
+
+    error(message, context) {
+      const redacted = redactContext(context);
+      if (redacted === undefined) {
+        child.error(message);
+        return;
+      }
+
+      child.error(redacted, message);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a shared `serviceLogger` wrapper around the existing Pino logger for service-layer logs.
- Replaces bare `console.*` calls in `src/services` with structured event-style logs while preserving existing redaction behavior for nested context and errors.
- Updates observability docs and service tests to assert structured logger output.
- Fixes two small existing CI blockers surfaced while validating this change: Container strict property initialization and flaky/brittle tests for migrations and in-memory `updatedAt` ordering.

Closes #232

## Validation
- `npm test` - 70 files / 936 tests passed
- `npm run typecheck` - passed
- `npm run lint -- src/container/Container.ts src/db/migrations.test.ts src/repositories/memory/InMemoryCreditLineRepository.ts src/services/dataRetentionWorker.ts src/services/drawWebhookService.ts src/services/horizonListener.ts src/services/jobQueue.ts src/services/reconciliationService.ts src/services/reconciliationWorker.ts src/services/sorobanClient.ts src/utils/serviceLogger.ts` - passed with existing warnings only
- `git diff --check` - passed
- `rg "console\\.(log|warn|error|info|debug)" src/services --glob '!**/__tests__/**' --glob '!**/__test__/**' --glob '!node_modules/**'` - no matches