### PR TITLE
[codex] ci: gate OpenAPI drift in CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -65,9 +65,9 @@ jobs:
           path: coverage/
           retention-days: 7
 
-      - name: Validate OpenAPI spec
+      - name: Validate OpenAPI spec and route drift
         if: matrix.node-version == '20.x'
-        run: npm run validate:spec
+        run: npm run validate:openapi
 
       - name: Check coverage threshold
         if: matrix.node-version == '20.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Typecheck (tsc --noEmit)
         run: npm run typecheck
 
+      - name: Validate OpenAPI spec and route drift
+        run: npm run validate:openapi
+
       - name: Lint (ESLint)
         run: npm run lint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ Before requesting review, confirm:
 - [ ] `npm test` passes locally
 - [ ] `npm run lint` passes
 - [ ] `npm run typecheck` passes
-- [ ] `npm run validate:spec` passes (if OpenAPI changed)
+- [ ] `npm run validate:openapi` passes (if OpenAPI changed or routes changed)
 - [ ] New code covered by tests; coverage ≥ 95 % on touched modules
 - [ ] No new secrets, credentials, or wallet pubkeys in code, tests, fixtures, or logs
 - [ ] All Zod schemas updated alongside any new route inputs

--- a/OPENAPI.md
+++ b/OPENAPI.md
@@ -23,17 +23,22 @@ on the next server restart — no build step needed.
 1. Implement the route handler in `src/routes/`.
 2. Open `src/openapi.yaml` and add the path under `paths:`.
 3. Add or reuse component schemas under `components/schemas:`.
-4. Run `npm run validate:spec` — must exit 0.
+4. Run `npm run validate:openapi` - must exit 0.
 5. Add at least one test in `src/tests/api.test.ts` for the new endpoint.
 6. Run `npm test` — all tests must pass.
 
-## Validating the spec
+## Validating the spec and route drift
 
 ```bash
-npm run validate:spec
+npm run validate:openapi
 ```
 
-This checks that `src/openapi.yaml` is well-formed YAML. For deeper linting
+This checks that `src/openapi.yaml` is well-formed YAML and that every mounted
+Express route operation is represented in the OpenAPI paths. The route drift
+check intentionally covers only routers mounted in `src/index.ts`; if a new
+router is mounted there, add it to `scripts/check-openapi-drift.mjs`.
+
+For deeper linting
 (spec correctness, unused schemas) install `@stoplight/spectral-cli`:
 
 ```bash
@@ -50,9 +55,9 @@ Re-run this whenever `openapi.yaml` changes.
 
 ## CI integration
 
-Add these steps to your CI pipeline:
+CI runs the combined validation through `npm run validate:openapi`:
 
 ```yaml
