### PR TITLE
feat(security): add admin audit log pipeline

### DIFF
--- a/docs/admin-audit-log.md
+++ b/docs/admin-audit-log.md
@@ -1,0 +1,30 @@
+# Admin Audit Log
+
+Privileged operator actions are recorded in an append-only audit log for compliance review.
+
+Recorded actions include API key issue/revoke, maintenance mode updates, and credit-line admin transitions such as suspend and close. Each record stores an actor fingerprint, action, target, redacted before/after snapshots, a correlation id, and a hash chained to the previous record.
+
+## Security Model
+
+- Raw admin API keys are never stored as actors. The actor value is a SHA-256 fingerprint prefix.
+- Sensitive fields whose names look like passwords, tokens, API keys, private keys, seeds, or authorization headers are stored as `[REDACTED]`.
+- The application exposes no update or delete path for audit records.
+- Each record includes `previousHash` and `hash` so missing or edited records can be detected by replaying the chain.
+
+## Query Endpoint
+
+`GET /api/admin/audit-logs`
+
+Headers:
+
+- `X-Admin-Api-Key`: required.
+
+Query parameters:
+
+- `limit`: 1-100 records, default 50.
+- `cursor`: pagination cursor returned by the previous response.
+- `actor`: exact actor fingerprint.
+- `action`: exact action name, such as `api_key.issued`.
+- `targetType`: exact target type, such as `credit_line`.
+
+Response body uses the standard `{ data, error }` envelope. `data.items` is newest first.

--- a/migrations/006_admin_audit_logs.sql
+++ b/migrations/006_admin_audit_logs.sql
@@ -1,0 +1,22 @@
+-- Append-only admin audit log for privileged operator actions.
+CREATE TABLE IF NOT EXISTS admin_audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor TEXT NOT NULL,
+  action TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id TEXT,
+  before JSONB,
+  after JSONB,
+  correlation_id TEXT NOT NULL,
+  previous_hash TEXT,
+  hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS admin_audit_logs_created_at_idx ON admin_audit_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS admin_audit_logs_actor_idx ON admin_audit_logs (actor);
+CREATE INDEX IF NOT EXISTS admin_audit_logs_action_idx ON admin_audit_logs (action);
+CREATE INDEX IF NOT EXISTS admin_audit_logs_target_idx ON admin_audit_logs (target_type, target_id);
+CREATE UNIQUE INDEX IF NOT EXISTS admin_audit_logs_hash_key ON admin_audit_logs (hash);
+
+COMMENT ON TABLE admin_audit_logs IS 'Append-only, tamper-evident audit log for privileged admin actions';

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,12 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
 import { apiKeysRouter } from './routes/apiKeys.js';
