### PR TITLE
feat(api): consistent money formatting for API responses

### DIFF
--- a/docs/MONEY_FORMATTING.md
+++ b/docs/MONEY_FORMATTING.md
@@ -1,0 +1,43 @@
+# Money formatting rules for API responses
+
+To remove client-side ambiguity around precision, rounding, and currency, all
+money-like fields in API responses use a single canonical shape produced by
+`formatMoney` (`src/utils/money.ts`).
+
+## Response shape
+
+```jsonc
+{
+  "minorUnits": "123456", // integer, smallest currency unit, as a string (lossless)
+  "amount": "1234.56",    // human-readable decimal string derived from minorUnits
+  "currency": "USD",      // ISO-4217-style code, upper-cased
+  "decimals": 2            // fractional digits used to derive `amount`
+}
+```
+
+## Rules
+
+- **`minorUnits` is the source of truth.** It is always an integer string in the
+  currency's smallest unit (cents for USD, stroops for XLM, etc.). Clients should
+  do arithmetic on `minorUnits`, never on `amount`.
+- **No floating point.** Inputs that are non-integer numbers or malformed strings
+  are rejected, because IEEE-754 floats cannot represent money losslessly.
+- **No rounding on output.** `amount` is an exact decimal rendering of
+  `minorUnits` at the given `decimals`; nothing is rounded away.
+- **Currency precision is explicit.** Zero-decimal (JPY) and high-precision
+  (XLM, 7) currencies are supported via the `decimals` argument.
+
+## Usage
+
+```ts
+import { formatMoney } from '../utils/money.js';
+
+res.json({ creditLimit: formatMoney(creditLimit, 'USD', 2) });
+```
+
+## Migration note
+
+Existing endpoints that returned money as a bare number/string should adopt this
+object shape. This is a breaking change for those fields: clients must read
+`minorUnits`/`amount` instead of the scalar. Roll out behind an API version bump
+where backwards compatibility is required.

--- a/src/utils/__tests__/money.test.ts
+++ b/src/utils/__tests__/money.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { formatMoney } from '../money.js';
+
+describe('money utils', () => {
+    describe('formatMoney', () => {
+        it('formats whole minor units into a 2-decimal amount', () => {
+            expect(formatMoney(123456)).toEqual({
+                minorUnits: '123456',
+                amount: '1234.56',
+                currency: 'USD',
+                decimals: 2,
+            });
+        });
+
+        it('pads fractional digits when the value is small', () => {
+            expect(formatMoney(5).amount).toBe('0.05');
+            expect(formatMoney(0).amount).toBe('0.00');
+        });
+
+        it('handles negative amounts', () => {
+            expect(formatMoney(-99).amount).toBe('-0.99');
+            expect(formatMoney(-123456).amount).toBe('-1234.56');
+        });
+
+        it('upper-cases the currency code', () => {
+            expect(formatMoney(100, 'usd').currency).toBe('USD');
+        });
+
+        it('supports zero-decimal and high-precision currencies', () => {
+            expect(formatMoney(1500, 'JPY', 0).amount).toBe('1500');
+            expect(formatMoney('10000000', 'XLM', 7).amount).toBe('1.0000000');
+        });
+
+        it('accepts string and bigint minor units losslessly', () => {
+            expect(formatMoney('900719925474099100').minorUnits).toBe('900719925474099100');
+            expect(formatMoney(900719925474099100n).amount).toBe('9007199254740991.00');
+        });
+
+        it('rejects non-integer numbers and malformed strings', () => {
+            expect(() => formatMoney(12.34)).toThrow(TypeError);
+            expect(() => formatMoney('12.34')).toThrow(TypeError);
+            expect(() => formatMoney('abc')).toThrow(TypeError);
+        });
+
+        it('rejects out-of-range decimals', () => {
+            expect(() => formatMoney(100, 'USD', -1)).toThrow(RangeError);
+            expect(() => formatMoney(100, 'USD', 19)).toThrow(RangeError);
+        });
+    });
+});

--- a/src/utils/money.ts
+++ b/src/utils/money.ts
@@ -1,0 +1,75 @@
+/**
+ * Money formatting helpers.
+ *
+ * Money-like values are represented in API responses as a structured object
+ * rather than a bare number to remove client-side ambiguity around precision
+ * and currency. The canonical, lossless source of truth is `minorUnits` (an
+ * integer string in the currency's smallest unit, e.g. cents/stroops). A
+ * human-readable `amount` decimal string is provided for convenience.
+ *
+ * Kept small, dependency-free, and pure so it can be imported from any layer.
+ */
+
+export interface MoneyResponse {
+    /** Lossless integer amount in the currency's minor units, as a string. */
+    minorUnits: string;
+    /** Human-readable decimal string, e.g. "1234.56". */
+    amount: string;
+    /** ISO-4217-style currency code, upper-cased. */
+    currency: string;
+    /** Number of fractional digits used to derive `amount` from `minorUnits`. */
+    decimals: number;
+}
+
+const MAX_DECIMALS = 18;
+
+/**
+ * Formats an integer minor-units value into the canonical money response.
+ *
+ * @param minorUnits integer value in minor units (number, bigint or digit string)
+ * @param currency   currency code (defaults to "USD")
+ * @param decimals   fractional digits for the currency (defaults to 2)
+ */
+export const formatMoney = (
+    minorUnits: number | bigint | string,
+    currency = 'USD',
+    decimals = 2,
+): MoneyResponse => {
+    if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_DECIMALS) {
+        throw new RangeError(`decimals must be an integer in [0, ${MAX_DECIMALS}]`);
+    }
+
+    const big = toBigInt(minorUnits);
+    const negative = big < 0n;
+    const digits = (negative ? -big : big).toString().padStart(decimals + 1, '0');
+
+    const whole = digits.slice(0, digits.length - decimals);
+    const fraction = decimals > 0 ? digits.slice(digits.length - decimals) : '';
+    const amount = `${negative ? '-' : ''}${whole}${fraction ? `.${fraction}` : ''}`;
+
+    return {
+        minorUnits: big.toString(),
+        amount,
+        currency: currency.toUpperCase(),
+        decimals,
+    };
+};
+
+/**
+ * Parses a value into a bigint of minor units, rejecting anything that is not a
+ * base-10 integer. Floats are rejected because they cannot represent money
+ * losslessly.
+ */
+const toBigInt = (value: number | bigint | string): bigint => {
+    if (typeof value === 'bigint') return value;
+    if (typeof value === 'number') {
+        if (!Number.isInteger(value)) {
+            throw new TypeError('minorUnits number must be an integer');
+        }
+        return BigInt(value);
+    }
+    if (typeof value === 'string' && /^-?\d+$/.test(value)) {
+        return BigInt(value);
+    }
+    throw new TypeError(`invalid minorUnits value: ${String(value)}`);
+};


### PR DESCRIPTION
Closes #222.

Adds a shared, dependency-free `formatMoney` helper (`src/utils/money.ts`) that renders money-like values as a canonical `{ minorUnits, amount, currency, decimals }` object, with `minorUnits` (integer string) as the lossless source of truth. Non-integer/float inputs are rejected so money is never represented in floating point.

- `src/utils/money.ts` — formatter supporting zero-decimal (JPY) and high-precision (XLM/7) currencies.
- `src/utils/__tests__/money.test.ts` — 8 vitest cases covering padding, negatives, bigint/string, and validation errors (verified passing).
- `docs/MONEY_FORMATTING.md` — formatting rules and a migration note for adopting the object shape.