### PR TITLE
Backend: Implement event-driven internal bus for credit lifecycle changes (in-process)

### DIFF
--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -31,6 +31,8 @@ import { ReconciliationService, type SorobanRpcClient } from "../services/reconc
 import { ReconciliationWorker } from "../services/reconciliationWorker.js";
 import { createSorobanClient, resolveSorobanConfig } from "../services/sorobanClient.js";
 import { defaultJobQueue } from "../services/jobQueue.js";
+import { defaultEventBus } from "../services/events/eventBus.js";
+import { registerAuditSubscriber } from "../services/events/auditSubscriber.js";
 import { DataRetentionService } from "../services/dataRetentionService.js";
 import { DataRetentionWorker } from "../services/dataRetentionWorker.js";
 
@@ -53,9 +55,15 @@ export class Container {
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
 
+  // In-process domain event bus (credit lifecycle).
+  private readonly _eventBus = defaultEventBus;
+
   private constructor() {
     // Initialize repositories based on environment
     this.initializeRepositories();
+
+    // Wire the in-process domain event bus and its default subscribers once.
+    registerAuditSubscriber(this._eventBus);
 
     // Initialize services
     this._sorobanClient = createSorobanClient(resolveSorobanConfig());
@@ -63,7 +71,7 @@ export class Container {
   }
 
   private rebuildServices(): void {
-    this._creditLineService = new CreditLineService(this._creditLineRepository);
+    this._creditLineService = new CreditLineService(this._creditLineRepository, this._eventBus);
     this._riskEvaluationService = new RiskEvaluationService(
       this._riskEvaluationRepository,
       createRiskProvider(),
@@ -142,6 +150,11 @@ export class Container {
 
   get reconciliationWorker(): ReconciliationWorker {
     return this._reconciliationWorker;
+  }
+
+  /** Process-wide in-process domain event bus for credit lifecycle events. */
+  get eventBus() {
+    return this._eventBus;
   }
 
   /** Undefined when running against in-memory repositories (no Postgres connection). */

--- a/src/services/CreditLineService.ts
+++ b/src/services/CreditLineService.ts
@@ -1,5 +1,7 @@
 import { type CreditLine, type CreateCreditLineRequest, type UpdateCreditLineRequest, CreditLineStatus } from '../models/CreditLine.js';
 import type { CreditLineRepository, CursorPaginationResult } from '../repositories/interfaces/CreditLineRepository.js';
+import type { EventBus } from './events/eventBus.js';
+import { nowIso } from './events/domainEvents.js';
 
 /**
  * Domain service for credit-line CRUD plus the `draw` / `repay` operations.
@@ -21,7 +23,23 @@ import type { CreditLineRepository, CursorPaginationResult } from '../repositori
  * the surfaces that call into this service.
  */
 export class CreditLineService {
-  constructor(private creditLineRepository: CreditLineRepository) {}
+  /**
+   * @param creditLineRepository persistence for credit lines
+   * @param eventBus optional in-process bus; when supplied, lifecycle changes
+   *   (open / draw / repay) publish domain events for decoupled subscribers
+   *   (audit, webhooks, notifications). Emission is fire-and-forget and never
+   *   blocks or fails the core operation.
+   */
+  constructor(
+    private creditLineRepository: CreditLineRepository,
+    private readonly eventBus?: EventBus,
+  ) {}
+
+  /** Publish a domain event without letting subscriber failures affect callers. */
+  private emit(event: Parameters<EventBus['publish']>[0]): void {
+    if (!this.eventBus) return;
+    void this.eventBus.publish(event);
+  }
 
   /**
    * Create a new credit line for `walletAddress` with an explicit credit limit
@@ -44,7 +62,16 @@ export class CreditLineService {
       throw new Error('Interest rate must be between 0 and 10000 basis points');
     }
 
-    return await this.creditLineRepository.create(request);
+    const created = await this.creditLineRepository.create(request);
+
+    this.emit({
+      type: 'credit.opened',
+      occurredAt: nowIso(),
+      creditLineId: created.id,
+      payload: { walletAddress: created.walletAddress, creditLimit: created.creditLimit },
+    });
+
+    return created;
   }
 
   /** Fetch a single credit line by id, or `null` if not found. */
@@ -158,9 +185,25 @@ export class CreditLineService {
       throw new Error('Credit limit exceeded');
     }
 
-    return await this.creditLineRepository.update(id, {
+    this.emit({
+      type: 'credit.draw_requested',
+      occurredAt: nowIso(),
+      creditLineId: id,
+      payload: { walletAddress: line.walletAddress, amount },
+    });
+
+    const updated = await this.creditLineRepository.update(id, {
       utilized: (utilizedNum + amountNum).toString(),
     }) as CreditLine;
+
+    this.emit({
+      type: 'credit.draw_confirmed',
+      occurredAt: nowIso(),
+      creditLineId: id,
+      payload: { walletAddress: line.walletAddress, amount, utilized: updated.utilized },
+    });
+
+    return updated;
   }
 
   /**
@@ -181,8 +224,17 @@ export class CreditLineService {
     const amountNum = parseFloat(amount);
     const utilizedNum = parseFloat(line.utilized || '0');
 
-    return await this.creditLineRepository.update(id, {
+    const updated = await this.creditLineRepository.update(id, {
       utilized: Math.max(0, utilizedNum - amountNum).toString(),
     }) as CreditLine;
+
+    this.emit({
+      type: 'credit.repay_confirmed',
+      occurredAt: nowIso(),
+      creditLineId: id,
+      payload: { walletAddress: line.walletAddress, amount, utilized: updated.utilized },
+    });
+
+    return updated;
   }
 }

--- a/src/services/events/__tests__/eventBus.test.ts
+++ b/src/services/events/__tests__/eventBus.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '../eventBus.js';
+import { registerAuditSubscriber, type AuditRecord } from '../auditSubscriber.js';
+import { nowIso, type CreditDomainEvent } from '../domainEvents.js';
+import { CreditLineService } from '../../CreditLineService.js';
+import { InMemoryCreditLineRepository } from '../../../repositories/memory/InMemoryCreditLineRepository.js';
+
+function openedEvent(creditLineId = 'cl-1'): CreditDomainEvent {
+  return {
+    type: 'credit.opened',
+    occurredAt: nowIso(),
+    creditLineId,
+    payload: { walletAddress: 'GWALLET', creditLimit: '1000.00' },
+  };
+}
+
+describe('EventBus', () => {
+  it('invokes every subscriber for an event type', async () => {
+    const bus = new EventBus();
+    const a = vi.fn();
+    const b = vi.fn();
+    bus.subscribe('credit.opened', a);
+    bus.subscribe('credit.opened', b);
+
+    await bus.publish(openedEvent());
+
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).toHaveBeenCalledOnce();
+  });
+
+  it('does not invoke handlers for other event types', async () => {
+    const bus = new EventBus();
+    const handler = vi.fn();
+    bus.subscribe('credit.repay_confirmed', handler);
+
+    await bus.publish(openedEvent());
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('isolates a failing handler so peers still run (at-least-once)', async () => {
+    const errors: unknown[] = [];
+    const bus = new EventBus((err) => errors.push(err));
+    const failing = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const surviving = vi.fn();
+    bus.subscribe('credit.opened', failing);
+    bus.subscribe('credit.opened', surviving);
+
+    await bus.publish(openedEvent());
+
+    expect(surviving).toHaveBeenCalledOnce();
+    expect(errors).toHaveLength(1);
+  });
+
+  it('unsubscribe removes the handler', async () => {
+    const bus = new EventBus();
+    const handler = vi.fn();
+    const off = bus.subscribe('credit.opened', handler);
+    off();
+
+    await bus.publish(openedEvent());
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(bus.handlerCount('credit.opened')).toBe(0);
+  });
+});
+
+describe('audit subscriber', () => {
+  it('records an audit entry for every lifecycle event', async () => {
+    const bus = new EventBus();
+    const records: AuditRecord[] = [];
+    registerAuditSubscriber(bus, (r) => {
+      records.push(r);
+    });
+
+    await bus.publish(openedEvent('cl-9'));
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ action: 'credit.opened', creditLineId: 'cl-9' });
+    expect(records[0].details).toMatchObject({ walletAddress: 'GWALLET' });
+  });
+});
+
+describe('CreditLineService event emission', () => {
+  it('emits opened, draw_requested, draw_confirmed and repay_confirmed', async () => {
+    const bus = new EventBus();
+    const seen: CreditDomainEvent['type'][] = [];
+    (['credit.opened', 'credit.draw_requested', 'credit.draw_confirmed', 'credit.repay_confirmed'] as const).forEach(
+      (t) => bus.subscribe(t, (e) => void seen.push(e.type)),
+    );
+
+    const service = new CreditLineService(new InMemoryCreditLineRepository(), bus);
+    const line = await service.createCreditLine({
+      walletAddress: 'GWALLET',
+      creditLimit: '1000.00',
+      interestRateBps: 500,
+    });
+    await service.draw(line.id, 'GWALLET', '100.00');
+    await service.repay(line.id, 'GWALLET', '50.00');
+
+    // Allow fire-and-forget publishes to settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(seen).toEqual(
+      expect.arrayContaining([
+        'credit.opened',
+        'credit.draw_requested',
+        'credit.draw_confirmed',
+        'credit.repay_confirmed',
+      ]),
+    );
+  });
+
+  it('works without an event bus (backward compatible)', async () => {
+    const service = new CreditLineService(new InMemoryCreditLineRepository());
+    const line = await service.createCreditLine({
+      walletAddress: 'GWALLET',
+      creditLimit: '1000.00',
+      interestRateBps: 500,
+    });
+    expect(line.id).toBeDefined();
+  });
+});

--- a/src/services/events/auditSubscriber.ts
+++ b/src/services/events/auditSubscriber.ts
@@ -1,0 +1,55 @@
+/**
+ * Audit-log subscriber for credit lifecycle events.
+ *
+ * Registers a handler on the {@link EventBus} that appends a structured,
+ * append-only audit record for every credit lifecycle event. The default sink
+ * writes to stdout via the shared logger contract; production deployments can
+ * supply a sink that persists to the audit table instead.
+ */
+import type { EventBus } from './eventBus.js';
+import type { CreditDomainEvent, CreditEventType } from './domainEvents.js';
+
+const LIFECYCLE_EVENTS: readonly CreditEventType[] = [
+  'credit.opened',
+  'credit.draw_requested',
+  'credit.draw_confirmed',
+  'credit.repay_confirmed',
+  'credit.defaulted',
+];
+
+/** A single immutable audit record derived from a domain event. */
+export interface AuditRecord {
+  readonly action: CreditEventType;
+  readonly creditLineId: string;
+  readonly occurredAt: string;
+  readonly details: Record<string, unknown>;
+}
+
+/** Where audit records are written. Defaults to stdout. */
+export type AuditSink = (record: AuditRecord) => void | Promise<void>;
+
+function defaultAuditSink(record: AuditRecord): void {
+  console.log('[audit]', JSON.stringify(record));
+}
+
+function toAuditRecord(event: CreditDomainEvent): AuditRecord {
+  return {
+    action: event.type,
+    creditLineId: event.creditLineId,
+    occurredAt: event.occurredAt,
+    details: { ...event.payload },
+  };
+}
+
+/**
+ * Subscribe an audit handler to every lifecycle event on `bus`.
+ * Returns a disposer that removes all subscriptions.
+ */
+export function registerAuditSubscriber(bus: EventBus, sink: AuditSink = defaultAuditSink): () => void {
+  const disposers = LIFECYCLE_EVENTS.map((type) =>
+    bus.subscribe(type, async (event) => {
+      await sink(toAuditRecord(event));
+    }),
+  );
+  return () => disposers.forEach((dispose) => dispose());
+}

--- a/src/services/events/domainEvents.ts
+++ b/src/services/events/domainEvents.ts
@@ -1,0 +1,68 @@
+/**
+ * Domain event definitions for the credit lifecycle.
+ *
+ * These are the canonical, in-process events emitted by the service layer when
+ * credit-line state changes. Downstream concerns (audit log, webhook dispatch,
+ * notifications) subscribe to them via the {@link EventBus} so they stay
+ * decoupled from the core request path.
+ *
+ * See `docs/ARCHITECTURE.md` §3 (eventing) for delivery semantics.
+ */
+
+/** Discriminator for every credit-lifecycle event. */
+export type CreditEventType =
+  | 'credit.opened'
+  | 'credit.draw_requested'
+  | 'credit.draw_confirmed'
+  | 'credit.repay_confirmed'
+  | 'credit.defaulted';
+
+/** Fields common to every domain event. */
+export interface DomainEventEnvelope<T extends CreditEventType, P> {
+  /** Stable event-type discriminator. */
+  readonly type: T;
+  /** ISO-8601 timestamp at which the event was emitted. */
+  readonly occurredAt: string;
+  /** Credit line the event pertains to. */
+  readonly creditLineId: string;
+  /** Event-specific payload. */
+  readonly payload: P;
+}
+
+export type CreditOpenedEvent = DomainEventEnvelope<
+  'credit.opened',
+  { walletAddress: string; creditLimit: string }
+>;
+
+export type DrawRequestedEvent = DomainEventEnvelope<
+  'credit.draw_requested',
+  { walletAddress: string; amount: string }
+>;
+
+export type DrawConfirmedEvent = DomainEventEnvelope<
+  'credit.draw_confirmed',
+  { walletAddress: string; amount: string; utilized: string }
+>;
+
+export type RepayConfirmedEvent = DomainEventEnvelope<
+  'credit.repay_confirmed',
+  { walletAddress: string; amount: string; utilized: string }
+>;
+
+export type DefaultedEvent = DomainEventEnvelope<
+  'credit.defaulted',
+  { walletAddress: string; reason?: string }
+>;
+
+/** Union of all credit lifecycle events. */
+export type CreditDomainEvent =
+  | CreditOpenedEvent
+  | DrawRequestedEvent
+  | DrawConfirmedEvent
+  | RepayConfirmedEvent
+  | DefaultedEvent;
+
+/** Helper to stamp `occurredAt` on a freshly minted event. */
+export function nowIso(): string {
+  return new Date().toISOString();
+}

--- a/src/services/events/eventBus.ts
+++ b/src/services/events/eventBus.ts
@@ -1,0 +1,93 @@
+/**
+ * In-process domain event bus.
+ *
+ * A minimal publish/subscribe bus used to decouple downstream handlers
+ * (audit log, webhooks, notifications) from the core credit-line request path.
+ *
+ * Delivery semantics (documented limitations):
+ *  - **In-process only.** Events are not persisted; they are lost on process
+ *    crash before a handler runs. For durable, cross-process delivery use an
+ *    external broker. This bus is intentionally lightweight.
+ *  - **At-least-once within the process.** Every registered handler for an
+ *    event type is invoked. A throwing or rejecting handler does not prevent
+ *    the others from running, and the failure is reported to an optional
+ *    error sink so a supervisor can retry/alert.
+ *  - **Synchronous publish, awaited handlers.** `publish` resolves only after
+ *    all handlers settle, giving callers a back-pressure point when needed.
+ */
+import type { CreditDomainEvent, CreditEventType } from './domainEvents.js';
+
+/** A handler may be sync or async; its rejection is isolated from peers. */
+export type EventHandler<E extends CreditDomainEvent = CreditDomainEvent> = (
+  event: E,
+) => void | Promise<void>;
+
+/** Optional sink invoked when a handler throws/rejects. */
+export type EventErrorSink = (error: unknown, event: CreditDomainEvent, handlerName: string) => void;
+
+export class EventBus {
+  private readonly handlers = new Map<CreditEventType, Set<EventHandler>>();
+
+  constructor(private readonly onError: EventErrorSink = defaultErrorSink) {}
+
+  /**
+   * Register `handler` for `type`. Returns an unsubscribe function so callers
+   * (e.g. tests) can deterministically tear down their subscription.
+   */
+  subscribe<E extends CreditDomainEvent>(
+    type: E['type'],
+    handler: EventHandler<E>,
+  ): () => void {
+    const set = this.handlers.get(type) ?? new Set<EventHandler>();
+    set.add(handler as EventHandler);
+    this.handlers.set(type, set);
+    return () => {
+      set.delete(handler as EventHandler);
+    };
+  }
+
+  /**
+   * Publish `event` to every subscriber of its type. Resolves once all
+   * handlers settle. A failing handler is isolated: the error is routed to the
+   * error sink and the remaining handlers still run (at-least-once delivery).
+   */
+  async publish(event: CreditDomainEvent): Promise<void> {
+    const set = this.handlers.get(event.type);
+    if (!set || set.size === 0) {
+      return;
+    }
+    // Snapshot so a handler that unsubscribes mid-dispatch is still invoked
+    // exactly once for this event.
+    const snapshot = Array.from(set);
+    await Promise.all(
+      snapshot.map(async (handler) => {
+        try {
+          await handler(event);
+        } catch (error) {
+          this.onError(error, event, handler.name || 'anonymous');
+        }
+      }),
+    );
+  }
+
+  /** Number of handlers registered for `type` — useful in tests. */
+  handlerCount(type: CreditEventType): number {
+    return this.handlers.get(type)?.size ?? 0;
+  }
+
+  /** Remove every subscription. Intended for test isolation / shutdown. */
+  clear(): void {
+    this.handlers.clear();
+  }
+}
+
+function defaultErrorSink(error: unknown, event: CreditDomainEvent, handlerName: string): void {
+  // Never throw from the error sink itself.
+  console.error(
+    `[EventBus] handler "${handlerName}" failed for ${event.type} (creditLineId=${event.creditLineId}):`,
+    error,
+  );
+}
+
+/** Process-wide default bus, mirroring `defaultJobQueue`. */
+export const defaultEventBus = new EventBus();


### PR DESCRIPTION
Adds a minimal in-process domain event bus that decouples downstream handlers (audit, webhooks, notifications) from the core credit request path.

- Domain events: credit.opened, draw_requested, draw_confirmed, repay_confirmed, defaulted.
- EventBus with at-least-once in-process dispatch: every handler runs; a failing handler is isolated to an error sink and peers still execute. Limitations (no persistence / in-process only) documented in the module.
- Audit subscriber that records every lifecycle event.
- CreditLineService publishes events on open/draw/repay (optional bus param, backward compatible); Container wires the default bus + audit subscriber.
- Tests for emission, isolation, unsubscribe, and audit recording.

Closes #209