+import { adminAuditRouter } from './routes/adminAudit.js';
+import { maintenanceRouter } from './routes/maintenance.js';
+import { metricsRouter, recordRequest } from './routes/metrics.js';
+import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
 
 export function createApp() {
   const app = express();
@@ -28,6 +32,7 @@ export function createApp() {
   app.use('/api/credit', creditRouter);
   app.use('/api/risk', riskRouter);
   app.use('/api/admin/api-keys', apiKeysRouter);
+  app.use('/api/admin/audit-logs', adminAuditRouter);
 
   // Admin-only route to toggle maintenance mode.
   app.use('/api/admin/maintenance', maintenanceRouter);

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -56,6 +56,7 @@ export class Container {
   private _reconciliationService!: ReconciliationService;
   private _reconciliationWorker!: ReconciliationWorker;
   private _sorobanClient!: SorobanRpcClient;
+  private _dashboardSummaryService!: DashboardSummaryService;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
 
@@ -156,6 +157,10 @@ export class Container {
 
   get reconciliationWorker(): ReconciliationWorker {
     return this._reconciliationWorker;
+  }
+
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
   }
 
   /** Process-wide in-process domain event bus for credit lifecycle events. */

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -33,6 +33,8 @@ tags:
     description: Draw confirmation webhook management
   - name: Reconciliation
     description: Admin control plane for DB-vs-chain reconciliation
+  - name: Admin
+    description: Privileged operator controls and audit review
 
 security:
   - ApiKeyAuth: []
@@ -446,6 +448,62 @@ components:
 
     # ── Error Schemas ─────────────────────────────────────────────────────────
 
+    AdminAuditRecord:
+      type: object
+      required: [id, actor, action, targetType, targetId, correlationId, createdAt, previousHash, hash]
+      properties:
+        id:
+          type: string
+          format: uuid
+        actor:
+          type: string
+          description: SHA-256 fingerprint of the admin actor secret, never the raw key
+          example: sha256:2a6f2d8c9e5b1a0c
+        action:
+          type: string
+          example: api_key.issued
+        targetType:
+          type: string
+          example: api_key
+        targetId:
+          type: string
+          nullable: true
+        before:
+          nullable: true
+        after:
+          nullable: true
+        correlationId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        previousHash:
+          type: string
+          nullable: true
+        hash:
+          type: string
+          pattern: "^[a-f0-9]{64}$"
+
+    AdminAuditLogResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [items, nextCursor, hasMore]
+          properties:
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/AdminAuditRecord"
+            nextCursor:
+              type: string
+              nullable: true
+            hasMore:
+              type: boolean
+        error:
+          type: string
+          nullable: true
+
     ErrorResponse:
       type: object
       required: [error]
@@ -483,6 +541,56 @@ paths:
                 service: creditra-backend
 
   # ── Reconciliation Routes ───────────────────────────────────────────────────
+
+  /api/admin/audit-logs:
+    get:
+      tags: [Admin]
+      operationId: listAdminAuditLogs
+      summary: List append-only admin audit records
+      description: Returns newest-first audit records for privileged operator actions. Requires `X-Admin-Api-Key`.
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: actor
+          in: query
+          schema:
+            type: string
+        - name: action
+          in: query
+          schema:
+            type: string
+        - name: targetType
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Admin audit records
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAuditLogResponse"
+        "400":
+          description: Invalid pagination or filter parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Missing or invalid admin API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /api/reconciliation/trigger:
     post:

--- a/src/routes/__tests__/adminAudit.route.test.ts
+++ b/src/routes/__tests__/adminAudit.route.test.ts
@@ -1,0 +1,97 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { apiKeysRouter } from '../apiKeys.js';
+import { adminAuditRouter } from '../adminAudit.js';
+import { creditRouter } from '../credit.js';
+import { ADMIN_KEY_HEADER } from '../../middleware/adminAuth.js';
+import { defaultAdminAuditLog, actorFingerprint } from '../../services/adminAuditLog.js';
+import { _resetStore, createCreditLine } from '../../services/creditService.js';
+
+const ADMIN = 'admin-secret-for-tests';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/api-keys', apiKeysRouter);
+  app.use('/api/admin/audit-logs', adminAuditRouter);
+  app.use('/api/credit', creditRouter);
+  return app;
+}
+
+describe('admin audit log routes', () => {
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN;
+    defaultAdminAuditLog.resetForTests();
+    _resetStore();
+  });
+
+  it('requires admin authentication', async () => {
+    const res = await request(buildApp()).get('/api/admin/audit-logs');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns audit records written by admin handlers without exposing secrets', async () => {
+    const app = buildApp();
+
+    const created = await request(app)
+      .post('/api/admin/api-keys')
+      .set(ADMIN_KEY_HEADER, ADMIN)
+      .send({ label: 'ops-key' });
+
+    expect(created.status).toBe(201);
+
+    const audit = await request(app)
+      .get('/api/admin/audit-logs')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+
+    expect(audit.status).toBe(200);
+    expect(audit.body.data.items).toHaveLength(1);
+    expect(audit.body.data.items[0]).toMatchObject({
+      actor: actorFingerprint(ADMIN),
+      action: 'api_key.issued',
+      targetType: 'api_key',
+      targetId: created.body.data.id,
+    });
+    expect(JSON.stringify(audit.body)).not.toContain(created.body.data.key);
+  });
+
+  it('supports action filters and limit validation', async () => {
+    const app = buildApp();
+    await request(app).post('/api/admin/api-keys').set(ADMIN_KEY_HEADER, ADMIN).send({ label: 'x' });
+
+    const filtered = await request(app)
+      .get('/api/admin/audit-logs?action=api_key.issued&limit=1')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.data.items).toHaveLength(1);
+    expect(filtered.body.data.hasMore).toBe(false);
+
+    const invalid = await request(app)
+      .get('/api/admin/audit-logs?limit=101')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(invalid.status).toBe(400);
+  });
+
+  it('records credit-line admin transitions', async () => {
+    const app = buildApp();
+    createCreditLine('line-1');
+
+    const suspended = await request(app)
+      .post('/api/credit/lines/line-1/suspend')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(suspended.status).toBe(200);
+
+    const audit = await request(app)
+      .get('/api/admin/audit-logs?action=credit_line.suspended')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(audit.status).toBe(200);
+    expect(audit.body.data.items[0]).toMatchObject({
+      action: 'credit_line.suspended',
+      targetType: 'credit_line',
+      targetId: 'line-1',
+    });
+    expect(audit.body.data.items[0].before.status).toBe('active');
+    expect(audit.body.data.items[0].after.status).toBe('suspended');
+  });
+});

