### PR TITLE
chore(reliability): standardize outbound HTTP retry policy

### DIFF
--- a/docs/http-timeouts.md
+++ b/docs/http-timeouts.md
@@ -7,6 +7,7 @@ This document describes the HTTP timeout configuration for outbound requests to 
 All outbound HTTP requests use configurable connect and read timeouts to prevent hanging connections and ensure predictable failure modes. The timeout utilities provide:
 
 - Separate connect and read timeout configuration
+- Standard retry policy for safe outbound methods
 - Structured error types for timeout vs. other failures
 - Environment-based configuration with sensible defaults
 - Consistent error handling across all HTTP clients
@@ -19,6 +20,10 @@ All outbound HTTP requests use configurable connect and read timeouts to prevent
 |----------|---------|-------------|
 | `HTTP_CONNECT_TIMEOUT_MS` | `5000` | Connection timeout in milliseconds (time to establish TCP connection) |
 | `HTTP_READ_TIMEOUT_MS` | `10000` | Read timeout in milliseconds (time to receive complete response after connection) |
+| `HTTP_MAX_RETRIES` | `2` | Retry attempts after the first request |
+| `HTTP_RETRY_DELAY_MS` | `250` | Initial retry delay in milliseconds |
+| `HTTP_MAX_RETRY_DELAY_MS` | `2000` | Maximum retry delay in milliseconds |
+| `HTTP_RETRY_JITTER_MS` | `100` | Random jitter added to retry delays |
 
 ### Setting Timeouts
 
@@ -32,6 +37,8 @@ HTTP_READ_TIMEOUT_MS=8000
 ```bash
 export HTTP_CONNECT_TIMEOUT_MS=5000
 export HTTP_READ_TIMEOUT_MS=15000
+export HTTP_MAX_RETRIES=2
+export HTTP_RETRY_DELAY_MS=250
 ```
 
 **Docker Compose:**
