### PR TITLE
feat(security): verify inbound webhook signatures

### DIFF
--- a/docs/inbound-webhooks.md
+++ b/docs/inbound-webhooks.md
@@ -1,0 +1,57 @@
+# Inbound Webhook Signatures
+
+Creditra accepts signed partner webhooks at `POST /api/inbound-webhooks/events`.
+
+Every inbound webhook must include:
+
+```http
+Content-Type: application/json
+X-Timestamp: 2026-07-09T00:00:00.000Z
+X-Nonce: unique-message-id
+X-Signature: sha256=<hex HMAC>
+```
+
+The signature is HMAC-SHA256 over the exact raw JSON request body plus the timestamp and nonce:
+
+```text
+hex(hmac_sha256(INBOUND_WEBHOOK_SECRET, X-Timestamp + "." + X-Nonce + "." + raw_body))
+```
+
+The server rejects:
+
+- missing or malformed signature headers
+- signatures that do not match in constant time
+- timestamps outside `INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS` (default 5 minutes)
+- repeated `X-Nonce` values inside the freshness window
+- requests when `INBOUND_WEBHOOK_SECRET` is not configured
+
+## Replay Protection
+
+The nonce is claimed after signature and timestamp verification. A second request with the same nonce inside the timestamp tolerance window receives `401 Replay detected`.
+
+The application ships an in-process nonce store for tests and single-process deployments, plus migration `006_inbound_webhook_nonces.sql` for durable deployments that back the nonce cache with PostgreSQL.
+
+## Example
+
+```ts
+import { createHmac } from "node:crypto";
+
+const timestamp = new Date().toISOString();
+const nonce = crypto.randomUUID();
+const body = JSON.stringify({ event: "partner.updated" });
+const signature = createHmac("sha256", process.env.INBOUND_WEBHOOK_SECRET!)
+  .update(`${timestamp}.${nonce}.`)
+  .update(body)
+  .digest("hex");
+
+await fetch("https://api.example.com/api/inbound-webhooks/events", {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    "x-timestamp": timestamp,
+    "x-nonce": nonce,
+    "x-signature": `sha256=${signature}`,
+  },
+  body,
+});
+```

--- a/migrations/006_inbound_webhook_nonces.sql
+++ b/migrations/006_inbound_webhook_nonces.sql
@@ -1,0 +1,11 @@
+-- Replay protection store for inbound signed webhooks.
+CREATE TABLE IF NOT EXISTS inbound_webhook_nonces (
+  nonce TEXT PRIMARY KEY,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS inbound_webhook_nonces_expires_at_idx
+  ON inbound_webhook_nonces (expires_at);
+
+COMMENT ON TABLE inbound_webhook_nonces IS 'Nonce cache for inbound webhook replay protection';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,11 @@ import { creditRouter } from "./routes/credit.js";
 import { riskRouter } from "./routes/risk.js";
 import { healthRouter } from "./routes/health.js";
 import { webhookRouter } from "./routes/webhook.js";
+import { inboundWebhookRouter } from "./routes/inboundWebhooks.js";
 import { reconciliationRouter } from "./routes/reconciliation.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { requestLogger } from "./middleware/requestLogger.js";
+import { captureRawBody } from "./middleware/rawBody.js";
 import {
   InMemoryRateLimitStore,
   RedisRateLimitStore,
@@ -136,7 +138,7 @@ app.use((req, res, next) => {
 
 // 100 kb hard cap; body-parser emits a 413 that errorHandler converts to a
 // structured response.
-app.use(express.json({ limit: '100kb' }));
+app.use(express.json({ limit: '100kb', verify: captureRawBody }));
 
 app.use(requestLogger);
 
@@ -153,6 +155,7 @@ app.use("/api/risk/evaluate", evaluateRateLimit);
 app.use("/api/risk/wallet", defaultRateLimit);
 app.use("/api/risk", riskRouter);
 app.use("/api/webhooks", webhookRouter);
+app.use("/api/inbound-webhooks", inboundWebhookRouter);
 app.use("/api/reconciliation", reconciliationRouter);
 
 // Global error handler — must be registered after routes

--- a/src/middleware/__tests__/inboundWebhookSignature.test.ts
+++ b/src/middleware/__tests__/inboundWebhookSignature.test.ts
@@ -1,0 +1,124 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { captureRawBody } from '../rawBody.js';
+import {
+  createInboundWebhookSignatureMiddleware,
+  signInboundWebhookPayload,
+} from '../inboundWebhookSignature.js';
+import { InMemoryInboundWebhookNonceStore } from '../../services/inboundWebhookNonceStore.js';
+
+const SECRET = 'inbound-webhook-secret';
+const NOW = Date.parse('2026-07-09T00:00:00.000Z');
+
+function buildApp(store = new InMemoryInboundWebhookNonceStore(() => NOW)) {
+  const app = express();
+  app.use(express.json({ verify: captureRawBody }));
+  app.post(
+    '/webhook',
+    createInboundWebhookSignatureMiddleware({
+      secret: SECRET,
+      nonceStore: store,
+      now: () => NOW,
+      toleranceMs: 5 * 60 * 1000,
+    }),
+    (_req, res) => res.status(202).json({ accepted: true }),
+  );
+  return app;
+}
+
+function signedHeaders(body: string, nonce = 'nonce-1', timestamp = '2026-07-09T00:00:00.000Z') {
+  return {
+    'x-timestamp': timestamp,
+    'x-nonce': nonce,
+    'x-signature': signInboundWebhookPayload(SECRET, timestamp, nonce, Buffer.from(body)),
+  };
+}
+
+describe('createInboundWebhookSignatureMiddleware', () => {
+  beforeEach(() => {
+    delete process.env.INBOUND_WEBHOOK_SECRET;
+  });
+
+  it('accepts a valid signed webhook', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set(signedHeaders(body))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ accepted: true });
+  });
+
+  it('rejects invalid signatures', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set({
+        ...signedHeaders(body),
+        'x-signature': `sha256=${'0'.repeat(64)}`,
+      })
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid webhook signature');
+  });
+
+  it('rejects stale timestamps', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set(signedHeaders(body, 'nonce-1', '2026-07-08T23:00:00.000Z'))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Stale webhook timestamp');
+  });
+
+  it('rejects replayed nonces', async () => {
+    const store = new InMemoryInboundWebhookNonceStore(() => NOW);
+    const app = buildApp(store);
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const headers = signedHeaders(body);
+
+    await request(app)
+      .post('/webhook')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body)
+      .expect(202);
+
+    const replay = await request(app)
+      .post('/webhook')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(replay.status).toBe(401);
+    expect(replay.body.error).toBe('Replay detected');
+  });
+
+  it('returns 503 when the signing secret is not configured', async () => {
+    const app = express();
+    app.use(express.json({ verify: captureRawBody }));
+    app.post('/webhook', createInboundWebhookSignatureMiddleware(), (_req, res) => {
+      res.status(202).json({ accepted: true });
+    });
+
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const res = await request(app)
+      .post('/webhook')
+      .set(signedHeaders(body))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(503);
+  });
+});

