### PR TITLE
Backend: Add cached read model for dashboard queries (materialized summaries)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
+import { dashboardRouter } from './routes/dashboard.js';
 
 export function createApp() {
   const app = express();
@@ -14,6 +15,7 @@ export function createApp() {
 
   app.use('/api/credit', creditRouter);
   app.use('/api/risk', riskRouter);
+  app.use('/api/dashboard', dashboardRouter);
 
   return app;
 }

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -33,6 +33,7 @@ import { createSorobanClient, resolveSorobanConfig } from "../services/sorobanCl
 import { defaultJobQueue } from "../services/jobQueue.js";
 import { DataRetentionService } from "../services/dataRetentionService.js";
 import { DataRetentionWorker } from "../services/dataRetentionWorker.js";
+import { DashboardSummaryService } from "../services/dashboardSummaryService.js";
 
 export class Container {
   private static instance: Container;
@@ -50,6 +51,7 @@ export class Container {
   private _riskEvaluationService: RiskEvaluationService;
   private _reconciliationService: ReconciliationService;
   private _reconciliationWorker: ReconciliationWorker;
+  private _dashboardSummaryService: DashboardSummaryService;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
 
@@ -76,6 +78,9 @@ export class Container {
     this._reconciliationWorker = new ReconciliationWorker(
       this._reconciliationService,
       defaultJobQueue,
+    );
+    this._dashboardSummaryService = new DashboardSummaryService(
+      this._creditLineRepository,
     );
 
     // Data retention requires a real Postgres connection (pgcrypto digest(),
@@ -142,6 +147,11 @@ export class Container {
 
   get reconciliationWorker(): ReconciliationWorker {
     return this._reconciliationWorker;
+  }
+
+  /** Cached read model for dashboard summary queries. */
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
   }
 
   /** Undefined when running against in-memory repositories (no Postgres connection). */

--- a/src/routes/__tests__/dashboard.route.test.ts
+++ b/src/routes/__tests__/dashboard.route.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import { describe, it, expect } from 'vitest';
+import { createApp } from '../../app.js';
+
+describe('GET /api/dashboard/summary', () => {
+  it('returns the cached dashboard summary envelope', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/dashboard/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeNull();
+    expect(res.body.data).toMatchObject({
+      totalCreditLines: expect.any(Number),
+      totalCreditLimit: expect.any(String),
+      totalUtilized: expect.any(String),
+      totalAvailable: expect.any(String),
+    });
+    expect(res.body.data.generatedAt).toBeDefined();
+    expect(res.body.data.countsByStatus).toBeDefined();
+  });
+
+  it('reflects newly created credit lines after cache invalidation', async () => {
+    const app = createApp();
+
+    const before = await request(app).get('/api/dashboard/summary');
+    const beforeCount = before.body.data.totalCreditLines as number;
+
+    await request(app)
+      .post('/api/credit/lines')
+      .send({
+        walletAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        creditLimit: '1234.00',
+        interestRateBps: 500,
+      });
+
+    const after = await request(app).get('/api/dashboard/summary');
+    expect(after.body.data.totalCreditLines).toBe(beforeCount + 1);
+  });
+});

--- a/src/routes/credit.ts
+++ b/src/routes/credit.ts
@@ -135,6 +135,8 @@ creditRouter.post('/lines', validateBody(createCreditLineSchema), async (req, re
       creditLimit: finalLimit,
       interestRateBps: interestRateBps ?? 0,
     });
+    // Keep the dashboard read model correct on mutation (not just TTL-fresh).
+    container.dashboardSummaryService.invalidate();
     return ok(res, creditLine, 201);
   } catch (error) {
     return fail(res, error instanceof Error ? error : undefined, 400);
@@ -152,6 +154,7 @@ creditRouter.put('/lines/:id', async (req, res) => {
     if (!creditLine) {
       return fail(res, 'Credit line not found', 404);
     }
+    container.dashboardSummaryService.invalidate();
     return ok(res, creditLine);
   } catch (error) {
     return fail(res, error instanceof Error ? error : undefined, 400);
@@ -164,6 +167,7 @@ creditRouter.delete('/lines/:id', async (req, res) => {
     if (!deleted) {
       return fail(res, 'Credit line not found', 404);
     }
+    container.dashboardSummaryService.invalidate();
     return res.status(204).send();
   } catch {
     return fail(res, 'Internal server error');

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1,0 +1,30 @@
+/**
+ * Dashboard read-model routes mounted at `/api/dashboard`.
+ *
+ * Serves aggregate summaries (credit-line totals, utilization, per-status
+ * counts) from the cached {@link DashboardSummaryService} read model rather
+ * than scanning the full credit-line set on every request.
+ *
+ * Staleness: responses may be up to the service TTL (default 30s) old. The
+ * `generatedAt` field on the payload lets clients display data freshness.
+ */
+import { Router, type Request, type Response } from 'express';
+import { Container } from '../container/Container.js';
+import { ok, fail } from '../utils/response.js';
+
+export const dashboardRouter = Router();
+
+const container = Container.getInstance();
+
+/**
+ * GET /api/dashboard/summary
+ * Returns the cached dashboard summary read model.
+ */
+dashboardRouter.get('/summary', async (_req: Request, res: Response) => {
+  try {
+    const summary = await container.dashboardSummaryService.getSummary();
+    ok(res, summary);
+  } catch (error) {
+    fail(res, error instanceof Error ? error : 'Failed to load dashboard summary', 500);
+  }
+});

--- a/src/services/__tests__/dashboardSummaryService.test.ts
+++ b/src/services/__tests__/dashboardSummaryService.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DashboardSummaryService } from '../dashboardSummaryService.js';
+import { CreditLineStatus, type CreditLine } from '../../models/CreditLine.js';
+import type { CreditLineRepository } from '../../repositories/interfaces/CreditLineRepository.js';
+
+function line(partial: Partial<CreditLine>): CreditLine {
+  return {
+    id: 'cl',
+    walletAddress: 'GW',
+    creditLimit: '1000.00',
+    availableCredit: '1000.00',
+    utilized: '0',
+    interestRateBps: 500,
+    status: CreditLineStatus.ACTIVE,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...partial,
+  };
+}
+
+function repoOf(lines: CreditLine[], findAll = vi.fn(async () => lines)): {
+  repo: CreditLineRepository;
+  findAll: typeof findAll;
+} {
+  const repo = { findAll } as unknown as CreditLineRepository;
+  return { repo, findAll };
+}
+
+describe('DashboardSummaryService.aggregate', () => {
+  it('computes totals and per-status counts', () => {
+    const lines = [
+      line({ id: 'a', creditLimit: '1000.00', utilized: '250.00', status: CreditLineStatus.ACTIVE }),
+      line({ id: 'b', creditLimit: '500.00', utilized: '500.00', status: CreditLineStatus.SUSPENDED }),
+      line({ id: 'c', creditLimit: '2000.00', utilized: '0', status: CreditLineStatus.ACTIVE }),
+    ];
+
+    const summary = DashboardSummaryService.aggregate(lines, '2026-01-01T00:00:00.000Z');
+
+    expect(summary.totalCreditLines).toBe(3);
+    expect(summary.totalCreditLimit).toBe('3500.00');
+    expect(summary.totalUtilized).toBe('750.00');
+    expect(summary.totalAvailable).toBe('2750.00');
+    expect(summary.countsByStatus[CreditLineStatus.ACTIVE]).toBe(2);
+    expect(summary.countsByStatus[CreditLineStatus.SUSPENDED]).toBe(1);
+  });
+
+  it('never reports negative available credit', () => {
+    const summary = DashboardSummaryService.aggregate(
+      [line({ creditLimit: '100.00', utilized: '150.00' })],
+      'now',
+    );
+    expect(summary.totalAvailable).toBe('0.00');
+  });
+});
+
+describe('DashboardSummaryService caching', () => {
+  it('serves from cache within the TTL (single repo read)', async () => {
+    let now = 0;
+    const { repo, findAll } = repoOf([line({})]);
+    const service = new DashboardSummaryService(repo, 30_000, () => now);
+
+    await service.getSummary();
+    now = 29_999;
+    await service.getSummary();
+
+    expect(findAll).toHaveBeenCalledTimes(1);
+    expect(service.isFresh()).toBe(true);
+  });
+
+  it('recomputes after the TTL elapses (staleness window upper bound)', async () => {
+    let now = 0;
+    const { repo, findAll } = repoOf([line({})]);
+    const service = new DashboardSummaryService(repo, 30_000, () => now);
+
+    await service.getSummary();
+    now = 30_001; // beyond TTL
+    await service.getSummary();
+
+    expect(findAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('recomputes immediately after invalidate()', async () => {
+    let now = 0;
+    const { repo, findAll } = repoOf([line({})]);
+    const service = new DashboardSummaryService(repo, 30_000, () => now);
+
+    await service.getSummary();
+    service.invalidate();
+    expect(service.isFresh()).toBe(false);
+    await service.getSummary();
+
+    expect(findAll).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/dashboardSummaryService.ts
+++ b/src/services/dashboardSummaryService.ts
@@ -1,0 +1,107 @@
+/**
+ * Cached read model for dashboard queries.
+ *
+ * Dashboard widgets (total credit lines, aggregate limit / utilized /
+ * available, per-status counts) are read-heavy and tolerant of brief
+ * staleness. Computing them on every request scans the whole credit-line set,
+ * which does not scale. This service materializes those aggregates into an
+ * in-memory summary and serves it from cache.
+ *
+ * ## Staleness guarantees
+ *  - The cache is served for at most `ttlMs` (default 30s). After the TTL the
+ *    next read recomputes from the source repository. Therefore a reader never
+ *    observes data older than `ttlMs` — the documented staleness window.
+ *  - Mutations that change the aggregates SHOULD call {@link invalidate} so the
+ *    next read recomputes immediately (correct, not merely fresh-within-window).
+ *
+ * This is a lightweight, in-process materialization. A production deployment
+ * could swap the compute step for a `SELECT … GROUP BY` against a summary
+ * table / materialized view without changing this contract.
+ */
+import type { CreditLineRepository } from '../repositories/interfaces/CreditLineRepository.js';
+import { CreditLineStatus, type CreditLine } from '../models/CreditLine.js';
+
+/** Materialized dashboard summary. All money fields are decimal strings. */
+export interface DashboardSummary {
+  readonly totalCreditLines: number;
+  readonly totalCreditLimit: string;
+  readonly totalUtilized: string;
+  readonly totalAvailable: string;
+  readonly countsByStatus: Readonly<Record<CreditLineStatus, number>>;
+  /** When this summary snapshot was computed. */
+  readonly generatedAt: string;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+
+export class DashboardSummaryService {
+  private cache?: { summary: DashboardSummary; expiresAt: number };
+
+  constructor(
+    private readonly creditLineRepository: CreditLineRepository,
+    private readonly ttlMs: number = DEFAULT_TTL_MS,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  /**
+   * Return the dashboard summary, served from cache when fresh (within the
+   * `ttlMs` staleness window) and recomputed otherwise.
+   */
+  async getSummary(): Promise<DashboardSummary> {
+    const nowMs = this.now();
+    if (this.cache && nowMs < this.cache.expiresAt) {
+      return this.cache.summary;
+    }
+    const summary = await this.computeSummary();
+    this.cache = { summary, expiresAt: nowMs + this.ttlMs };
+    return summary;
+  }
+
+  /**
+   * Drop the cached summary so the next {@link getSummary} recomputes. Call
+   * after any mutation that affects the aggregates (create/draw/repay/status).
+   */
+  invalidate(): void {
+    this.cache = undefined;
+  }
+
+  /** True when a cached summary is present and still within its TTL. */
+  isFresh(): boolean {
+    return this.cache !== undefined && this.now() < this.cache.expiresAt;
+  }
+
+  private async computeSummary(): Promise<DashboardSummary> {
+    const lines = await this.creditLineRepository.findAll();
+    return DashboardSummaryService.aggregate(lines, new Date(this.now()).toISOString());
+  }
+
+  /** Pure aggregation — extracted so it is trivially unit-testable. */
+  static aggregate(lines: CreditLine[], generatedAt: string): DashboardSummary {
+    const countsByStatus: Record<CreditLineStatus, number> = {
+      [CreditLineStatus.ACTIVE]: 0,
+      [CreditLineStatus.SUSPENDED]: 0,
+      [CreditLineStatus.CLOSED]: 0,
+      [CreditLineStatus.PENDING]: 0,
+    };
+
+    let totalLimit = 0;
+    let totalUtilized = 0;
+
+    for (const line of lines) {
+      countsByStatus[line.status] = (countsByStatus[line.status] ?? 0) + 1;
+      totalLimit += parseFloat(line.creditLimit) || 0;
+      totalUtilized += parseFloat(line.utilized || '0') || 0;
+    }
+
+    const totalAvailable = Math.max(0, totalLimit - totalUtilized);
+
+    return {
+      totalCreditLines: lines.length,
+      totalCreditLimit: totalLimit.toFixed(2),
+      totalUtilized: totalUtilized.toFixed(2),
+      totalAvailable: totalAvailable.toFixed(2),
+      countsByStatus,
+      generatedAt,
+    };
+  }
+}


### PR DESCRIPTION
Adds a cached read model for dashboard summary queries (credit-line totals, utilization, available, per-status counts) so dashboards do not scan the full credit-line set on every request.

- DashboardSummaryService: materializes aggregates with a TTL-bounded cache (default 30s) plus explicit invalidate(). Staleness guarantee: a reader never sees data older than the TTL window; mutations invalidate for immediate correctness.
- GET /api/dashboard/summary serves the read model via the shared { data, error } envelope with a generatedAt freshness marker.
- Cache invalidation wired into credit-line create/update/delete handlers.
- Tests for aggregation correctness, cache hits within TTL, recompute after TTL, invalidation, and route behavior incl. reflecting new lines.

Closes #210