@@ -97,6 +104,31 @@ const response = await fetchWithTimeout('https://slow-api.example.com/data', {
   },
 });
 ```
+
+### Retry Policy
+
+`fetchWithTimeout` retries transient failures for safe methods only:
+
+- Methods retried by default: `GET`, `HEAD`, `OPTIONS`
+- Retryable statuses: `408`, `429`, `500`, `502`, `503`, `504`
+- Retryable failures: network errors and timeout errors
+- Delay: exponential backoff with jitter, honoring `Retry-After` when present
+
+POST, PUT, PATCH, and DELETE are not retried automatically. A caller must opt in
+by setting `retry.retryMethods` when the request is known to be idempotent:
+
+```typescript
+await fetchWithTimeout('https://api.example.com/retry-safe-post', {
+  method: 'POST',
+  body: JSON.stringify(payload),
+  retry: {
+    maxRetries: 2,
+    retryMethods: ['POST'],
+  },
+});
+```
+
+Disable retries entirely for a request with `retry: false`.
 
 ## Error Handling
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -20,6 +20,7 @@ import { Router } from 'express';
 import { ok } from '../utils/response.js';
 import { getConnection } from '../db/client.js';
 import { resolveConfig } from '../services/horizonListener.js';
+import { fetchWithTimeout } from '../utils/fetchWithTimeout.js';
 
 export const healthRouter = Router();
 
@@ -87,10 +88,13 @@ async function checkHorizon(): Promise<DependencyHealth> {
      const horizonUrl = resolveConfig().horizonUrl;
 
      try {
-          const controller = new AbortController();
-          const timeout = setTimeout(() => controller.abort(), HORIZON_CHECK_TIMEOUT_MS);
-          const response = await fetch(horizonUrl, { signal: controller.signal });
-          clearTimeout(timeout);
+          const response = await fetchWithTimeout(horizonUrl, {
+               timeouts: {
+                    connectTimeoutMs: HORIZON_CHECK_TIMEOUT_MS,
+                    readTimeoutMs: 0,
+               },
+               retry: false,
+          });
 
           if (!response.ok) {
                return { status: 'degraded', message: `Horizon returned HTTP ${response.status}` };

--- a/src/services/__tests__/drawWebhookService.test.ts
+++ b/src/services/__tests__/drawWebhookService.test.ts
@@ -18,6 +18,40 @@ import {
     resolveWebhookConfig,
 } from "../drawWebhookService.js";
 import type { HorizonEvent } from "../horizonListener.js";
+import {
+    setWebhookDeliveryStateStore,
+    type DeliveryRecord,
+    type WebhookDeliveryStateStore,
+} from "../webhookDeliveryState.js";
+
+function createTestDeliveryStore(): WebhookDeliveryStateStore {
+    const records = new Map<string, DeliveryRecord>();
+    const key = (drawId: string, url: string) => `${drawId}::${url}`;
+
+    return {
+        isDelivered(drawId: string, url: string): boolean {
+            return records.get(key(drawId, url))?.status === "delivered";
+        },
+        record(record: Omit<DeliveryRecord, "updatedAt">): void {
+            records.set(key(record.drawId, record.url), {
+                ...record,
+                updatedAt: new Date().toISOString(),
+            });
+        },
+        deadLetters(): DeliveryRecord[] {
+            return [...records.values()].filter((record) => record.status === "dead_letter");
+        },
+        counts() {
+            const values = [...records.values()];
+            return {
+                total: values.length,
+                delivered: values.filter((record) => record.status === "delivered").length,
+                failed: values.filter((record) => record.status === "failed").length,
+                deadLetter: values.filter((record) => record.status === "dead_letter").length,
+            };
+        },
+    };
+}
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -30,6 +64,7 @@ describe("DrawWebhookService", () => {
         serviceLoggerMock.warn.mockReset();
         serviceLoggerMock.error.mockReset();
         vi.useFakeTimers();
+        setWebhookDeliveryStateStore(createTestDeliveryStore());
         
         // Clear environment variables
         delete process.env.WEBHOOK_URLS;
@@ -410,7 +445,7 @@ describe("DrawWebhookService", () => {
             expect(results[0]).toEqual({
                 url: "https://example.com/webhook",
                 reachable: false,
-                error: "Connection refused"
+                error: "HTTP request failed: Connection refused"
             });
         });
 
@@ -453,6 +488,7 @@ describe("DrawWebhookService", () => {
             const firstCallSignature = mockFetch.mock.calls[0][1].headers["X-Webhook-Signature"];
 
             mockFetch.mockClear();
+            setWebhookDeliveryStateStore(createTestDeliveryStore());
             await sendDrawConfirmationWebhook(event);
             const secondCallSignature = mockFetch.mock.calls[0][1].headers["X-Webhook-Signature"];
 
@@ -470,7 +506,13 @@ describe("DrawWebhookService", () => {
             initializeWebhooks();
 
             // Mock fetch that never resolves
-            mockFetch.mockImplementation(() => new Promise(() => {}));
+            mockFetch.mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+                init.signal.addEventListener("abort", () => {
+                    reject(Object.assign(new Error("The operation was aborted"), {
+                        name: "AbortError",
+                    }));
+                });
+            }));
 
             const event: HorizonEvent = {
                 ledger: 1000,
@@ -497,7 +539,7 @@ describe("DrawWebhookService", () => {
                 url: "https://example.com/webhook",
                 success: false,
                 attempt: 1,
-                error: "Request timeout"
+                error: "HTTP read timeout after 1000ms: https://example.com/webhook"
             });
         });
     });

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -18,7 +18,10 @@
 import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
 import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
-import { redactLogArgs } from "../utils/logRedact.js";
+import { fetchWithTimeout } from "../utils/fetchWithTimeout.js";
+import { createServiceLogger } from "../utils/serviceLogger.js";
+
+const log = createServiceLogger("DrawWebhookService");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -129,19 +132,9 @@ async function deliverWebhook(
     timeoutMs: number
 ): Promise<{ success: boolean; status?: number; error?: string }> {
     const payloadString = JSON.stringify(payload);
-    
-    const controller = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
     try {
-        const timeout = new Promise<never>((_resolve, reject) => {
-            timeoutId = setTimeout(() => {
-                controller.abort();
-                reject(new Error("Request timeout"));
-            }, timeoutMs);
-        });
-
-        const response = await Promise.race([fetch(url, {
+        const response = await fetchWithTimeout(url, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
@@ -150,12 +143,12 @@ async function deliverWebhook(
                 "User-Agent": "Creditra-Webhook/1.0"
             },
             body: payloadString,
-            signal: controller.signal
-        }), timeout]);
-
-        if (timeoutId !== undefined) {
-            clearTimeout(timeoutId);
-        }
+            timeouts: {
+                connectTimeoutMs: timeoutMs,
+                readTimeoutMs: 0,
+            },
+            retry: false,
+        });
 
         if (response.ok) {
             return { success: true, status: response.status };
@@ -167,12 +160,8 @@ async function deliverWebhook(
             };
         }
     } catch (error) {
-        if (timeoutId !== undefined) {
-            clearTimeout(timeoutId);
-        }
-        
         if (error instanceof Error) {
-            throw error.name === "AbortError" ? new Error("Request timeout") : error;
+            throw error;
         }
         
         throw new Error("Unknown error occurred");
@@ -341,10 +330,12 @@ export async function sendDrawConfirmationWebhook(
                 attempts,
                 lastError
             });
-            console.warn(...redactLogArgs([
-                "[DrawWebhook] Delivery permanently failed, moved to dead-letter:",
-                { drawId: payload.data.drawId, url, attempts, lastError }
-            ]));
+            log.warn("webhook:delivery:dead-letter", {
+                drawId: payload.data.drawId,
+                url,
+                attempts,
+                lastError,
+            });
 
             return { url, success: false, attempt: attempts, error: lastError };
         }

--- a/src/services/providers/ExternalApiRiskProvider.ts
+++ b/src/services/providers/ExternalApiRiskProvider.ts
@@ -1,4 +1,5 @@
 import type { IRiskProvider, RiskProviderOutput } from "./IRiskProvider.js";
+import { fetchWithTimeout } from "../../utils/fetchWithTimeout.js";
 
 export interface ExternalApiRiskProviderConfig {
   baseUrl: string;
@@ -29,26 +30,25 @@ export class ExternalApiRiskProvider implements IRiskProvider {
   }
 
   async evaluate(walletAddress: string): Promise<RiskProviderOutput> {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.config.timeoutMs);
-
     let response: Response;
     try {
-      response = await fetch(`${this.config.baseUrl}/evaluate`, {
+      response = await fetchWithTimeout(`${this.config.baseUrl}/evaluate`, {
         method: "POST",
-        signal: controller.signal,
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${this.config.apiKey}`,
         },
         body: JSON.stringify({ walletAddress }),
