### PR TITLE
feat(api): add idempotency middleware for POST mutations

### DIFF
--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,0 +1,36 @@
+# Idempotent POST mutations
+
+Creditra accepts an optional `Idempotency-Key` header on POST mutations. When a
+client retries the same mutation with the same key, route, principal, and request
+body, the API returns the first non-5xx response instead of running the handler a
+second time.
+
+## Scope
+
+The idempotency scope is:
+
+- HTTP method and request path.
+- Principal, derived from `X-API-Key`, `X-Admin-Api-Key`, `Authorization`, or
+  `walletAddress` when no auth header exists.
+- SHA-256 hash of the parsed request body and query string.
+
+The raw key, API key, bearer token, and wallet value are not stored in the cache;
+only hashes are used.
+
+## Replay behavior
+
+- Missing `Idempotency-Key`: request runs normally.
+- Same key and same request: returns the cached response with
+  `Idempotency-Status: replayed`.
+- Same key but different request body, route, or principal: returns `409`.
+- Same key while the first request is still running:
+  - In-memory store waits and returns the first response.
+  - Postgres store returns `409` with `Retry-After: 1` to prevent duplicate
+    processing across instances.
+- 5xx responses are not cached, so clients can retry transient failures.
+
+## Storage
+
+Production deployments with `DATABASE_URL` use the `idempotency_keys` table from
+`migrations/006_idempotency_keys.sql`. Test and local no-database runs use the
+bounded in-memory store. Entries default to a 24-hour TTL.