--- a/src/middleware/inboundWebhookSignature.ts
+++ b/src/middleware/inboundWebhookSignature.ts
@@ -1,0 +1,108 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { getRawBody } from './rawBody.js';
+import {
+  defaultInboundWebhookNonceStore,
+  type InboundWebhookNonceStore,
+} from '../services/inboundWebhookNonceStore.js';
+
+const SIGNATURE_PREFIX = 'sha256=';
+const DEFAULT_TOLERANCE_MS = 5 * 60 * 1000;
+
+export interface InboundWebhookSignatureOptions {
+  secret?: string;
+  toleranceMs?: number;
+  nonceStore?: InboundWebhookNonceStore;
+  now?: () => number;
+}
+
+function readHeader(req: Request, name: string): string | undefined {
+  const value = req.headers[name.toLowerCase()];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseSignature(header: string | undefined): Buffer | undefined {
+  if (!header?.startsWith(SIGNATURE_PREFIX)) {
+    return undefined;
+  }
+  const hex = header.slice(SIGNATURE_PREFIX.length);
+  if (!/^[a-f0-9]{64}$/i.test(hex)) {
+    return undefined;
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+export function buildInboundWebhookSignaturePayload(
+  timestamp: string,
+  nonce: string,
+  rawBody: Buffer,
+): Buffer {
+  return Buffer.concat([
+    Buffer.from(`${timestamp}.${nonce}.`, 'utf8'),
+    rawBody,
+  ]);
+}
+
+export function signInboundWebhookPayload(
+  secret: string,
+  timestamp: string,
+  nonce: string,
+  rawBody: Buffer,
+): string {
+  const digest = createHmac('sha256', secret)
+    .update(buildInboundWebhookSignaturePayload(timestamp, nonce, rawBody))
+    .digest('hex');
+  return `${SIGNATURE_PREFIX}${digest}`;
+}
+
+function unauthorized(res: Response, message: string): void {
+  res.status(401).json({ data: null, error: message });
+}
+
+export function createInboundWebhookSignatureMiddleware(
+  options: InboundWebhookSignatureOptions = {},
+) {
+  const nonceStore = options.nonceStore ?? defaultInboundWebhookNonceStore;
+  const now = options.now ?? (() => Date.now());
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const secret = options.secret ?? process.env.INBOUND_WEBHOOK_SECRET;
+    if (!secret) {
+      res.status(503).json({ data: null, error: 'Inbound webhook signing secret is not configured' });
+      return;
+    }
+
+    const timestamp = readHeader(req, 'x-timestamp');
+    const nonce = readHeader(req, 'x-nonce');
+    const provided = parseSignature(readHeader(req, 'x-signature'));
+    const rawBody = getRawBody(req);
+
+    if (!timestamp || !nonce || !provided || !rawBody) {
+      unauthorized(res, 'Missing or malformed webhook signature headers');
+      return;
+    }
+
+    const sentAtMs = Date.parse(timestamp);
+    const toleranceMs = options.toleranceMs ?? Number.parseInt(
+      process.env.INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS ?? String(DEFAULT_TOLERANCE_MS),
+      10,
+    );
+    if (!Number.isFinite(sentAtMs) || Math.abs(now() - sentAtMs) > toleranceMs) {
+      unauthorized(res, 'Stale webhook timestamp');
+      return;
+    }
+
+    const expected = parseSignature(signInboundWebhookPayload(secret, timestamp, nonce, rawBody));
+    if (!expected || provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+      unauthorized(res, 'Invalid webhook signature');
+      return;
+    }
+
+    if (!nonceStore.claim(nonce, sentAtMs + toleranceMs)) {
+      unauthorized(res, 'Replay detected');
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/middleware/rawBody.ts
+++ b/src/middleware/rawBody.ts
@@ -1,0 +1,13 @@
+import type { Request } from 'express';
+
+export interface RawBodyRequest extends Request {
+  rawBody?: Buffer;
+}
+
+export function captureRawBody(req: Request, _res: unknown, buf: Buffer): void {
+  (req as RawBodyRequest).rawBody = Buffer.from(buf);
+}
+
+export function getRawBody(req: Request): Buffer | undefined {
+  return (req as RawBodyRequest).rawBody;
+}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -31,6 +31,8 @@ tags:
     description: On-chain risk evaluation
   - name: Webhooks
     description: Draw confirmation webhook management
+  - name: Inbound Webhooks
+    description: Signed partner webhook ingestion
   - name: Reconciliation
     description: Admin control plane for DB-vs-chain reconciliation
 
@@ -400,6 +402,32 @@ components:
           type: integer
         timeoutMs:
           type: integer
+
+    InboundWebhookRequest:
+      type: object
+      required: [event]
+      properties:
+        event:
+          type: string
+          example: partner.updated
+      additionalProperties: true
+
+    InboundWebhookAcceptedResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [accepted, event]
+          properties:
+            accepted:
+              type: boolean
+              example: true
+            event:
+              type: string
+              example: partner.updated
+        error:
+          type: string
+          nullable: true
 
     AdminRecalibrateResponse:
       type: object
@@ -1131,6 +1159,60 @@ paths:
                 backoffMultiplier: 2.0
                 timeoutMs: 10000
                 configured: true
+
+  /api/inbound-webhooks/events:
+    post:
+      tags: [Inbound Webhooks]
+      operationId: receiveInboundWebhookEvent
+      summary: Receive a signed inbound webhook event
+      description: |
+        Requires `X-Signature`, `X-Timestamp`, and `X-Nonce`.
+        `X-Signature` is `sha256=<hex>` over `X-Timestamp + "." + X-Nonce + "." + raw_body`.
+        Stale timestamps and repeated nonces are rejected to prevent replay.
+      security: []
+      parameters:
+        - name: X-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+            pattern: "^sha256=[a-fA-F0-9]{64}$"
+        - name: X-Timestamp
+          in: header
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: X-Nonce
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboundWebhookRequest"
+      responses:
+        "202":
+          description: Event accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboundWebhookAcceptedResponse"
+        "401":
+          description: Missing, invalid, stale, or replayed signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Inbound webhook signing secret is not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /api/webhooks/test:
     post:

--- a/src/routes/__tests__/inboundWebhooks.test.ts
+++ b/src/routes/__tests__/inboundWebhooks.test.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { captureRawBody } from '../../middleware/rawBody.js';
+import { signInboundWebhookPayload } from '../../middleware/inboundWebhookSignature.js';
+import { defaultInboundWebhookNonceStore } from '../../services/inboundWebhookNonceStore.js';
+import { inboundWebhookRouter } from '../inboundWebhooks.js';
+
+const SECRET = 'route-secret';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ verify: captureRawBody }));
+  app.use('/api/inbound-webhooks', inboundWebhookRouter);
+  return app;
+}
+
+function signedHeaders(body: string, nonce = 'route-nonce') {
+  const timestamp = new Date().toISOString();
+  return {
+    'x-timestamp': timestamp,
+    'x-nonce': nonce,
+    'x-signature': signInboundWebhookPayload(SECRET, timestamp, nonce, Buffer.from(body)),
+  };
+}
+
+describe('inbound webhook routes', () => {
+  beforeEach(() => {
+    process.env.INBOUND_WEBHOOK_SECRET = SECRET;
+    defaultInboundWebhookNonceStore.resetForTests();
+  });
+
+  it('accepts signed inbound events', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/api/inbound-webhooks/events')
+      .set(signedHeaders(body))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({
+      data: { accepted: true, event: 'partner.updated' },
+      error: null,
+    });
+  });
+
+  it('rejects unsigned inbound events', async () => {
+    const res = await request(buildApp())
+      .post('/api/inbound-webhooks/events')
+      .send({ event: 'partner.updated' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/routes/inboundWebhooks.ts
+++ b/src/routes/inboundWebhooks.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { createInboundWebhookSignatureMiddleware } from '../middleware/inboundWebhookSignature.js';
+import { ok } from '../utils/response.js';
+
+export const inboundWebhookRouter = Router();
+
+inboundWebhookRouter.post(
+  '/events',
+  createInboundWebhookSignatureMiddleware(),
+  (req, res) => {
+    ok(res, {
+      accepted: true,
+      event: typeof req.body?.event === 'string' ? req.body.event : 'unknown',
+    }, 202);
+  },
+);

--- a/src/services/inboundWebhookNonceStore.ts
+++ b/src/services/inboundWebhookNonceStore.ts
@@ -1,0 +1,37 @@
+export interface InboundWebhookNonceStore {
+  claim(nonce: string, expiresAtMs: number): boolean;
+  purgeExpired(nowMs?: number): number;
+  resetForTests(): void;
+}
+
+export class InMemoryInboundWebhookNonceStore implements InboundWebhookNonceStore {
+  private readonly nonces = new Map<string, number>();
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  claim(nonce: string, expiresAtMs: number): boolean {
+    this.purgeExpired();
+    if (this.nonces.has(nonce)) {
+      return false;
+    }
+    this.nonces.set(nonce, expiresAtMs);
+    return true;
+  }
+
+  purgeExpired(nowMs: number = this.now()): number {
+    let purged = 0;
+    for (const [nonce, expiresAtMs] of this.nonces.entries()) {
+      if (expiresAtMs <= nowMs) {
+        this.nonces.delete(nonce);
+        purged += 1;
+      }
+    }
+    return purged;
+  }
+
+  resetForTests(): void {
+    this.nonces.clear();
+  }
+}
+
+export const defaultInboundWebhookNonceStore = new InMemoryInboundWebhookNonceStore();


### PR DESCRIPTION
Closes #181.

## Summary
- add inbound webhook signature verification middleware for `X-Signature`, `X-Timestamp`, and `X-Nonce`
- sign and verify `timestamp.nonce.raw_body` with HMAC-SHA256 and constant-time comparison
- reject missing/malformed signatures, stale timestamps, invalid HMACs, and replayed nonces
- capture the raw JSON body through the Express parser `verify` hook so signatures are checked against the exact request bytes
- add `POST /api/inbound-webhooks/events` as the signed ingestion endpoint
- add an inbound nonce migration and in-process TTL nonce store
- document partner signing requirements in `docs/inbound-webhooks.md` and update `src/openapi.yaml`

## Security notes
- requests fail closed with `503` if `INBOUND_WEBHOOK_SECRET` is not configured
- the default timestamp tolerance is 5 minutes and can be configured with `INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS`
- nonces are claimed only after signature and timestamp verification succeed

## Validation
- `vitest run src/middleware/__tests__/inboundWebhookSignature.test.ts src/routes/__tests__/inboundWebhooks.test.ts src/db/migrations.test.ts src/db/validate-schema.test.ts --pool=forks --maxWorkers=1` (38 passed)
- `eslint src/middleware/rawBody.ts src/middleware/inboundWebhookSignature.ts src/middleware/__tests__/inboundWebhookSignature.test.ts src/services/inboundWebhookNonceStore.ts src/routes/inboundWebhooks.ts src/routes/__tests__/inboundWebhooks.test.ts src/index.ts`
- `node --input-type=module -e "import fs from 'node:fs'; import yaml from 'yaml'; yaml.parse(fs.readFileSync('src/openapi.yaml', 'utf8')); console.log('OpenAPI spec valid');"`
- `git diff --check`
- `tsc --noEmit --pretty false` still fails on existing unrelated main-branch errors in `src/app.ts`, `src/container/Container.ts`, `src/middleware/requestLogger.ts`, `src/routes/credit*.ts`, `src/routes/dashboard.ts`, `src/routes/simulation.ts`, and `src/services/drawWebhookService.ts`; no inbound webhook files are reported.