+        timeouts: {
+          connectTimeoutMs: this.config.timeoutMs,
+          readTimeoutMs: 0,
+        },
+        retry: false,
       });
     } catch (err) {
       throw new Error(
         `External risk provider request failed: ${(err as Error).message}`,
       );
-    } finally {
-      clearTimeout(timer);
     }
 
     if (!response.ok) {

--- a/src/utils/__tests__/fetchWithTimeout.test.ts
+++ b/src/utils/__tests__/fetchWithTimeout.test.ts
@@ -5,6 +5,7 @@ import {
   HttpTimeoutError,
   HttpRequestError,
   getDefaultTimeouts,
+  getDefaultRetryConfig,
 } from '../fetchWithTimeout.js';
 
 describe('fetchWithTimeout', () => {
@@ -34,6 +35,17 @@ describe('fetchWithTimeout', () => {
 
       delete process.env['HTTP_CONNECT_TIMEOUT_MS'];
       delete process.env['HTTP_READ_TIMEOUT_MS'];
+    });
+  });
+
+  describe('getDefaultRetryConfig', () => {
+    it('should return safe-method retry defaults', () => {
+      const retry = getDefaultRetryConfig();
+
+      expect(retry.maxRetries).toBe(2);
+      expect(retry.retryDelayMs).toBe(250);
+      expect(retry.retryMethods).toEqual(['GET', 'HEAD', 'OPTIONS']);
+      expect(retry.retryStatuses).toContain(503);
     });
   });
 
@@ -70,6 +82,7 @@ describe('fetchWithTimeout', () => {
 
       const promise = fetchWithTimeout('https://example.com/slow', {
         timeouts: { connectTimeoutMs: 50, readTimeoutMs: 50 },
+        retry: false,
       });
 
       vi.advanceTimersByTime(100);
@@ -83,7 +96,7 @@ describe('fetchWithTimeout', () => {
       global.fetch = vi.fn().mockRejectedValue(networkError);
 
       await expect(
-        fetchWithTimeout('https://example.com/fail')
+        fetchWithTimeout('https://example.com/fail', { retry: false })
       ).rejects.toThrow(HttpRequestError);
     });
 
@@ -113,6 +126,72 @@ describe('fetchWithTimeout', () => {
           signal: expect.any(AbortSignal),
         })
       );
+    });
+
+    it('should retry retryable statuses for safe methods', async () => {
+      const retryableResponse = new Response('Service Unavailable', {
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+      const okResponse = new Response('OK', { status: 200 });
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce(retryableResponse)
+        .mockResolvedValueOnce(okResponse);
+
+      const response = await fetchWithTimeout('https://example.com/api', {
+        retry: {
+          maxRetries: 1,
+          retryDelayMs: 0,
+          retryJitterMs: 0,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not retry POST requests by default', async () => {
+      const retryableResponse = new Response('Service Unavailable', {
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+      global.fetch = vi.fn().mockResolvedValue(retryableResponse);
+
+      const response = await fetchWithTimeout('https://example.com/api', {
+        method: 'POST',
+        retry: {
+          maxRetries: 1,
+          retryDelayMs: 0,
+          retryJitterMs: 0,
+        },
+      });
+
+      expect(response.status).toBe(503);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry POST only when explicitly allowed', async () => {
+      const retryableResponse = new Response('Service Unavailable', {
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+      const okResponse = new Response('OK', { status: 200 });
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce(retryableResponse)
+        .mockResolvedValueOnce(okResponse);
+
+      const response = await fetchWithTimeout('https://example.com/api', {
+        method: 'POST',
+        retry: {
+          maxRetries: 1,
+          retryDelayMs: 0,
+          retryJitterMs: 0,
+          retryMethods: ['POST'],
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/utils/fetchWithTimeout.ts
+++ b/src/utils/fetchWithTimeout.ts
@@ -18,6 +18,23 @@ export interface FetchTimeoutConfig {
 export interface FetchWithTimeoutOptions extends RequestInit {
   /** Custom timeout configuration (overrides defaults) */
   timeouts?: Partial<FetchTimeoutConfig>;
+  /** Retry policy. Defaults to safe-method retries; set false to disable. */
+  retry?: Partial<FetchRetryConfig> | false;
+}
+
+export interface FetchRetryConfig {
+  /** Number of retry attempts after the initial request */
+  maxRetries: number;
+  /** Initial retry delay in milliseconds */
+  retryDelayMs: number;
+  /** Maximum retry delay in milliseconds */
+  maxRetryDelayMs: number;
+  /** Random jitter added to each delay in milliseconds */
+  retryJitterMs: number;
+  /** HTTP statuses that are considered transient */
+  retryStatuses: number[];
+  /** HTTP methods that may be retried automatically */
+  retryMethods: string[];
 }
 
 /**
@@ -65,6 +82,17 @@ export function getDefaultTimeouts(): FetchTimeoutConfig {
   return {
     connectTimeoutMs: parseInt(process.env['HTTP_CONNECT_TIMEOUT_MS'] ?? '5000', 10),
     readTimeoutMs: parseInt(process.env['HTTP_READ_TIMEOUT_MS'] ?? '10000', 10),
+  };
+}
+
+export function getDefaultRetryConfig(): FetchRetryConfig {
+  return {
+    maxRetries: parseInt(process.env['HTTP_MAX_RETRIES'] ?? '2', 10),
+    retryDelayMs: parseInt(process.env['HTTP_RETRY_DELAY_MS'] ?? '250', 10),
+    maxRetryDelayMs: parseInt(process.env['HTTP_MAX_RETRY_DELAY_MS'] ?? '2000', 10),
+    retryJitterMs: parseInt(process.env['HTTP_RETRY_JITTER_MS'] ?? '100', 10),
+    retryStatuses: [408, 429, 500, 502, 503, 504],
+    retryMethods: ['GET', 'HEAD', 'OPTIONS'],
   };
 }
 
@@ -116,6 +144,49 @@ export async function fetchWithTimeout(
   url: string,
   options: FetchWithTimeoutOptions = {}
 ): Promise<Response> {
+  const retry = resolveRetryConfig(options.retry);
+  const method = (options.method ?? 'GET').toUpperCase();
+  const canRetryMethod = retry.retryMethods.includes(method);
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retry.maxRetries; attempt++) {
+    try {
+      const response = await fetchOnceWithTimeout(url, options);
+
+      if (
+        attempt < retry.maxRetries &&
+        canRetryMethod &&
+        retry.retryStatuses.includes(response.status)
+      ) {
+        await waitBeforeRetry(attempt, retry, response);
+        continue;
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error;
+
+      if (
+        attempt >= retry.maxRetries ||
+        !canRetryMethod ||
+        isCallerAbort(options.signal ?? undefined, error)
+      ) {
+        throw error;
+      }
+
+      await waitBeforeRetry(attempt, retry);
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new HttpRequestError('HTTP request failed with unknown error', url);
+}
+
+async function fetchOnceWithTimeout(
+  url: string,
+  options: FetchWithTimeoutOptions = {}
+): Promise<Response> {
   const defaults = getDefaultTimeouts();
   const timeouts: FetchTimeoutConfig = {
     connectTimeoutMs: options.timeouts?.connectTimeoutMs ?? defaults.connectTimeoutMs,
@@ -162,6 +233,74 @@ export async function fetchWithTimeout(
     // Unknown error type
     throw new HttpRequestError('HTTP request failed with unknown error', url);
   }
+}
+
+function resolveRetryConfig(
+  overrides: FetchWithTimeoutOptions['retry'],
+): FetchRetryConfig {
+  if (overrides === false) {
+    return {
+      ...getDefaultRetryConfig(),
+      maxRetries: 0,
+    };
+  }
+
+  const defaults = getDefaultRetryConfig();
+  return {
+    ...defaults,
+    ...overrides,
+    retryStatuses: overrides?.retryStatuses ?? defaults.retryStatuses,
+    retryMethods: (overrides?.retryMethods ?? defaults.retryMethods).map((method) => method.toUpperCase()),
+  };
+}
+
+async function waitBeforeRetry(
+  attempt: number,
+  retry: FetchRetryConfig,
+  response?: Response,
+): Promise<void> {
+  const retryAfterMs = parseRetryAfterMs(response);
+  const backoffMs = Math.min(
+    retry.maxRetryDelayMs,
+    retry.retryDelayMs * 2 ** attempt,
+  );
+  const jitterMs = retry.retryJitterMs > 0
+    ? Math.floor(Math.random() * retry.retryJitterMs)
+    : 0;
+  const delayMs = retryAfterMs ?? backoffMs + jitterMs;
+
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function parseRetryAfterMs(response?: Response): number | undefined {
+  const header = response?.headers.get('retry-after');
+  if (!header) {
+    return undefined;
+  }
+
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  const dateMs = Date.parse(header);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return undefined;
+}
+
+function isCallerAbort(signal: AbortSignal | undefined, error: unknown): boolean {
+  return Boolean(
+    signal?.aborted &&
+    error instanceof Error &&
+    error.name === 'AbortError',
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #199.

## Summary
- add a shared outbound HTTP retry policy to `fetchWithTimeout`, with configurable retry counts, delay, max delay, jitter, retry statuses, and retry-safe methods
- keep automatic retries limited to safe methods by default (`GET`, `HEAD`, `OPTIONS`)
- migrate Horizon health checks, external API risk requests, and draw webhook delivery onto the shared timeout helper
- keep side-effecting POST calls (`ExternalApiRiskProvider` and draw webhooks) on `retry: false` unless a caller explicitly opts in
- document the environment variables and retry/timeout behavior in `docs/http-timeouts.md`

## Safety notes
- POST is not retried by default, so duplicate webhook delivery or external risk submissions are not introduced by the shared helper.
- The draw webhook timeout path now uses the shared timeout error, and its dead-letter log uses the service logger instead of the previously missing helper reference.

## Validation
- `vitest run src/utils/__tests__/fetchWithTimeout.test.ts src/services/providers/__tests__/ExternalApiRiskProvider.test.ts src/services/__tests__/drawWebhookService.test.ts src/__tests__/health.test.ts tests/health.test.ts --pool=forks --maxWorkers=1` (50 passed)
- `eslint src/utils/fetchWithTimeout.ts src/utils/__tests__/fetchWithTimeout.test.ts src/services/providers/ExternalApiRiskProvider.ts src/services/drawWebhookService.ts src/services/__tests__/drawWebhookService.test.ts src/routes/health.ts`
- `git diff --check`
- `tsc --noEmit --pretty false` still fails on existing unrelated main-branch errors in `src/app.ts`, `src/container/Container.ts`, `src/middleware/requestLogger.ts`, `src/routes/credit*.ts`, `src/routes/dashboard.ts`, and `src/routes/simulation.ts`; no files changed by this PR are reported.
