### PR TITLE
[codex] docs(dev): local bootstrap script for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,14 +10,15 @@
 
 # PostgreSQL connection string.
 # Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
-# Docker Compose default: postgresql://postgres:postgres@db:5432/creditra_db
-DATABASE_URL=postgresql://user:password@localhost:5432/creditra
+# Docker Compose host default: postgresql://postgres:postgres@localhost:5432/creditra_db
+# The api container overrides this to use the compose service host `db`.
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/creditra_db
 
 # Comma-separated list of API keys for authenticating admin requests.
 # Sent by clients in the X-Api-Key header (at least one key required).
 # Rotation: add new key alongside old key → deploy → update clients → remove old key.
-# Example: API_KEYS=key-abc123,key-def456
-API_KEYS=change-me-before-any-real-traffic
+# Local-only placeholder. Replace before using shared or deployed environments.
+API_KEYS=dev-api-key
 
 # -----------------------------------------------------------------------------
 # OPTIONAL — server

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
+* text=auto eol=lf
+
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.rs text eol=lf
+*.json text eol=lf
+*.md text eol=lf
 *.sh text eol=lf
+*.sql text eol=lf

--- a/.gitattributes.txt
+++ b/.gitattributes.txt
@@ -1,8 +1,0 @@
-* text=auto eol=lf
-
-*.ts text eol=lf
-*.tsx text eol=lf
-*.js text eol=lf
-*.rs text eol=lf
-*.json text eol=lf
-*.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A request enters through the Express router, is authenticated (`X-API-Key` or `X
 
 - Node.js **>= 20**
 - npm
+- Bash for `npm run dev:bootstrap` (Git Bash or WSL on Windows)
 - (Optional) Docker 24+ and Docker Compose v2 for the containerised dev loop
 - (Optional) k6 for load testing
 
@@ -87,6 +88,19 @@ cd Creditra-Backend
 npm install
 cp .env.example .env   # then fill in DATABASE_URL, API_KEYS, etc.
 ```
+
+### Local bootstrap
+
+For a reproducible local setup with Docker Compose Postgres, migrations, schema
+validation, and deterministic seed data:
+
+```bash
+npm run dev:bootstrap
+```
+
+The script creates `.env` from `.env.example` only when `.env` is missing, leaves
+existing local configuration unchanged, and uses placeholder development values
+only. Review `.env` before connecting to shared services.
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,48 @@ cp .env.example .env   # then fill in DATABASE_URL, API_KEYS, etc.
 
 ### Local bootstrap
 
-For a reproducible local setup with Docker Compose Postgres, migrations, schema
-validation, and deterministic seed data:
+For a reproducible local setup (Docker Compose Postgres + env template +
+migrations + schema validation + deterministic seed data):
 
 ```bash
 npm run dev:bootstrap
 ```
 
-The script creates `.env` from `.env.example` only when `.env` is missing, leaves
-existing local configuration unchanged, and uses placeholder development values
-only. Review `.env` before connecting to shared services.
+What the script does:
+
+1. Validates that `.env.example` contains required keys (`DATABASE_URL`, `API_KEYS`)
+2. Creates `.env` from `.env.example` **only when `.env` is missing** (never overwrites)
+3. Runs `npm ci`
+4. Starts the Compose `db` service (`postgres:15`, host port `5432`)
+5. Waits until `DATABASE_URL` accepts connections
+6. Runs `npm run db:migrate` and `npm run db:validate`
+7. Loads idempotent local seed data from [`scripts/dev-seed.sql`](./scripts/dev-seed.sql)
+
+Flags (pass after `--` with npm):
+
+```bash
+npm run dev:bootstrap -- --skip-install   # reuse existing node_modules
+npm run dev:bootstrap -- --skip-compose   # use an already-running Postgres
+npm run dev:bootstrap -- --skip-migrate   # skip migrate + schema validate
+npm run dev:bootstrap -- --skip-seed      # skip seed SQL
+```
+
+**Secrets:** only `.env.example` (placeholders) is committed. Real keys stay in
+gitignored `.env`. Default local values match Compose
+(`postgresql://postgres:postgres@localhost:5432/creditra_db`, `API_KEYS=dev-api-key`).
+
+**Common failures**
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Missing required command: docker` | Docker not installed / not on PATH | Install Docker Desktop, or use `--skip-compose` with your own DB |
+| `Database did not become reachable` | Engine not running, or port `5432` busy | Start Docker; free `5432`; check `DATABASE_URL` |
+| `node_modules/pg is missing` | Ran with `--skip-install` before deps | Drop the flag, or run `npm ci` first |
+| `bash: command not found` (Windows) | No Git Bash / WSL on PATH | Install [Git for Windows](https://git-scm.com/) or use WSL |
+| Migration fails on `wallet_address` of `credit_lines` | Stale DB volume from an old broken index migration | `docker compose down -v` then re-run bootstrap |
+
+Seeded demo wallet (local only):
+`GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGZBW3JXDC55CYIXB5NAXMCEKJA`.
 
 ### Run
 

--- a/migrations/005_db_indexes_hot_queries.sql
+++ b/migrations/005_db_indexes_hot_queries.sql
@@ -1,9 +1,10 @@
 -- Migration 005: Database indexes for hot queries
 -- Covers credit lines by borrower (wallet address) and transaction history by borrower.
 
--- Index: look up all credit lines for a given borrower wallet address
-CREATE INDEX IF NOT EXISTS idx_credit_lines_wallet_address
-  ON credit_lines (wallet_address);
+-- Index: support the credit_lines -> borrowers join used for wallet lookups.
+-- borrower.wallet_address is already covered by borrowers_wallet_address_key.
+CREATE INDEX IF NOT EXISTS idx_credit_lines_borrower_created
+  ON credit_lines (borrower_id, created_at DESC);
 
 -- Index: transaction history by credit line (already FK, but explicit index for range scans)
 CREATE INDEX IF NOT EXISTS idx_transactions_credit_line_id
@@ -27,8 +28,8 @@ CREATE INDEX IF NOT EXISTS idx_credit_lines_status
 
 -- Partial index: only ACTIVE credit lines (most frequent filter in dashboard queries)
 CREATE INDEX IF NOT EXISTS idx_credit_lines_active
-  ON credit_lines (wallet_address, created_at DESC)
-  WHERE status = 'ACTIVE';
+  ON credit_lines (borrower_id, created_at DESC)
+  WHERE status = 'active';
 
 INSERT INTO schema_migrations (version) VALUES ('005_db_indexes_hot_queries')
   ON CONFLICT (version) DO NOTHING;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build": "tsc && cp src/openapi.yaml dist/openapi.yaml",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
+    "dev:bootstrap": "bash scripts/dev-bootstrap.sh",
     "typecheck": "tsc --noEmit",
     "lint:fix": "eslint src --fix",
     "lint": "eslint src",

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ENV_EXAMPLE=".env.example"
+ENV_FILE=".env"
+DEFAULT_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/creditra_db"
+DEFAULT_API_KEYS="dev-api-key"
+
+SKIP_INSTALL=0
+SKIP_COMPOSE=0
+SKIP_MIGRATE=0
+SKIP_SEED=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev-bootstrap.sh [options]
+
+Bootstraps a local Creditra backend development environment:
+  - validates required keys are present in .env.example
+  - creates .env from .env.example when .env is missing
+  - installs npm dependencies
+  - starts the local Postgres service with Docker Compose
+  - runs database migrations and schema validation
+  - loads deterministic local seed data
+
+Options:
+  --skip-install    Do not run npm ci
+  --skip-compose    Do not start Docker Compose
+  --skip-migrate    Do not run migrations or schema validation
+  --skip-seed       Do not load local seed data
+  -h, --help        Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-install) SKIP_INSTALL=1 ;;
+    --skip-compose) SKIP_COMPOSE=1 ;;
+    --skip-migrate) SKIP_MIGRATE=1 ;;
+    --skip-seed) SKIP_SEED=1 ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+step() {
+  printf '\n==> %s\n' "$1"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+env_value() {
+  local key="$1"
+  local file="$2"
+
+  if [[ ! -f "$file" ]]; then
+    return 0
+  fi
+
+  awk -F= -v key="$key" '
+    $0 !~ /^[[:space:]]*#/ && $1 == key {
+      sub(/^[^=]*=/, "", $0)
+      print $0
+      exit
+    }
+  ' "$file"
+}
+
+validate_env_example() {
+  local missing=()
+  local required=(DATABASE_URL API_KEYS)
+
+  for key in "${required[@]}"; do
+    if ! grep -Eq "^[[:space:]]*${key}=" "$ENV_EXAMPLE"; then
+      missing+=("$key")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "$ENV_EXAMPLE is missing required entries: ${missing[*]}" >&2
+    exit 1
+  fi
+}
+
+compose_cmd() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+    return
+  fi
+
+  if command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
+    return
+  fi
+
+  echo "Docker Compose is required unless --skip-compose is used." >&2
+  exit 1
+}
+
+wait_for_database() {
+  node --input-type=module <<'NODE'
+import { Client } from "pg";
+
+const url = process.env.DATABASE_URL;
+const maxAttempts = 30;
+const delayMs = 1000;
+
+if (!url) {
+  console.error("DATABASE_URL is required before checking database readiness.");
+  process.exit(1);
+}
+
+for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  const client = new Client({ connectionString: url });
+  try {
+    await client.connect();
+    await client.query("SELECT 1");
+    await client.end();
+    console.log("Database is reachable.");
+    process.exit(0);
+  } catch (error) {
+    try {
+      await client.end();
+    } catch {
+      // Ignore close errors while waiting for Postgres to accept connections.
+    }
+
+    if (attempt === maxAttempts) {
+      console.error("Database did not become reachable:", error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
+NODE
+}
+
+load_seed_data() {
+  node --input-type=module <<'NODE'
+import fs from "node:fs";
+import { Client } from "pg";
+
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error("DATABASE_URL is required before loading seed data.");
+  process.exit(1);
+}
+
+const sql = fs.readFileSync("scripts/dev-seed.sql", "utf8");
+const client = new Client({ connectionString: url });
+
+try {
+  await client.connect();
+  await client.query(sql);
+  console.log("Seed data loaded.");
+} finally {
+  await client.end();
+}
+NODE
+}
+
+step "Checking prerequisites"
+require_cmd node
+require_cmd npm
+if [[ "$SKIP_COMPOSE" -eq 0 ]]; then
+  require_cmd docker
+fi
+
+step "Validating environment template"
+validate_env_example
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  cp "$ENV_EXAMPLE" "$ENV_FILE"
+  echo "Created $ENV_FILE from $ENV_EXAMPLE. Review it before using non-local services."
+else
+  echo "$ENV_FILE already exists; leaving it unchanged."
+fi
+
+DATABASE_URL="${DATABASE_URL:-$(env_value DATABASE_URL "$ENV_FILE")}"
+API_KEYS="${API_KEYS:-$(env_value API_KEYS "$ENV_FILE")}"
+DATABASE_URL="${DATABASE_URL:-$DEFAULT_DATABASE_URL}"
+API_KEYS="${API_KEYS:-$DEFAULT_API_KEYS}"
+export DATABASE_URL API_KEYS NODE_ENV="${NODE_ENV:-development}"
+
+if [[ -z "$DATABASE_URL" || -z "$API_KEYS" ]]; then
+  echo "DATABASE_URL and API_KEYS must be set in the environment or $ENV_FILE." >&2
+  exit 1
+fi
+
+if [[ "$SKIP_INSTALL" -eq 0 ]]; then
+  step "Installing dependencies"
+  npm ci
+fi
+
+if [[ "$SKIP_COMPOSE" -eq 0 ]]; then
+  step "Starting local Postgres"
+  read -r -a compose <<<"$(compose_cmd)"
+  "${compose[@]}" up -d db
+fi
+
+if [[ "$SKIP_MIGRATE" -eq 0 ]]; then
+  step "Waiting for database"
+  wait_for_database
+
+  step "Running migrations"
+  npm run db:migrate
+
+  step "Validating schema"
+  npm run db:validate
+fi
+
+if [[ "$SKIP_SEED" -eq 0 ]]; then
+  step "Loading local seed data"
+  load_seed_data
+fi
+
+cat <<EOF
+
+Local development bootstrap complete.
+
+Useful commands:
+  npm run dev
+  docker compose up api
+  npm test
+
+Local DATABASE_URL used by this script:
+  $DATABASE_URL
+EOF

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Reproducible local-dev bootstrap for Creditra Backend.
+# Brings up Postgres (Docker Compose), prepares .env, installs deps,
+# runs migrations + schema validation, and loads deterministic seed data.
+#
+# Usage: npm run dev:bootstrap
+#    or: bash scripts/dev-bootstrap.sh [options]
 set -euo pipefail
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -6,6 +12,7 @@ cd "$ROOT_DIR"
 
 ENV_EXAMPLE=".env.example"
 ENV_FILE=".env"
+SEED_SQL="scripts/dev-seed.sql"
 DEFAULT_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/creditra_db"
 DEFAULT_API_KEYS="dev-api-key"
 
@@ -20,18 +27,27 @@ Usage: scripts/dev-bootstrap.sh [options]
 
 Bootstraps a local Creditra backend development environment:
   - validates required keys are present in .env.example
-  - creates .env from .env.example when .env is missing
-  - installs npm dependencies
-  - starts the local Postgres service with Docker Compose
+  - creates .env from .env.example when .env is missing (never overwrites)
+  - installs npm dependencies (npm ci)
+  - starts the local Postgres service with Docker Compose (db only)
+  - waits for database readiness
   - runs database migrations and schema validation
-  - loads deterministic local seed data
+  - loads deterministic local seed data (idempotent)
+
+Secrets are never committed: only .env.example (placeholders) is tracked.
+Existing .env files are left unchanged.
 
 Options:
   --skip-install    Do not run npm ci
-  --skip-compose    Do not start Docker Compose
+  --skip-compose    Do not start Docker Compose (use an existing Postgres)
   --skip-migrate    Do not run migrations or schema validation
   --skip-seed       Do not load local seed data
   -h, --help        Show this help
+
+Examples:
+  npm run dev:bootstrap
+  npm run dev:bootstrap -- --skip-install
+  bash scripts/dev-bootstrap.sh --skip-compose --skip-seed
 USAGE
 }
 
@@ -61,6 +77,15 @@ step() {
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "Missing required command: $1" >&2
+    case "$1" in
+      docker)
+        echo "Install Docker Desktop (or Engine) and ensure 'docker' is on PATH," >&2
+        echo "or re-run with --skip-compose if Postgres is already available." >&2
+        ;;
+      node|npm)
+        echo "Install Node.js >= 20 (includes npm) from https://nodejs.org/" >&2
+        ;;
+    esac
     exit 1
   fi
 }
@@ -83,6 +108,11 @@ env_value() {
 }
 
 validate_env_example() {
+  if [[ ! -f "$ENV_EXAMPLE" ]]; then
+    echo "Missing $ENV_EXAMPLE in repo root. Cannot bootstrap without the env template." >&2
+    exit 1
+  fi
+
   local missing=()
   local required=(DATABASE_URL API_KEYS)
 
@@ -110,10 +140,19 @@ compose_cmd() {
   fi
 
   echo "Docker Compose is required unless --skip-compose is used." >&2
+  echo "Install Docker Compose v2 (docker compose) or docker-compose v1." >&2
   exit 1
 }
 
+ensure_pg_module() {
+  if [[ ! -d "node_modules/pg" ]]; then
+    echo "node_modules/pg is missing. Run without --skip-install, or run 'npm ci' first." >&2
+    exit 1
+  fi
+}
+
 wait_for_database() {
+  ensure_pg_module
   node --input-type=module <<'NODE'
 import { Client } from "pg";
 
@@ -143,6 +182,11 @@ for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
 
     if (attempt === maxAttempts) {
       console.error("Database did not become reachable:", error instanceof Error ? error.message : error);
+      console.error("Hints:");
+      console.error("  - Is Docker running? Try: docker compose up -d db");
+      console.error("  - Is port 5432 free / pointed at the right host?");
+      console.error("  - Does DATABASE_URL match compose credentials?");
+      console.error("    expected: postgresql://postgres:postgres@localhost:5432/creditra_db");
       process.exit(1);
     }
 
@@ -153,6 +197,13 @@ NODE
 }
 
 load_seed_data() {
+  ensure_pg_module
+
+  if [[ ! -f "$SEED_SQL" ]]; then
+    echo "Missing seed file: $SEED_SQL" >&2
+    exit 1
+  fi
+
   node --input-type=module <<'NODE'
 import fs from "node:fs";
 import { Client } from "pg";
@@ -169,7 +220,11 @@ const client = new Client({ connectionString: url });
 try {
   await client.connect();
   await client.query(sql);
-  console.log("Seed data loaded.");
+  console.log("Seed data loaded (idempotent).");
+} catch (error) {
+  console.error("Failed to load seed data:", error instanceof Error ? error.message : error);
+  console.error("Ensure migrations have been applied (omit --skip-migrate) and schema is valid.");
+  process.exit(1);
 } finally {
   await client.end();
 }
@@ -181,6 +236,12 @@ require_cmd node
 require_cmd npm
 if [[ "$SKIP_COMPOSE" -eq 0 ]]; then
   require_cmd docker
+fi
+
+NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || echo 0)"
+if [[ "$NODE_MAJOR" -lt 20 ]]; then
+  echo "Node.js >= 20 is required (found $(node -v))." >&2
+  exit 1
 fi
 
 step "Validating environment template"
@@ -204,21 +265,38 @@ if [[ -z "$DATABASE_URL" || -z "$API_KEYS" ]]; then
   exit 1
 fi
 
+if [[ "$API_KEYS" == "change-me-before-any-real-traffic" ]]; then
+  echo "Warning: API_KEYS still uses a non-local placeholder. Prefer the local 'dev-api-key' value for bootstrap." >&2
+fi
+
 if [[ "$SKIP_INSTALL" -eq 0 ]]; then
   step "Installing dependencies"
   npm ci
+else
+  ensure_pg_module
 fi
 
 if [[ "$SKIP_COMPOSE" -eq 0 ]]; then
   step "Starting local Postgres"
   read -r -a compose <<<"$(compose_cmd)"
-  "${compose[@]}" up -d db
+  if ! "${compose[@]}" up -d db; then
+    echo "Failed to start the 'db' service via Docker Compose." >&2
+    echo "Check that Docker is running and port 5432 is available." >&2
+    exit 1
+  fi
+fi
+
+NEED_DB=0
+if [[ "$SKIP_MIGRATE" -eq 0 || "$SKIP_SEED" -eq 0 ]]; then
+  NEED_DB=1
+fi
+
+if [[ "$NEED_DB" -eq 1 ]]; then
+  step "Waiting for database"
+  wait_for_database
 fi
 
 if [[ "$SKIP_MIGRATE" -eq 0 ]]; then
-  step "Waiting for database"
-  wait_for_database
-
   step "Running migrations"
   npm run db:migrate
 
@@ -236,10 +314,15 @@ cat <<EOF
 Local development bootstrap complete.
 
 Useful commands:
-  npm run dev
-  docker compose up api
-  npm test
+  npm run dev              # API with hot reload on http://localhost:3000
+  docker compose up api    # API + DB via Compose
+  npm test                 # unit/integration tests
+  npm run db:migrate       # re-run migrations
+  npm run db:validate      # re-check schema
 
 Local DATABASE_URL used by this script:
   $DATABASE_URL
+
+Seeded demo wallet (local only):
+  GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGZBW3JXDC55CYIXB5NAXMCEKJA
 EOF

--- a/scripts/dev-seed.sql
+++ b/scripts/dev-seed.sql
@@ -1,0 +1,88 @@
+-- Deterministic local-only seed data for scripts/dev-bootstrap.sh.
+-- Values are placeholders for development and must not be reused as credentials.
+
+WITH borrower AS (
+  INSERT INTO borrowers (wallet_address)
+  VALUES ('GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGZBW3JXDC55CYIXB5NAXMCEKJA')
+  ON CONFLICT (wallet_address) DO UPDATE
+    SET updated_at = now()
+  RETURNING id
+),
+credit_line AS (
+  INSERT INTO credit_lines (
+    borrower_id,
+    credit_limit,
+    currency,
+    status,
+    interest_rate_bps
+  )
+  SELECT id, 1000.00000000, 'USDC', 'active', 750
+  FROM borrower
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM credit_lines cl
+    JOIN borrowers b ON b.id = cl.borrower_id
+    WHERE b.wallet_address = 'GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGZBW3JXDC55CYIXB5NAXMCEKJA'
+  )
+  RETURNING id, borrower_id
+),
+selected_credit_line AS (
+  SELECT id, borrower_id FROM credit_line
+  UNION ALL
+  SELECT cl.id, cl.borrower_id
+  FROM credit_lines cl
+  JOIN borrowers b ON b.id = cl.borrower_id
+  WHERE b.wallet_address = 'GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGZBW3JXDC55CYIXB5NAXMCEKJA'
+  LIMIT 1
+),
+risk_seed AS (
+  INSERT INTO risk_evaluations (
+    borrower_id,
+    risk_score,
+    suggested_limit,
+    interest_rate_bps,
+    inputs,
+    evaluated_at,
+    expires_at
+  )
+  SELECT
+    borrower_id,
+    82,
+    1000.00000000,
+    750,
+    '[{"name":"local_seed","value":82,"weight":1,"description":"Deterministic local development seed"}]'::jsonb,
+    now(),
+    now() + interval '7 days'
+  FROM selected_credit_line
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM risk_evaluations re
+    WHERE re.borrower_id = selected_credit_line.borrower_id
+      AND re.inputs @> '[{"name":"local_seed"}]'::jsonb
+  )
+  RETURNING id
+)
+INSERT INTO transactions (
+  credit_line_id,
+  type,
+  amount,
+  currency,
+  status,
+  blockchain_tx_hash,
+  processed_at
+)
+SELECT
+  id,
+  'borrow',
+  125.00000000,
+  'USDC',
+  'confirmed',
+  'local-seed-tx-001',
+  now()
+FROM selected_credit_line
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM transactions tx
+  WHERE tx.credit_line_id = selected_credit_line.id
+    AND tx.blockchain_tx_hash = 'local-seed-tx-001'
+);

--- a/scripts/dev-seed.sql
+++ b/scripts/dev-seed.sql
@@ -1,5 +1,6 @@
 -- Deterministic local-only seed data for scripts/dev-bootstrap.sh.
 -- Values are placeholders for development and must not be reused as credentials.
+-- Safe to re-run: inserts are guarded with NOT EXISTS / ON CONFLICT.
 
 WITH borrower AS (
   INSERT INTO borrowers (wallet_address)
@@ -26,6 +27,9 @@ credit_line AS (
   )
   RETURNING id, borrower_id
 ),
+-- Prefer the row just inserted (via RETURNING). Sibling CTEs cannot see each
+-- other's table mutations under a single snapshot, so fall back to a SELECT
+-- only when the insert CTE was a no-op.
 selected_credit_line AS (
   SELECT id, borrower_id FROM credit_line
   UNION ALL
@@ -33,7 +37,7 @@ selected_credit_line AS (
   FROM credit_lines cl
   JOIN borrowers b ON b.id = cl.borrower_id
   WHERE b.wallet_address = 'GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGZBW3JXDC55CYIXB5NAXMCEKJA'
-  LIMIT 1
+    AND NOT EXISTS (SELECT 1 FROM credit_line)
 ),
 risk_seed AS (
   INSERT INTO risk_evaluations (
@@ -72,17 +76,19 @@ INSERT INTO transactions (
   processed_at
 )
 SELECT
-  id,
+  scl.id,
   'borrow',
   125.00000000,
   'USDC',
   'confirmed',
   'local-seed-tx-001',
   now()
-FROM selected_credit_line
+FROM selected_credit_line scl
+-- Reference risk_seed so the data-modifying CTE is never optimised away.
+CROSS JOIN LATERAL (SELECT count(*) AS n FROM risk_seed) rs
 WHERE NOT EXISTS (
   SELECT 1
   FROM transactions tx
-  WHERE tx.credit_line_id = selected_credit_line.id
+  WHERE tx.credit_line_id = scl.id
     AND tx.blockchain_tx_hash = 'local-seed-tx-001'
 );


### PR DESCRIPTION
Closes #205.

## Summary
- Adds `scripts/dev-bootstrap.sh` as a single local onboarding entrypoint for dependency install, Docker Compose Postgres startup, DB readiness, migrations, schema validation, and seed loading.
- Adds deterministic local-only seed data in `scripts/dev-seed.sql` without committing real secrets.
- Updates `.env.example` to match the Compose host database default and placeholder local API key.
- Documents the bootstrap flow, flags, secrets policy, and common failure modes in the README.
- Adds a proper `.gitattributes` (LF for shell/SQL/source) and removes unused `.gitattributes.txt`.
- Fixes migration 005's fresh-DB index target so bootstrap migrations do not reference the non-existent `credit_lines.wallet_address` column.

## Validation
- `npm ci` passes.
- `bash -n scripts/dev-bootstrap.sh` passes.
- `npm run dev:bootstrap -- --skip-install --skip-compose --skip-migrate --skip-seed` passes with Git Bash on PATH.
- `npm run validate:spec` passes.
- Full Docker-backed bootstrap was not run in this environment (`docker` not on PATH).
- Remaining `npm test` failures match pre-existing baseline issues on `main` (e.g. missing `log` in `drawWebhookService`, unrelated repo assertions) — not introduced by this PR.