-- run: npm run validate:spec
+- run: npm run validate:openapi
 - run: npm test
 ```

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "db:validate": "tsx src/db/validate-cli.ts",
     "db:retention": "tsx src/db/data-retention-cli.ts",
     "validate:spec": "node --input-type=module -e \"import fs from 'node:fs'; import yaml from 'yaml'; yaml.parse(fs.readFileSync('src/openapi.yaml', 'utf8')); console.log('OpenAPI spec valid');\"",
+    "openapi:drift": "node scripts/check-openapi-drift.mjs",
+    "validate:openapi": "npm run validate:spec && npm run openapi:drift",
     "load:smoke": "k6 run scripts/load/smoke.js",
     "load:stress": "k6 run scripts/load/stress.js",
     "load:spike": "k6 run scripts/load/spike.js"

--- a/scripts/check-openapi-drift.mjs
+++ b/scripts/check-openapi-drift.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import yaml from 'yaml';
+
+const root = process.cwd();
+const openapiPath = path.join(root, 'src', 'openapi.yaml');
+const methods = ['get', 'post', 'put', 'patch', 'delete'];
+const methodSet = new Set(methods);
+
+const mountedRouters = [
+  {
+    file: path.join(root, 'src', 'routes', 'health.ts'),
+    router: 'healthRouter',
+    basePath: '/health',
+  },
+  {
+    file: path.join(root, 'src', 'routes', 'credit.ts'),
+    router: 'creditRouter',
+    basePath: '/api/credit',
+  },
+  {
+    file: path.join(root, 'src', 'routes', 'risk.ts'),
+    router: 'riskRouter',
+    basePath: '/api/risk',
+  },
+  {
+    file: path.join(root, 'src', 'routes', 'webhook.ts'),
+    router: 'webhookRouter',
+    basePath: '/api/webhooks',
+  },
+  {
+    file: path.join(root, 'src', 'routes', 'reconciliation.ts'),
+    router: 'reconciliationRouter',
+    basePath: '/api/reconciliation',
+  },
+];
+
+function normalizePath(value) {
+  const cleaned = value.replace(/\/+/g, '/');
+  if (cleaned.length > 1 && cleaned.endsWith('/')) {
+    return cleaned.slice(0, -1);
+  }
+  return cleaned;
+}
+
+function expressToOpenApiPath(basePath, routePath) {
+  const joined = routePath === '/'
+    ? basePath
+    : `${basePath}${routePath.startsWith('/') ? '' : '/'}${routePath}`;
+
+  return normalizePath(joined).replace(/:([A-Za-z0-9_]+)/g, '{$1}');
+}
+
+function routeKey(method, routePath) {
+  return `${method.toUpperCase()} ${routePath}`;
+}
+
+function extractRuntimeRoutes() {
+  const routes = new Map();
+
+  for (const mounted of mountedRouters) {
+    const source = fs.readFileSync(mounted.file, 'utf8');
+    const matcher = new RegExp(
+      `\\b${mounted.router}\\s*\\.\\s*(${methods.join('|')})\\s*\\(\\s*(['"\`])([^'"\`]+)\\2`,
+      'g',
+    );
+
+    for (const match of source.matchAll(matcher)) {
+      const [, method, , routePath] = match;
+      const openApiPath = expressToOpenApiPath(mounted.basePath, routePath);
+      const key = routeKey(method, openApiPath);
+      const existing = routes.get(key);
+
+      if (existing) {
+        throw new Error(
+          `Duplicate runtime route ${key} found in ${mounted.file}; already seen in ${existing.file}`,
+        );
+      }
+
+      routes.set(key, {
+        method,
+        path: openApiPath,
+        file: path.relative(root, mounted.file),
+      });
+    }
+  }
+
+  return routes;
+}
+
+function extractOpenApiRoutes() {
+  const spec = yaml.parse(fs.readFileSync(openapiPath, 'utf8'));
+  const paths = spec?.paths;
+
+  if (!paths || typeof paths !== 'object') {
+    throw new Error('src/openapi.yaml must define a top-level paths object.');
+  }
+
+  const routes = new Map();
+
+  for (const [routePath, operations] of Object.entries(paths)) {
+    if (!operations || typeof operations !== 'object') {
+      continue;
+    }
+
+    for (const method of Object.keys(operations)) {
+      if (!methodSet.has(method)) {
+        continue;
+      }
+
+      const normalizedPath = normalizePath(routePath);
+      const key = routeKey(method, normalizedPath);
+
+      if (routes.has(key)) {
+        throw new Error(`Duplicate OpenAPI route ${key} found in src/openapi.yaml.`);
+      }
+
+      routes.set(key, {
+        method,
+        path: normalizedPath,
+        file: path.relative(root, openapiPath),
+      });
+    }
+  }
+
+  return routes;
+}
+
+function sortedKeys(map) {
+  return Array.from(map.keys()).sort((a, b) => a.localeCompare(b));
+}
+
+function diff(left, right) {
+  return sortedKeys(left).filter((key) => !right.has(key));
+}
+
+const runtimeRoutes = extractRuntimeRoutes();
+const openApiRoutes = extractOpenApiRoutes();
+const missingFromOpenApi = diff(runtimeRoutes, openApiRoutes);
+const staleInOpenApi = diff(openApiRoutes, runtimeRoutes);
+
+if (missingFromOpenApi.length > 0 || staleInOpenApi.length > 0) {
+  console.error('OpenAPI drift detected.');
+
+  if (missingFromOpenApi.length > 0) {
+    console.error('\nRuntime routes missing from src/openapi.yaml:');
+    for (const key of missingFromOpenApi) {
+      const route = runtimeRoutes.get(key);
+      console.error(`  - ${key} (${route.file})`);
+    }
+  }
+
+  if (staleInOpenApi.length > 0) {
+    console.error('\nOpenAPI routes without a mounted Express route:');
+    for (const key of staleInOpenApi) {
+      console.error(`  - ${key} (src/openapi.yaml)`);
+    }
+  }
+
+  console.error('\nUpdate src/openapi.yaml or the mounted route catalog in scripts/check-openapi-drift.mjs.');
+  process.exit(1);
+}
+
+console.log(`OpenAPI drift check passed (${runtimeRoutes.size} mounted route operations).`);

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -104,6 +104,23 @@ components:
           example: 3
       additionalProperties: false
 