--- a/src/routes/adminAudit.ts
+++ b/src/routes/adminAudit.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { adminAuth } from '../middleware/adminAuth.js';
+import { defaultAdminAuditLog } from '../services/adminAuditLog.js';
+import { ok, fail } from '../utils/response.js';
+
+export const adminAuditRouter = Router();
+
+function parseLimit(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+adminAuditRouter.get('/', adminAuth, (req, res) => {
+  const limit = parseLimit(req.query.limit);
+  if (req.query.limit !== undefined && (limit === undefined || limit < 1 || limit > 100)) {
+    fail(res, 'limit must be an integer between 1 and 100', 400);
+    return;
+  }
+
+  ok(res, defaultAdminAuditLog.list({
+    limit,
+    cursor: typeof req.query.cursor === 'string' ? req.query.cursor : undefined,
+    actor: typeof req.query.actor === 'string' ? req.query.actor : undefined,
+    action: typeof req.query.action === 'string' ? req.query.action : undefined,
+    targetType: typeof req.query.targetType === 'string' ? req.query.targetType : undefined,
+  }));
+});

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -16,6 +16,8 @@
 import { Router, type Request, type Response } from 'express';
 import { adminAuth } from '../middleware/adminAuth.js';
 import { defaultApiKeyStore } from '../services/apiKeyStore.js';
+import { defaultAdminAuditLog } from '../services/adminAuditLog.js';
+import { adminActorFromRequest } from '../utils/adminActor.js';
 
 export const apiKeysRouter = Router();
 
@@ -25,6 +27,12 @@ apiKeysRouter.post('/', adminAuth, (req: Request, res: Response) => {
     ? req.body.label.trim()
     : 'unlabelled';
   const { id, plaintext, metadata } = defaultApiKeyStore.issue(label);
+  defaultAdminAuditLog.record({
+    actor: adminActorFromRequest(req),
+    action: 'api_key.issued',
+    target: { type: 'api_key', id },
+    after: { id, label, status: metadata.status },
+  });
   res.status(201).json({
     data: {
       id,
@@ -48,10 +56,18 @@ apiKeysRouter.get('/audit', adminAuth, (_req: Request, res: Response) => {
 
 /** DELETE /api/admin/api-keys/:id — revoke (enters grace period). */
 apiKeysRouter.delete('/:id', adminAuth, (req: Request, res: Response) => {
+  const before = defaultApiKeyStore.list().find((key) => key.id === req.params.id);
   const ok = defaultApiKeyStore.revoke(req.params.id);
   if (!ok) {
     res.status(404).json({ data: null, error: 'API key not found' });
     return;
   }
+  defaultAdminAuditLog.record({
+    actor: adminActorFromRequest(req),
+    action: 'api_key.revoked',
+    target: { type: 'api_key', id: req.params.id },
+    before,
+    after: { id: req.params.id, status: 'revoked' },
+  });
   res.json({ data: { id: req.params.id, status: 'revoked' }, error: null });
 });

--- a/src/routes/credit.ts
+++ b/src/routes/credit.ts
@@ -32,6 +32,8 @@ import {
 import type { DrawBody, RepayBody } from '../schemas/index.js';
 import { Container } from '../container/Container.js';
 import { adminAuth } from '../middleware/adminAuth.js';
+import { defaultAdminAuditLog } from '../services/adminAuditLog.js';
+import { adminActorFromRequest } from '../utils/adminActor.js';
 import { ok, fail } from '../utils/response.js';
 import {
   CreditLineNotFoundError,
@@ -40,6 +42,7 @@ import {
   TransactionType,
   suspendCreditLine,
   closeCreditLine,
+  getCreditLine,
   getTransactions,
   submitDrawRequest,
   submitRepayRequest,
@@ -246,7 +249,16 @@ creditRouter.post(
   adminAuth,
   (req: Request, res: Response): void => {
     try {
+      const before = getCreditLine(req.params.id);
+      const beforeSnapshot = before ? { ...before, events: [...before.events] } : undefined;
       const line = suspendCreditLine(req.params.id);
+      defaultAdminAuditLog.record({
+        actor: adminActorFromRequest(req),
+        action: 'credit_line.suspended',
+        target: { type: 'credit_line', id: req.params.id },
+        before: beforeSnapshot,
+        after: line,
+      });
       res.status(200).json({ data: line, message: 'Credit line suspended.', error: null });
     } catch (err) {
       handleServiceError(err, res);
@@ -259,7 +271,16 @@ creditRouter.post(
   adminAuth,
   (req: Request, res: Response): void => {
     try {
+      const before = getCreditLine(req.params.id);
+      const beforeSnapshot = before ? { ...before, events: [...before.events] } : undefined;
       const line = closeCreditLine(req.params.id);
+      defaultAdminAuditLog.record({
+        actor: adminActorFromRequest(req),
+        action: 'credit_line.closed',
+        target: { type: 'credit_line', id: req.params.id },
+        before: beforeSnapshot,
+        after: line,
+      });
       res.status(200).json({ data: line, message: 'Credit line closed.', error: null });
     } catch (err) {
       handleServiceError(err, res);

--- a/src/routes/maintenance.ts
+++ b/src/routes/maintenance.ts
@@ -5,6 +5,8 @@ import {
     setMaintenanceMode,
     getAuditLog,
 } from '../middleware/maintenanceMode.js';
+import { defaultAdminAuditLog } from '../services/adminAuditLog.js';
+import { adminActorFromRequest } from '../utils/adminActor.js';
 
 export const maintenanceRouter = Router();
 
@@ -39,7 +41,15 @@ maintenanceRouter.post('/', adminAuth, (req, res) => {
             ? req.headers['x-admin-api-key'][0]
             : req.headers['x-admin-api-key']) ?? 'unknown';
 
+    const before = { enabled: isMaintenanceModeEnabled() };
     setMaintenanceMode(enabled, actor);
+    defaultAdminAuditLog.record({
+        actor: adminActorFromRequest(req),
+        action: 'maintenance_mode.updated',
+        target: { type: 'maintenance_mode' },
+        before,
+        after: { enabled: isMaintenanceModeEnabled() },
+    });
 
     res.json({
         maintenanceMode: isMaintenanceModeEnabled(),

--- a/src/services/__tests__/adminAuditLog.test.ts
+++ b/src/services/__tests__/adminAuditLog.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { AdminAuditLog, actorFingerprint, redactAuditValue } from '../adminAuditLog.js';
+
+describe('AdminAuditLog', () => {
+  it('redacts sensitive fields recursively before storing records', () => {
+    const log = new AdminAuditLog(() => new Date('2026-07-09T00:00:00.000Z'));
+
+    const record = log.record({
+      actor: actorFingerprint('admin-secret'),
+      action: 'api_key.issued',
+      target: { type: 'api_key', id: 'key-1' },
+      after: {
+        id: 'key-1',
+        plaintextKey: 'ck_secret',
+        nested: { authorization: 'Bearer secret' },
+      },
+    });
+
+    expect(record.after).toEqual({
+      id: 'key-1',
+      plaintextKey: '[REDACTED]',
+      nested: { authorization: '[REDACTED]' },
+    });
+    expect(JSON.stringify(record)).not.toContain('ck_secret');
+    expect(JSON.stringify(record)).not.toContain('Bearer secret');
+  });
+
+  it('creates a tamper-evident hash chain', () => {
+    const log = new AdminAuditLog(() => new Date('2026-07-09T00:00:00.000Z'));
+
+    const first = log.record({
+      actor: 'actor-1',
+      action: 'maintenance_mode.updated',
+      target: { type: 'maintenance_mode' },
+      after: { enabled: true },
+      correlationId: 'corr-1',
+    });
+    const second = log.record({
+      actor: 'actor-1',
+      action: 'maintenance_mode.updated',
+      target: { type: 'maintenance_mode' },
+      after: { enabled: false },
+      correlationId: 'corr-2',
+    });
+
+    expect(first.previousHash).toBeNull();
+    expect(first.hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(second.previousHash).toBe(first.hash);
+    expect(second.hash).not.toBe(first.hash);
+  });
+
+  it('filters and paginates newest-first records', () => {
+    let tick = 0;
+    const log = new AdminAuditLog(() => new Date(1000 + tick++));
+
+    log.record({ actor: 'a', action: 'one', target: { type: 'credit_line', id: '1' } });
+    log.record({ actor: 'b', action: 'two', target: { type: 'api_key', id: '2' } });
+    log.record({ actor: 'a', action: 'three', target: { type: 'credit_line', id: '3' } });
+
+    const firstPage = log.list({ targetType: 'credit_line', limit: 1 });
+    expect(firstPage.items).toHaveLength(1);
+    expect(firstPage.items[0].action).toBe('three');
+    expect(firstPage.hasMore).toBe(true);
+
+    const secondPage = log.list({ targetType: 'credit_line', limit: 1, cursor: firstPage.nextCursor ?? undefined });
+    expect(secondPage.items).toHaveLength(1);
+    expect(secondPage.items[0].action).toBe('one');
+    expect(secondPage.hasMore).toBe(false);
+  });
+
+  it('exposes redaction as a standalone helper', () => {
+    expect(redactAuditValue({ token: 'secret', keep: 'value' })).toEqual({
+      token: '[REDACTED]',
+      keep: 'value',
+    });
+  });
+});

--- a/src/services/adminAuditLog.ts
+++ b/src/services/adminAuditLog.ts
@@ -1,0 +1,142 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+export interface AuditTarget {
+  type: string;
+  id?: string;
+}
+
+export interface AdminAuditRecordInput {
+  actor: string;
+  action: string;
+  target: AuditTarget;
+  before?: unknown;
+  after?: unknown;
+  correlationId?: string;
+}
+
+export interface AdminAuditRecord {
+  id: string;
+  actor: string;
+  action: string;
+  targetType: string;
+  targetId: string | null;
+  before: unknown;
+  after: unknown;
+  correlationId: string;
+  createdAt: string;
+  previousHash: string | null;
+  hash: string;
+}
+
+export interface AdminAuditQuery {
+  limit?: number;
+  cursor?: string;
+  actor?: string;
+  action?: string;
+  targetType?: string;
+}
+
+export interface AdminAuditPage {
+  items: AdminAuditRecord[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const REDACTED = '[REDACTED]';
+const SENSITIVE_KEY_PATTERN = /(authorization|secret|password|plaintext|token|api[-_]?key|private[-_]?key|seed|mnemonic)/i;
+
+export function actorFingerprint(actorSecret: string): string {
+  const digest = createHash('sha256').update(actorSecret, 'utf8').digest('hex').slice(0, 16);
+  return `sha256:${digest}`;
+}
+
+export function redactAuditValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactAuditValue(item));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : redactAuditValue(nested),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function computeHash(record: Omit<AdminAuditRecord, 'hash'>): string {
+  return createHash('sha256').update(stableStringify(record), 'utf8').digest('hex');
+}
+
+export class AdminAuditLog {
+  private readonly records: AdminAuditRecord[] = [];
+
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  record(input: AdminAuditRecordInput): AdminAuditRecord {
+    const previousHash = this.records.at(-1)?.hash ?? null;
+    const withoutHash: Omit<AdminAuditRecord, 'hash'> = {
+      id: randomUUID(),
+      actor: input.actor,
+      action: input.action,
+      targetType: input.target.type,
+      targetId: input.target.id ?? null,
+      before: redactAuditValue(input.before),
+      after: redactAuditValue(input.after),
+      correlationId: input.correlationId ?? randomUUID(),
+      createdAt: this.now().toISOString(),
+      previousHash,
+    };
+    const record = Object.freeze({
+      ...withoutHash,
+      hash: computeHash(withoutHash),
+    });
+    this.records.push(record);
+    return record;
+  }
+
+  list(query: AdminAuditQuery = {}): AdminAuditPage {
+    const limit = Math.min(Math.max(query.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+    const start = query.cursor ? Number.parseInt(query.cursor, 10) : 0;
+    const offset = Number.isFinite(start) && start > 0 ? start : 0;
+    const filtered = this.records
+      .filter((record) => !query.actor || record.actor === query.actor)
+      .filter((record) => !query.action || record.action === query.action)
+      .filter((record) => !query.targetType || record.targetType === query.targetType)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+    const items = filtered.slice(offset, offset + limit);
+    const nextOffset = offset + items.length;
+
+    return {
+      items,
+      nextCursor: nextOffset < filtered.length ? String(nextOffset) : null,
+      hasMore: nextOffset < filtered.length,
+    };
+  }
+
+  resetForTests(): void {
+    this.records.length = 0;
+  }
+}
+
+export const defaultAdminAuditLog = new AdminAuditLog();

--- a/src/utils/adminActor.ts
+++ b/src/utils/adminActor.ts
@@ -1,0 +1,9 @@
+import type { Request } from 'express';
+import { ADMIN_KEY_HEADER } from '../middleware/adminAuth.js';
+import { actorFingerprint } from '../services/adminAuditLog.js';
+
+export function adminActorFromRequest(req: Request): string {
+  const header = req.headers[ADMIN_KEY_HEADER];
+  const raw = Array.isArray(header) ? header[0] : header;
+  return raw ? actorFingerprint(raw) : 'unknown';
+}


### PR DESCRIPTION
Closes #180.

## Summary
- add an append-only admin audit log service with actor fingerprints, redacted before/after snapshots, correlation ids, and a tamper-evident hash chain
- add `admin_audit_logs` migration with timestamp, actor, action, target, correlation id, and hash indexes
- add `GET /api/admin/audit-logs` with pagination and filters for actor, action, and target type
- record audit entries from existing admin handlers for API key issue/revoke, maintenance mode updates, and credit-line suspend/close transitions
- document the audit log security model and update `src/openapi.yaml`
- fix app wiring imports so the admin audit route, existing maintenance route, and metrics route are mounted through `createApp()`

## Security notes
- raw admin API keys are not stored as actors; the actor value is a SHA-256 fingerprint prefix
- fields named like secrets, tokens, passwords, plaintext keys, private keys, seeds, or authorization headers are stored as `[REDACTED]`
- there are no update/delete paths for audit records in the application service

## Validation
- `vitest run src/services/__tests__/adminAuditLog.test.ts src/routes/__tests__/adminAudit.route.test.ts src/routes/__tests__/apiKeys.route.test.ts tests/maintenanceMode.test.ts src/db/migrations.test.ts src/db/validate-schema.test.ts --pool=forks --maxWorkers=1` (49 passed)
- `eslint src/services/adminAuditLog.ts src/services/__tests__/adminAuditLog.test.ts src/routes/adminAudit.ts src/routes/__tests__/adminAudit.route.test.ts src/utils/adminActor.ts src/routes/apiKeys.ts src/routes/maintenance.ts src/routes/credit.ts src/app.ts src/container/Container.ts`
- `node --input-type=module -e "import fs from 'node:fs'; import yaml from 'yaml'; yaml.parse(fs.readFileSync('src/openapi.yaml', 'utf8')); console.log('OpenAPI spec valid');"`
- `git diff --check`
- `tsc --noEmit --pretty false` still fails on existing unrelated main-branch errors in `src/container/__tests__/Container.contract.test.ts`, `src/middleware/requestLogger.ts`, `src/routes/__tests__/metrics.test.ts`, `src/routes/creditBulk.ts`, `src/routes/simulation.ts`, and `src/services/drawWebhookService.ts`; no new admin-audit files are reported.