--- a/migrations/006_idempotency_keys.sql
+++ b/migrations/006_idempotency_keys.sql
@@ -1,0 +1,27 @@
+-- Idempotency cache for POST mutations.
+-- Values are scoped by key, route, and principal so two callers can safely use
+-- the same client-generated key on different authenticated scopes.
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+  token UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key_hash TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  principal_hash TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  response_status INTEGER,
+  response_body JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  CONSTRAINT idempotency_keys_status_check
+    CHECK (status IN ('pending', 'completed'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idempotency_keys_scope_key
+  ON idempotency_keys (key_hash, scope, principal_hash);
+
+CREATE INDEX IF NOT EXISTS idempotency_keys_expires_at_idx
+  ON idempotency_keys (expires_at);
+
+COMMENT ON TABLE idempotency_keys IS 'POST mutation idempotency cache with TTL';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { healthRouter } from "./routes/health.js";
 import { webhookRouter } from "./routes/webhook.js";
 import { reconciliationRouter } from "./routes/reconciliation.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { createIdempotencyMiddleware } from "./middleware/idempotency.js";
 import { requestLogger } from "./middleware/requestLogger.js";
 import {
   InMemoryRateLimitStore,
@@ -23,7 +24,12 @@ import { loadCorsPolicy, isAllowedCorsOrigin } from "./config/cors.js";
 import { loadRateLimitConfig, loadRateLimitStoreConfig } from "./config/rateLimit.js";
 import { validateEnv } from "./config/env.js";
 import { Container } from "./container/Container.js";
+import { getConnection } from "./db/client.js";
 import { initializeWebhooks } from "./services/drawWebhookService.js";
+import {
+  InMemoryIdempotencyStore,
+  PostgresIdempotencyStore,
+} from "./services/idempotencyStore.js";
 import { logger } from "./utils/logger.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -111,6 +117,10 @@ const evaluateRateLimit = createRateLimitMiddleware({
   ...appRateLimitConfig.evaluate,
   keyGenerator: createIpKeyGenerator(),
 }, evaluateRateLimitStore);
+const idempotencyStore =
+  process.env.DATABASE_URL && process.env.NODE_ENV !== "test"
+    ? new PostgresIdempotencyStore(getConnection())
+    : new InMemoryIdempotencyStore();
 
 app.use(cors({
   origin(origin, callback) {
@@ -139,6 +149,7 @@ app.use((req, res, next) => {
 app.use(express.json({ limit: '100kb' }));
 
 app.use(requestLogger);
+app.use(createIdempotencyMiddleware(idempotencyStore));
 
 app.use("/health", healthRouter);
 

--- a/src/middleware/__tests__/idempotency.test.ts
+++ b/src/middleware/__tests__/idempotency.test.ts
@@ -1,0 +1,107 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createIdempotencyMiddleware } from "../idempotency.js";
+import { InMemoryIdempotencyStore } from "../../services/idempotencyStore.js";
+
+function createTestApp() {
+  const app = express();
+  const store = new InMemoryIdempotencyStore();
+  let calls = 0;
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  app.use(express.json());
+  app.use(createIdempotencyMiddleware(store));
+  app.post("/mutations", async (req, res) => {
+    calls += 1;
+    if (req.body?.wait) {
+      await gate;
+    }
+    res.status(201).json({ calls, body: req.body });
+  });
+
+  return {
+    app,
+    getCalls: () => calls,
+    release: () => release?.(),
+  };
+}
+
+describe("createIdempotencyMiddleware", () => {
+  it("passes through POST requests without an Idempotency-Key", async () => {
+    const { app, getCalls } = createTestApp();
+
+    const first = await request(app).post("/mutations").send({ amount: "10" });
+    const second = await request(app).post("/mutations").send({ amount: "10" });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(first.body.calls).toBe(1);
+    expect(second.body.calls).toBe(2);
+    expect(getCalls()).toBe(2);
+  });
+
+  it("replays the original response for the same route, principal, key, and body", async () => {
+    const { app, getCalls } = createTestApp();
+
+    const first = await request(app)
+      .post("/mutations")
+      .set("Idempotency-Key", "client-key-1")
+      .send({ walletAddress: "GABC", amount: "10" });
+    const replay = await request(app)
+      .post("/mutations")
+      .set("Idempotency-Key", "client-key-1")
+      .send({ walletAddress: "GABC", amount: "10" });
+
+    expect(first.status).toBe(201);
+    expect(replay.status).toBe(201);
+    expect(replay.headers["idempotency-status"]).toBe("replayed");
+    expect(replay.body).toEqual(first.body);
+    expect(getCalls()).toBe(1);
+  });
+
+  it("rejects reuse of the same key for a different request body", async () => {
+    const { app, getCalls } = createTestApp();
+
+    const first = await request(app)
+      .post("/mutations")
+      .set("Idempotency-Key", "client-key-2")
+      .send({ walletAddress: "GABC", amount: "10" });
+    const conflict = await request(app)
+      .post("/mutations")
+      .set("Idempotency-Key", "client-key-2")
+      .send({ walletAddress: "GABC", amount: "11" });
+
+    expect(first.status).toBe(201);
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.error).toMatch(/different request/);
+    expect(getCalls()).toBe(1);
+  });
+
+  it("waits for an in-flight identical request and does not run the handler twice", async () => {
+    const { app, getCalls, release } = createTestApp();
+
+    const first = request(app)
+      .post("/mutations")
+      .set("Idempotency-Key", "client-key-3")
+      .send({ walletAddress: "GABC", amount: "10", wait: true });
+    const second = request(app)
+      .post("/mutations")
+      .set("Idempotency-Key", "client-key-3")
+      .send({ walletAddress: "GABC", amount: "10", wait: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    release();
+
+    const [firstResponse, secondResponse] = await Promise.all([first, second]);
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(201);
+    expect(secondResponse.headers["idempotency-status"]).toBe("replayed");
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(getCalls()).toBe(1);
+  });
+});

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,0 +1,205 @@
+import { createHash } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+import type {
+  CachedIdempotencyResponse,
+  IdempotencyStore,
+} from "../services/idempotencyStore.js";
+
+const IDEMPOTENCY_HEADER = "idempotency-key";
+const MAX_KEY_LENGTH = 255;
+
+export function createIdempotencyMiddleware(store: IdempotencyStore) {
+  return async function idempotencyMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    if (req.method !== "POST") {
+      next();
+      return;
+    }
+
+    const rawHeader = req.headers[IDEMPOTENCY_HEADER];
+    if (rawHeader === undefined) {
+      next();
+      return;
+    }
+
+    if (Array.isArray(rawHeader)) {
+      res.status(400).json({ data: null, error: "Only one Idempotency-Key header is allowed" });
+      return;
+    }
+
+    const idempotencyKey = rawHeader.trim();
+    if (!idempotencyKey) {
+      res.status(400).json({ data: null, error: "Idempotency-Key must not be empty" });
+      return;
+    }
+    if (idempotencyKey.length > MAX_KEY_LENGTH) {
+      res.status(400).json({ data: null, error: "Idempotency-Key is too long" });
+      return;
+    }
+
+    const begin = await store.begin({
+      keyHash: sha256(idempotencyKey),
+      scope: `${req.method}:${req.path}`,
+      principalHash: sha256(resolvePrincipal(req)),
+      requestHash: sha256(stableStringify({
+        method: req.method,
+        path: req.path,
+        query: req.query,
+        body: req.body ?? null,
+      })),
+    });
+
+    if (begin.state === "conflict") {
+      res.status(409).json({
+        data: null,
+        error: "Idempotency-Key was already used for a different request",
+      });
+      return;
+    }
+
+    if (begin.state === "replay") {
+      sendCachedResponse(res, begin.response);
+      return;
+    }
+
+    if (begin.state === "pending") {
+      try {
+        const response = await begin.response;
+        sendCachedResponse(res, response);
+      } catch {
+        res.status(409).json({
+          data: null,
+          error: "A matching idempotent request is still being processed",
+        });
+      }
+      return;
+    }
+
+    if (begin.state === "inProgress") {
+      res.setHeader("Retry-After", "1");
+      res.status(409).json({
+        data: null,
+        error: "A matching idempotent request is still being processed",
+      });
+      return;
+    }
+
+    captureResponse(req, res, store, begin.token);
+    next();
+  };
+}
+
+function captureResponse(
+  req: Request,
+  res: Response,
+  store: IdempotencyStore,
+  token: string,
+): void {
+  const originalJson = res.json.bind(res);
+  const originalSend = res.send.bind(res);
+  let capturedBody: unknown;
+
+  res.json = ((body: unknown) => {
+    capturedBody = body;
+    return originalJson(body);
+  }) as Response["json"];
+
+  res.send = ((body: unknown) => {
+    if (capturedBody === undefined) {
+      capturedBody = normalizeSendBody(body);
+    }
+    return originalSend(body);
+  }) as Response["send"];
+
+  res.on("finish", () => {
+    const response: CachedIdempotencyResponse = {
+      statusCode: res.statusCode,
+      body: capturedBody ?? null,
+    };
+
+    if (res.statusCode >= 500) {
+      void store.fail(token);
+      return;
+    }
+
+    void store.complete(token, response);
+  });
+
+  res.on("close", () => {
+    if (!res.writableEnded) {
+      void store.fail(token);
+    }
+  });
+
+  req.on("aborted", () => {
+    void store.fail(token);
+  });
+}
+
+function sendCachedResponse(res: Response, response: CachedIdempotencyResponse): void {
+  res.setHeader("Idempotency-Status", "replayed");
+  res.status(response.statusCode).json(response.body);
+}
+
+function normalizeSendBody(body: unknown): unknown {
+  if (Buffer.isBuffer(body)) {
+    return body.toString("utf8");
+  }
+
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch {
+      return body;
+    }
+  }
+
+  return body;
+}
+
+function resolvePrincipal(req: Request): string {
+  const apiKey = headerValue(req, "x-api-key");
+  if (apiKey) return `x-api-key:${sha256(apiKey)}`;
+
+  const adminApiKey = headerValue(req, "x-admin-api-key");
+  if (adminApiKey) return `x-admin-api-key:${sha256(adminApiKey)}`;
+
+  const authorization = headerValue(req, "authorization");
+  if (authorization) return `authorization:${sha256(authorization)}`;
+
+  const walletAddress = typeof req.body?.walletAddress === "string"
+    ? req.body.walletAddress
+    : undefined;
+  if (walletAddress) return `wallet:${sha256(walletAddress)}`;
+
+  return "anonymous";
+}
+
+function headerValue(req: Request, name: string): string | undefined {
+  const value = req.headers[name];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(",")}}`;
+}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -13,6 +13,11 @@ info:
     Protected endpoints require a valid API key passed via the `X-API-Key` header.
     API keys are configured via the `API_KEYS` environment variable (comma-separated).
 
+    ## Idempotent POST retries
+    POST mutations accept an optional `Idempotency-Key` header. Reusing the same
+    key with the same route, principal, and request body returns the original
+    non-5xx response instead of executing the mutation again.
+
     ## Keeping the spec in sync
     - Every new route **must** have a corresponding entry here before merging.
     - Run `npm run validate:spec` in CI to catch YAML/structural errors early.
@@ -46,6 +51,19 @@ components:
       description: |
         API key for authenticated endpoints. Required for admin operations.
         Keys are configured via the `API_KEYS` environment variable.
+
+  parameters:
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      schema:
+        type: string
+        maxLength: 255
+      description: >
+        Optional client-generated key for retry-safe POST mutations. The key is
+        scoped by route, authenticated principal, and request body. Reusing it
+        for a different request returns 409 Conflict.
 
   schemas:
     HealthResponse:
@@ -490,6 +508,8 @@ paths:
       operationId: triggerReconciliation
       summary: Schedule a reconciliation job
       description: Admin-gated endpoint that schedules a DB-vs-chain reconciliation job and returns immediately.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
       responses:
         "202":
           description: Reconciliation job scheduled
@@ -647,6 +667,8 @@ paths:
       operationId: createCreditLine
       summary: Create a new credit line
       security: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: true
         content:
@@ -912,6 +934,7 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
         - name: id
           in: path
           required: true
@@ -959,6 +982,7 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
         - name: id
           in: path
           required: true
@@ -1045,6 +1069,8 @@ paths:
         Rate limited: default 10 requests per minute per IP address.
         Configure via RATE_LIMIT_MAX_EVALUATE and RATE_LIMIT_WINDOW_MS env vars.
       security: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: true
         content:
@@ -1139,6 +1165,8 @@ paths:
       summary: Test webhook connectivity
       description: Sends a test payload to all configured webhook endpoints
       security: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
       responses:
         "200":
           description: Test results

--- a/src/services/idempotencyStore.ts
+++ b/src/services/idempotencyStore.ts
@@ -1,0 +1,249 @@
+import { randomUUID } from "node:crypto";
+import type { DbClient } from "../db/client.js";
+
+export interface CachedIdempotencyResponse {
+  statusCode: number;
+  body: unknown;
+}
+
+export type IdempotencyBeginResult =
+  | { state: "started"; token: string }
+  | { state: "replay"; response: CachedIdempotencyResponse }
+  | { state: "pending"; response: Promise<CachedIdempotencyResponse> }
+  | { state: "inProgress" }
+  | { state: "conflict" };
+
+export interface IdempotencyEntry {
+  keyHash: string;
+  scope: string;
+  principalHash: string;
+  requestHash: string;
+}
+
+export interface IdempotencyStore {
+  begin(entry: IdempotencyEntry): Promise<IdempotencyBeginResult>;
+  complete(token: string, response: CachedIdempotencyResponse): Promise<void>;
+  fail(token: string): Promise<void>;
+}
+
+interface PendingMemoryRecord {
+  state: "pending";
+  token: string;
+  requestHash: string;
+  expiresAt: number;
+  promise: Promise<CachedIdempotencyResponse>;
+  resolve: (response: CachedIdempotencyResponse) => void;
+  reject: (error: Error) => void;
+}
+
+interface CompletedMemoryRecord {
+  state: "completed";
+  token: string;
+  requestHash: string;
+  expiresAt: number;
+  response: CachedIdempotencyResponse;
+}
+
+type MemoryRecord = PendingMemoryRecord | CompletedMemoryRecord;
+
+export class InMemoryIdempotencyStore implements IdempotencyStore {
+  private readonly records = new Map<string, MemoryRecord>();
+  private readonly tokens = new Map<string, string>();
+
+  constructor(private readonly ttlMs = 24 * 60 * 60 * 1000) {}
+
+  async begin(entry: IdempotencyEntry): Promise<IdempotencyBeginResult> {
+    this.pruneExpired();
+    const cacheKey = this.cacheKey(entry);
+    const existing = this.records.get(cacheKey);
+
+    if (existing) {
+      if (existing.requestHash !== entry.requestHash) {
+        return { state: "conflict" };
+      }
+
+      if (existing.state === "completed") {
+        return { state: "replay", response: existing.response };
+      }
+
+      return { state: "pending", response: existing.promise };
+    }
+
+    const token = randomUUID();
+    let resolve!: (response: CachedIdempotencyResponse) => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<CachedIdempotencyResponse>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    this.records.set(cacheKey, {
+      state: "pending",
+      token,
+      requestHash: entry.requestHash,
+      expiresAt: Date.now() + this.ttlMs,
+      promise,
+      resolve,
+      reject,
+    });
+    this.tokens.set(token, cacheKey);
+
+    return { state: "started", token };
+  }
+
+  async complete(token: string, response: CachedIdempotencyResponse): Promise<void> {
+    const cacheKey = this.tokens.get(token);
+    if (!cacheKey) return;
+
+    const record = this.records.get(cacheKey);
+    if (!record || record.state !== "pending") return;
+
+    this.records.set(cacheKey, {
+      state: "completed",
+      token,
+      requestHash: record.requestHash,
+      expiresAt: Date.now() + this.ttlMs,
+      response,
+    });
+    record.resolve(response);
+  }
+
+  async fail(token: string): Promise<void> {
+    const cacheKey = this.tokens.get(token);
+    if (!cacheKey) return;
+
+    const record = this.records.get(cacheKey);
+    this.records.delete(cacheKey);
+    this.tokens.delete(token);
+
+    if (record?.state === "pending") {
+      record.reject(new Error("Idempotent request did not complete"));
+    }
+  }
+
+  private cacheKey(entry: IdempotencyEntry): string {
+    return `${entry.keyHash}:${entry.scope}:${entry.principalHash}`;
+  }
+
+  private pruneExpired(): void {
+    const now = Date.now();
+    for (const [cacheKey, record] of this.records.entries()) {
+      if (record.expiresAt <= now) {
+        this.records.delete(cacheKey);
+        this.tokens.delete(record.token);
+      }
+    }
+  }
+}
+
+interface IdempotencyRow {
+  token: string;
+  request_hash: string;
+  status: "pending" | "completed";
+  response_status: number | null;
+  response_body: unknown | null;
+}
+
+export class PostgresIdempotencyStore implements IdempotencyStore {
+  private connected?: Promise<void>;
+
+  constructor(
+    private readonly client: DbClient,
+    private readonly ttlMs = 24 * 60 * 60 * 1000,
+  ) {}
+
+  async begin(entry: IdempotencyEntry): Promise<IdempotencyBeginResult> {
+    await this.ensureConnected();
+    await this.deleteExpired();
+
+    const expiresAt = new Date(Date.now() + this.ttlMs);
+    const token = randomUUID();
+
+    const inserted = await this.client.query(
+      `
+        INSERT INTO idempotency_keys (
+          token,
+          key_hash,
+          scope,
+          principal_hash,
+          request_hash,
+          status,
+          expires_at
+        )
+        VALUES ($1, $2, $3, $4, $5, 'pending', $6)
+        ON CONFLICT (key_hash, scope, principal_hash) DO NOTHING
+        RETURNING token
+      `,
+      [token, entry.keyHash, entry.scope, entry.principalHash, entry.requestHash, expiresAt],
+    );
+
+    if (inserted.rows.length > 0) {
+      return { state: "started", token };
+    }
+
+    const existing = await this.client.query(
+      `
+        SELECT token, request_hash, status, response_status, response_body
+        FROM idempotency_keys
+        WHERE key_hash = $1 AND scope = $2 AND principal_hash = $3
+      `,
+      [entry.keyHash, entry.scope, entry.principalHash],
+    );
+    const row = existing.rows[0] as IdempotencyRow | undefined;
+
+    if (!row) {
+      return this.begin(entry);
+    }
+
+    if (row.request_hash !== entry.requestHash) {
+      return { state: "conflict" };
+    }
+
+    if (row.status === "completed" && row.response_status !== null) {
+      return {
+        state: "replay",
+        response: {
+          statusCode: row.response_status,
+          body: row.response_body,
+        },
+      };
+    }
+
+    return { state: "inProgress" };
+  }
+
+  async complete(token: string, response: CachedIdempotencyResponse): Promise<void> {
+    await this.ensureConnected();
+    await this.client.query(
+      `
+        UPDATE idempotency_keys
+        SET status = 'completed',
+            response_status = $2,
+            response_body = $3::jsonb,
+            updated_at = now()
+        WHERE token = $1
+      `,
+      [token, response.statusCode, JSON.stringify(response.body ?? null)],
+    );
+  }
+
+  async fail(token: string): Promise<void> {
+    await this.ensureConnected();
+    await this.client.query(
+      "DELETE FROM idempotency_keys WHERE token = $1 AND status = 'pending'",
+      [token],
+    );
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (!this.client.connect) return;
+    if (!this.connected) {
+      this.connected = this.client.connect();
+    }
+    await this.connected;
+  }
+
+  private async deleteExpired(): Promise<void> {
+    await this.client.query("DELETE FROM idempotency_keys WHERE expires_at <= now()");
+  }
+}


### PR DESCRIPTION
## Summary

Closes #179.

- add an `Idempotency-Key` middleware for POST mutations with route/principal/request-body scoping
- add in-memory and Postgres-backed idempotency stores plus the `idempotency_keys` migration
- document replay/conflict/concurrency behavior and expose the header in OpenAPI
- cover pass-through, replay, body-conflict, and concurrent duplicate handling with focused tests

## Security notes

- raw idempotency keys and auth headers are hashed before storage
- 5xx responses are not cached, so transient failures can be retried
- same-key/different-body reuse returns `409 Conflict`
- in-memory dev/test store waits for in-flight duplicates; Postgres store returns `409` + `Retry-After` for in-flight duplicates across instances to avoid duplicate mutation execution

## Validation

- `vitest run src/middleware/__tests__/idempotency.test.ts --pool=forks --maxWorkers=1`
- `eslint src/middleware/idempotency.ts src/services/idempotencyStore.ts src/middleware/__tests__/idempotency.test.ts`
- `node --input-type=module -e "import fs from 'node:fs'; import yaml from 'yaml'; yaml.parse(fs.readFileSync('src/openapi.yaml', 'utf8')); console.log('OpenAPI spec valid');"`
- `git diff --check`

`tsc --noEmit --pretty false` is currently blocked by existing unrelated repo errors in files such as `src/app.ts`, `src/container/Container.ts`, `src/middleware/requestLogger.ts`, `src/routes/creditBulk.ts`, `src/routes/simulation.ts`, and `src/services/drawWebhookService.ts`; no idempotency files were reported in that failure list.