+    CreditLineAmountRequest:
+      type: object
+      required: [walletAddress, amount]
+      properties:
+        walletAddress:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Stellar wallet address submitting the action
+          example: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+        amount:
+          type: string
+          pattern: "^\\d+(\\.\\d+)?$"
+          description: Action amount as a decimal string
+          example: "250.00"
+      additionalProperties: false
+
     CreditLine:
       type: object
       properties:
@@ -189,6 +206,28 @@ components:
         message:
           type: string
           example: "Credit line suspended."
+
+    CreditLineTransactionSubmitResponse:
+      type: object
+      required: [id, walletAddress, amount, txHash, status]
+      properties:
+        id:
+          type: string
+          description: Credit line identifier
+        walletAddress:
+          type: string
+          description: Stellar wallet address that submitted the request
+        amount:
+          type: string
+          description: Submitted amount as a decimal string
+        txHash:
+          type: string
+          nullable: true
+          description: Submitted transaction hash, or null when queued locally
+        status:
+          type: string
+          enum: [submitted, pending]
+          description: Whether the Soroban transaction was submitted or left pending
 
     # ── Transaction Schemas ──────────────────────────────────────────────────
 
@@ -901,6 +940,102 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /api/credit/lines/{id}/draw:
+    post:
+      tags: [Credit]
+      operationId: drawCreditLine
+      summary: Submit a draw request for a credit line
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreditLineAmountRequest"
+            example:
+              walletAddress: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+              amount: "250.00"
+      responses:
+        "200":
+          description: Draw request accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLineTransactionSubmitResponse"
+        "400":
+          description: Invalid draw request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/credit/lines/{id}/repay:
+    post:
+      tags: [Credit]
+      operationId: repayCreditLine
+      summary: Submit a repayment request for a credit line
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreditLineAmountRequest"
+            example:
+              walletAddress: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+              amount: "100.00"
+      responses:
+        "200":
+          description: Repayment request accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLineTransactionSubmitResponse"
+        "400":
+          description: Invalid repayment request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/credit/lines/{id}/suspend:
     post:
       tags: [Credit]
@@ -1109,6 +1244,34 @@ paths:
               example:
                 data: null
                 error: Content-Type must be application/json
+
+  /api/risk/admin/recalibrate:
+    post:
+      tags: [Risk]
+      operationId: recalibrateRiskModel
+      summary: Trigger risk model recalibration
+      description: Admin-gated endpoint that triggers risk model recalibration.
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: Risk model recalibration triggered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminRecalibrateResponse"
+        "401":
+          description: API key missing
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /api/webhooks/config:
     get:


### PR DESCRIPTION
## Summary

- Add `scripts/check-openapi-drift.mjs` to compare mounted Express route operations with `src/openapi.yaml`.
- Add `openapi:drift` and `validate:openapi` scripts, then wire the combined validation into both CI workflows.
- Document the route-drift validation workflow in `OPENAPI.md` and `CONTRIBUTING.md`.
- Update `src/openapi.yaml` for existing mounted routes that were missing from the spec: credit draw, credit repay, and risk admin recalibration.

Closes #203

## Validation

- Passed: `npm ci`
- Passed: `npm run validate:openapi`
- Failed, existing baseline: `npm run typecheck` reports unrelated missing symbols/properties such as `recordRequest`, `maintenanceModeGuard`, `metricsRouter`, `dashboardSummaryService`, and `log`.
- Failed, existing baseline: `npm run lint` reports unrelated existing lint errors in `src/app.ts`, repository tests, metrics tests, `PostgresTransactionRepository.ts`, and dashboard summary tests.
- Failed, existing baseline: `npm test` reports 32 failing tests unrelated to this branch, including `maintenanceModeGuard is not defined`, `log is not defined`, and existing credit/repository expectation drift.