### PR TITLE
Add durable outbound webhook dispatcher

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -253,6 +253,22 @@ Reachability probe for every configured URL. Returns `{ total, reachable, unreac
 
 #### `GET /api/webhooks/health`
 
+#### `GET /api/webhooks/subscriptions` *(API-key auth)*
+
+Returns active outbound webhook subscriber metadata without secret material.
+
+#### `GET /api/webhooks/deliveries` *(API-key auth)*
+
+Returns recent durable delivery rows. Optional query parameters:
+
+- `status`: `queued`, `delivered`, `failed`, or `dead_letter`
+- `limit`: 1-200
+
+#### `POST /api/webhooks/deliveries/:id/replay` *(API-key auth)*
+
+Requeues a stored delivery for asynchronous retry and returns `202` with the
+new job id.
+
 `active | disabled` — disabled when no URLs are configured.
 
 #### Outbound payload contract (subscriber side)

--- a/docs/webhook-subscribers.md
+++ b/docs/webhook-subscribers.md
@@ -24,6 +24,11 @@ Implementation references:
 Do not put real `WEBHOOK_SECRET` values in logs, docs, tickets, or sample
 payloads.
 
+When PostgreSQL is configured, startup mirrors `WEBHOOK_URLS` into
+`outbound_webhook_subscriptions` and records each asynchronous delivery in
+`outbound_webhook_deliveries`. The database stores only `secret_ref`
+(`WEBHOOK_SECRET`), never the secret value itself.
+
 ## Request Contract
 
 Creditra sends a `POST` request to each configured subscriber URL.
@@ -164,6 +169,9 @@ The management routes are mounted under `/api/webhooks`.
 | `GET` | `/api/webhooks/config` | Returns sanitized webhook configuration: URLs, retry knobs, timeout, and configured state. It never returns `WEBHOOK_SECRET`. |
 | `POST` | `/api/webhooks/test` | Sends a connectivity probe to every configured URL and returns `{ total, reachable, unreachable, results }`. |
 | `GET` | `/api/webhooks/health` | Returns `disabled` when no URLs are configured, otherwise `active` with URL count and retry settings. |
+| `GET` | `/api/webhooks/subscriptions` | Lists active subscriber metadata. Requires `X-API-Key`. |
+| `GET` | `/api/webhooks/deliveries?status=dead_letter` | Lists recent delivery rows for inspection. Requires `X-API-Key`. |
+| `POST` | `/api/webhooks/deliveries/:id/replay` | Requeues a failed or dead-letter delivery. Requires `X-API-Key`. |
 
 ## Subscriber Checklist
 

--- a/migrations/008_outbound_webhooks.sql
+++ b/migrations/008_outbound_webhooks.sql
@@ -1,0 +1,54 @@
+-- Durable outbound webhook subscriptions and delivery attempts.
+-- Secrets are referenced by name (for example WEBHOOK_SECRET), never stored.
+
+CREATE TABLE IF NOT EXISTS outbound_webhook_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  url TEXT NOT NULL,
+  event_types JSONB NOT NULL DEFAULT '[]'::jsonb,
+  active BOOLEAN NOT NULL DEFAULT true,
+  secret_ref TEXT NOT NULL DEFAULT 'WEBHOOK_SECRET',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outbound_webhook_subscriptions_url_key
+  ON outbound_webhook_subscriptions (url);
+
+CREATE INDEX IF NOT EXISTS outbound_webhook_subscriptions_active_idx
+  ON outbound_webhook_subscriptions (active);
+
+CREATE TABLE IF NOT EXISTS outbound_webhook_deliveries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscription_id UUID NOT NULL
+    REFERENCES outbound_webhook_subscriptions(id) ON DELETE RESTRICT,
+  url TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  status TEXT NOT NULL CHECK (
+    status IN ('queued', 'delivered', 'failed', 'dead_letter')
+  ),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  response_status INTEGER,
+  last_error TEXT,
+  next_attempt_at TIMESTAMPTZ,
+  delivered_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outbound_webhook_deliveries_event_subscription_key
+  ON outbound_webhook_deliveries (subscription_id, event_id)
+  WHERE status = 'delivered';
+
+CREATE INDEX IF NOT EXISTS outbound_webhook_deliveries_status_idx
+  ON outbound_webhook_deliveries (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS outbound_webhook_deliveries_event_idx
+  ON outbound_webhook_deliveries (event_type, event_id);
+
+COMMENT ON TABLE outbound_webhook_subscriptions IS
+  'Outbound webhook subscribers; secret_ref points to environment-managed secret material.';
+
+COMMENT ON TABLE outbound_webhook_deliveries IS
+  'Durable outbound webhook delivery attempts, retries, and dead-letter records.';

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -38,6 +38,13 @@ import { registerAuditSubscriber } from "../services/events/auditSubscriber.js";
 import { DataRetentionService } from "../services/dataRetentionService.js";
 import { DataRetentionWorker } from "../services/dataRetentionWorker.js";
 import { DashboardSummaryService } from "../services/dashboardSummaryService.js";
+import {
+  InMemoryOutboundWebhookStore,
+  PostgresOutboundWebhookStore,
+  type OutboundWebhookStore,
+} from "../services/outboundWebhookStore.js";
+import { OutboundWebhookDispatcher } from "../services/outboundWebhookDispatcher.js";
+import { resolveWebhookConfig } from "../services/drawWebhookService.js";
 
 export class Container {
   private static instance: Container;
@@ -56,8 +63,11 @@ export class Container {
   private _reconciliationService!: ReconciliationService;
   private _reconciliationWorker!: ReconciliationWorker;
   private _sorobanClient!: SorobanRpcClient;
+  private _dashboardSummaryService!: DashboardSummaryService;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _outboundWebhookStore?: OutboundWebhookStore;
+  private _outboundWebhookDispatcher?: OutboundWebhookDispatcher;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -101,6 +111,42 @@ export class Container {
         this._dataRetentionService,
         defaultJobQueue,
       );
+    }
+
+    if (!this._outboundWebhookDispatcher) {
+      this._outboundWebhookStore = this._dbClient
+        ? new PostgresOutboundWebhookStore(this._dbClient)
+        : new InMemoryOutboundWebhookStore();
+      this._outboundWebhookDispatcher = new OutboundWebhookDispatcher(
+        this._outboundWebhookStore,
+        defaultJobQueue,
+        this._eventBus,
+        {
+          secret: process.env["WEBHOOK_SECRET"] ?? "",
+          maxAttempts: Math.max(
+            1,
+            parseInt(process.env["WEBHOOK_MAX_RETRIES"] ?? "3", 10),
+          ),
+          timeoutMs: Math.max(
+            1,
+            parseInt(process.env["WEBHOOK_TIMEOUT_MS"] ?? "10000", 10),
+          ),
+          initialBackoffMs: Math.max(
+            0,
+            parseInt(process.env["WEBHOOK_INITIAL_BACKOFF_MS"] ?? "1000", 10),
+          ),
+        },
+      );
+      try {
+        const webhookConfig = resolveWebhookConfig();
+        void this._outboundWebhookDispatcher
+          .initializeFromEnvironment(webhookConfig.urls)
+          .catch((error) => {
+            console.error("[Container] Outbound webhook initialization failed:", error);
+          });
+      } catch (error) {
+        console.error("[Container] Outbound webhook configuration failed:", error);
+      }
     }
   }
 
@@ -158,9 +204,20 @@ export class Container {
     return this._reconciliationWorker;
   }
 
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
   /** Process-wide in-process domain event bus for credit lifecycle events. */
   get eventBus() {
     return this._eventBus;
+  }
+
+  get outboundWebhookDispatcher(): OutboundWebhookDispatcher {
+    if (!this._outboundWebhookDispatcher) {
+      throw new Error('Outbound webhook dispatcher is not initialized');
+    }
+    return this._outboundWebhookDispatcher;
   }
 
   /** Undefined when running against in-memory repositories (no Postgres connection). */

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -16,6 +16,8 @@ export const EXPECTED_TABLES = [
   'risk_evaluations',
   'transactions',
   'events',
+  'outbound_webhook_subscriptions',
+  'outbound_webhook_deliveries',
 ] as const;
 
 /**

--- a/src/db/validate-schema.test.ts
+++ b/src/db/validate-schema.test.ts
@@ -26,6 +26,8 @@ describe('missingTables', () => {
         { table_name: 'risk_evaluations' },
         { table_name: 'transactions' },
         { table_name: 'events' },
+        { table_name: 'outbound_webhook_subscriptions' },
+        { table_name: 'outbound_webhook_deliveries' },
       ],
     });
     const missing = await missingTables(client);
@@ -188,6 +190,8 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'outbound_webhook_subscriptions' },
+            { table_name: 'outbound_webhook_deliveries' },
           ],
         };
       }
@@ -209,6 +213,13 @@ describe('validateSchema', () => {
             { column_name: 'type' },
             { column_name: 'amount' },
             { column_name: 'event_type' },
+            { column_name: 'url' },
+            { column_name: 'event_types' },
+            { column_name: 'active' },
+            { column_name: 'secret_ref' },
+            { column_name: 'subscription_id' },
+            { column_name: 'event_id' },
+            { column_name: 'attempts' },
             { column_name: 'created_at' },
           ],
         };
@@ -223,6 +234,8 @@ describe('validateSchema', () => {
             { indexname: 'risk_evaluations_borrower_id_idx' },
             { indexname: 'transactions_credit_line_id_idx' },
             { indexname: 'events_idempotency_key_key' },
+            { indexname: 'outbound_webhook_subscriptions_url_key' },
+            { indexname: 'outbound_webhook_deliveries_status_idx' },
           ],
         };
       }
@@ -263,6 +276,8 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'outbound_webhook_subscriptions' },
+            { table_name: 'outbound_webhook_deliveries' },
           ],
         };
       }
@@ -279,6 +294,8 @@ describe('validateSchema', () => {
             { indexname: 'risk_evaluations_borrower_id_idx' },
             { indexname: 'transactions_credit_line_id_idx' },
             { indexname: 'events_idempotency_key_key' },
+            { indexname: 'outbound_webhook_subscriptions_url_key' },
+            { indexname: 'outbound_webhook_deliveries_status_idx' },
           ],
         };
       }
@@ -309,6 +326,8 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'outbound_webhook_subscriptions' },
+            { table_name: 'outbound_webhook_deliveries' },
           ],
         };
       }
@@ -329,6 +348,13 @@ describe('validateSchema', () => {
             { column_name: 'type' },
             { column_name: 'amount' },
             { column_name: 'event_type' },
+            { column_name: 'url' },
+            { column_name: 'event_types' },
+            { column_name: 'active' },
+            { column_name: 'secret_ref' },
+            { column_name: 'subscription_id' },
+            { column_name: 'event_id' },
+            { column_name: 'attempts' },
             { column_name: 'created_at' },
           ],
         };
@@ -364,6 +390,8 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'outbound_webhook_subscriptions' },
+            { table_name: 'outbound_webhook_deliveries' },
           ],
         };
       }
@@ -376,6 +404,8 @@ describe('validateSchema', () => {
             { indexname: 'risk_evaluations_borrower_id_idx' },
             { indexname: 'transactions_credit_line_id_idx' },
             { indexname: 'events_idempotency_key_key' },
+            { indexname: 'outbound_webhook_subscriptions_url_key' },
+            { indexname: 'outbound_webhook_deliveries_status_idx' },
           ],
         };
       }
@@ -405,6 +435,8 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'outbound_webhook_subscriptions' },
+            { table_name: 'outbound_webhook_deliveries' },
           ],
         };
       }
@@ -425,6 +457,13 @@ describe('validateSchema', () => {
             { column_name: 'type' },
             { column_name: 'amount' },
             { column_name: 'event_type' },
+            { column_name: 'url' },
+            { column_name: 'event_types' },
+            { column_name: 'active' },
+            { column_name: 'secret_ref' },
+            { column_name: 'subscription_id' },
+            { column_name: 'event_id' },
+            { column_name: 'attempts' },
             { column_name: 'created_at' },
           ],
         };

--- a/src/db/validate-schema.ts
+++ b/src/db/validate-schema.ts
@@ -28,6 +28,8 @@ const REQUIRED_COLUMNS: Record<string, string[]> = {
   risk_evaluations: ['id', 'borrower_id', 'risk_score', 'suggested_limit', 'interest_rate_bps', 'evaluated_at'],
   transactions: ['id', 'credit_line_id', 'type', 'amount', 'currency', 'created_at'],
   events: ['id', 'event_type', 'created_at'],
+  outbound_webhook_subscriptions: ['id', 'url', 'event_types', 'active', 'secret_ref', 'created_at'],
+  outbound_webhook_deliveries: ['id', 'subscription_id', 'event_type', 'event_id', 'status', 'attempts', 'created_at'],
 };
 
 /**
@@ -40,6 +42,8 @@ const REQUIRED_INDEXES: Record<string, string[]> = {
   risk_evaluations: ['risk_evaluations_borrower_id_idx'],
   transactions: ['transactions_credit_line_id_idx'],
   events: ['events_idempotency_key_key'],
+  outbound_webhook_subscriptions: ['outbound_webhook_subscriptions_url_key'],
+  outbound_webhook_deliveries: ['outbound_webhook_deliveries_status_idx'],
 };
 
 /**

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -20,8 +20,14 @@ import { Router, type Request, type Response } from 'express';
 import { getWebhookConfig, testWebhookConnectivity } from '../services/drawWebhookService.js';
 import { getWebhookDeliveryStateStore } from '../services/webhookDeliveryState.js';
 import { redactLogArgs } from '../utils/logRedact.js';
+import { Container } from '../container/Container.js';
+import { createApiKeyMiddleware } from '../middleware/auth.js';
+import { loadApiKeys } from '../config/apiKeys.js';
+import type { OutboundWebhookStatus } from '../services/outboundWebhookStore.js';
 
 export const webhookRouter = Router();
+const container = Container.getInstance();
+const requireApiKey = createApiKeyMiddleware(() => loadApiKeys());
 
 /**
  * Get current webhook configuration
@@ -101,4 +107,57 @@ webhookRouter.get('/health', (_req: Request, res: Response) => {
             deadLetter: counts.deadLetter
         }
     });
+});
+
+/**
+ * List active outbound webhook subscriptions. Admin/API-key gated because
+ * subscriber URLs are operational integration metadata.
+ */
+webhookRouter.get('/subscriptions', requireApiKey, async (_req: Request, res: Response) => {
+    const subscriptions = await container.outboundWebhookDispatcher.listSubscriptions();
+    res.status(200).json({
+        data: subscriptions.map((subscription) => ({
+            id: subscription.id,
+            url: subscription.url,
+            eventTypes: subscription.eventTypes,
+            active: subscription.active,
+            secretRef: subscription.secretRef,
+            createdAt: subscription.createdAt,
+            updatedAt: subscription.updatedAt
+        })),
+        error: null
+    });
+});
+
+/**
+ * Inspect recent outbound delivery rows. Admin/API-key gated; payloads are
+ * included so operators can debug event fan-out without reading server logs.
+ */
+webhookRouter.get('/deliveries', requireApiKey, async (req: Request, res: Response) => {
+    const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+    const limit = typeof req.query.limit === 'string' ? Number(req.query.limit) : undefined;
+    const allowedStatuses = new Set(['queued', 'delivered', 'failed', 'dead_letter']);
+    const deliveries = await container.outboundWebhookDispatcher.listDeliveries({
+        status: status && allowedStatuses.has(status)
+            ? (status as OutboundWebhookStatus)
+            : undefined,
+        limit: Number.isFinite(limit) ? limit : undefined
+    });
+    res.status(200).json({ data: deliveries, error: null });
+});
+
+/**
+ * Replay a failed/dead-letter delivery by queueing it again. The original row
+ * is preserved and moved back to queued so history remains inspectable.
+ */
+webhookRouter.post('/deliveries/:id/replay', requireApiKey, async (req: Request, res: Response) => {
+    try {
+        const jobId = await container.outboundWebhookDispatcher.replayDelivery(req.params.id);
+        res.status(202).json({ data: { jobId }, error: null });
+    } catch (error) {
+        res.status(404).json({
+            data: null,
+            error: error instanceof Error ? error.message : 'Delivery not found'
+        });
+    }
 });

--- a/src/services/__tests__/outboundWebhookDispatcher.test.ts
+++ b/src/services/__tests__/outboundWebhookDispatcher.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '../events/eventBus.js';
+import { InMemoryJobQueue } from '../jobQueue.js';
+import { OutboundWebhookDispatcher } from '../outboundWebhookDispatcher.js';
+import { InMemoryOutboundWebhookStore } from '../outboundWebhookStore.js';
+
+describe('OutboundWebhookDispatcher', () => {
+  it('queues and delivers credit lifecycle events asynchronously', async () => {
+    const store = new InMemoryOutboundWebhookStore();
+    const queue = new InMemoryJobQueue();
+    const bus = new EventBus();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+    });
+
+    const dispatcher = new OutboundWebhookDispatcher(
+      store,
+      queue,
+      bus,
+      {
+        secret: 'test-secret',
+        maxAttempts: 3,
+        timeoutMs: 1_000,
+        initialBackoffMs: 10,
+      },
+      fetchImpl as unknown as typeof fetch,
+    );
+    await dispatcher.initializeFromEnvironment(['https://example.com/hook']);
+
+    await bus.publish({
+      type: 'credit.opened',
+      occurredAt: '2026-07-09T00:00:00.000Z',
+      creditLineId: 'credit-1',
+      payload: { walletAddress: 'GABC', creditLimit: '1000' },
+    });
+
+    expect(queue.size()).toBe(1);
+    await queue.drain();
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://example.com/hook',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'X-Webhook-Signature': expect.stringMatching(/^sha256=/),
+          'User-Agent': 'Creditra-Webhook/1.0',
+        }),
+        body: expect.stringContaining('"event":"credit.opened"'),
+      }),
+    );
+
+    const deliveries = await dispatcher.listDeliveries();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      eventType: 'credit.opened',
+      status: 'delivered',
+      attempts: 1,
+      responseStatus: 204,
+    });
+  });
+
+  it('moves exhausted deliveries to dead-letter state', async () => {
+    const store = new InMemoryOutboundWebhookStore();
+    const queue = new InMemoryJobQueue();
+    const bus = new EventBus();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+    });
+
+    const dispatcher = new OutboundWebhookDispatcher(
+      store,
+      queue,
+      bus,
+      {
+        secret: 'test-secret',
+        maxAttempts: 1,
+        timeoutMs: 1_000,
+        initialBackoffMs: 10,
+      },
+      fetchImpl as unknown as typeof fetch,
+    );
+    await dispatcher.initializeFromEnvironment(['https://example.com/hook']);
+
+    const jobIds = await dispatcher.scheduleEvent({
+      type: 'credit.repay_confirmed',
+      occurredAt: '2026-07-09T00:00:00.000Z',
+      creditLineId: 'credit-1',
+      payload: { walletAddress: 'GABC', amount: '10', utilized: '90' },
+    });
+
+    expect(jobIds).toHaveLength(1);
+    await queue.drain();
+
+    const deliveries = await dispatcher.listDeliveries({ status: 'dead_letter' });
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      eventType: 'credit.repay_confirmed',
+      status: 'dead_letter',
+      attempts: 1,
+    });
+    expect(queue.getFailedJobs()).toHaveLength(1);
+  });
+});

--- a/src/services/outboundWebhookDispatcher.ts
+++ b/src/services/outboundWebhookDispatcher.ts
@@ -1,0 +1,233 @@
+import { createHmac } from 'node:crypto';
+import type { CreditDomainEvent, CreditEventType } from './events/domainEvents.js';
+import type { EventBus } from './events/eventBus.js';
+import type { Job, JobQueue } from './jobQueue.js';
+import type {
+  OutboundWebhookDelivery,
+  OutboundWebhookStore,
+} from './outboundWebhookStore.js';
+import { createServiceLogger } from '../utils/serviceLogger.js';
+
+const log = createServiceLogger('OutboundWebhookDispatcher');
+
+export const WEBHOOK_DELIVERY_JOB = 'outbound-webhook-delivery';
+
+const DEFAULT_EVENT_TYPES: CreditEventType[] = [
+  'credit.opened',
+  'credit.draw_confirmed',
+  'credit.repay_confirmed',
+  'credit.defaulted',
+];
+
+export interface OutboundWebhookDispatcherConfig {
+  secret: string;
+  maxAttempts: number;
+  timeoutMs: number;
+  initialBackoffMs: number;
+}
+
+export class OutboundWebhookDispatcher {
+  constructor(
+    private readonly store: OutboundWebhookStore,
+    private readonly jobQueue: JobQueue,
+    private readonly eventBus: EventBus,
+    private readonly config: OutboundWebhookDispatcherConfig,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {
+    this.jobQueue.registerHandler(
+      WEBHOOK_DELIVERY_JOB,
+      (job: Job<{ deliveryId: string }>) => this.processDeliveryJob(job),
+    );
+    this.subscribeToDomainEvents();
+  }
+
+  async initializeFromEnvironment(urls: string[]): Promise<void> {
+    if (urls.length > 0 && !this.config.secret) {
+      throw new Error('WEBHOOK_SECRET is required when WEBHOOK_URLS is configured');
+    }
+    await Promise.all(
+      urls.map((url) =>
+        this.store.upsertEnvSubscription({
+          url,
+          eventTypes: DEFAULT_EVENT_TYPES,
+          secretRef: 'WEBHOOK_SECRET',
+        }),
+      ),
+    );
+  }
+
+  async scheduleEvent(event: CreditDomainEvent): Promise<string[]> {
+    const subscriptions = await this.store.listSubscriptions();
+    const matching = subscriptions.filter(
+      (subscription) =>
+        subscription.active && subscription.eventTypes.includes(event.type),
+    );
+
+    const jobIds: string[] = [];
+    for (const subscription of matching) {
+      const eventId = this.eventId(event);
+      const existing = await this.store.findDelivery(subscription.id, eventId);
+      if (existing?.status === 'delivered') {
+        continue;
+      }
+
+      const delivery = await this.store.createDelivery({
+        subscriptionId: subscription.id,
+        url: subscription.url,
+        eventType: event.type,
+        eventId,
+        payload: this.payloadFor(event),
+      });
+
+      jobIds.push(
+        this.jobQueue.enqueue(
+          WEBHOOK_DELIVERY_JOB,
+          { deliveryId: delivery.id },
+          {
+            maxAttempts: this.config.maxAttempts,
+            id: `webhook-${delivery.id}`,
+          },
+        ),
+      );
+    }
+    return jobIds;
+  }
+
+  async replayDelivery(deliveryId: string): Promise<string> {
+    const delivery = await this.store.getDelivery(deliveryId);
+    if (!delivery) {
+      throw new Error(`Webhook delivery not found: ${deliveryId}`);
+    }
+    await this.store.updateDelivery(delivery.id, {
+      status: 'queued',
+      nextAttemptAt: undefined,
+      lastError: undefined,
+    });
+    return this.jobQueue.enqueue(
+      WEBHOOK_DELIVERY_JOB,
+      { deliveryId },
+      {
+        maxAttempts: this.config.maxAttempts,
+        id: `webhook-replay-${delivery.id}-${Date.now()}`,
+      },
+    );
+  }
+
+  async listDeliveries(filter?: Parameters<OutboundWebhookStore['listDeliveries']>[0]) {
+    return this.store.listDeliveries(filter);
+  }
+
+  async listSubscriptions() {
+    return this.store.listSubscriptions();
+  }
+
+  private subscribeToDomainEvents(): void {
+    for (const type of DEFAULT_EVENT_TYPES) {
+      this.eventBus.subscribe(type, (event) => {
+        void this.scheduleEvent(event).catch((error) => {
+          log.error('outbound-webhook:schedule:failed', {
+            type: event.type,
+            creditLineId: event.creditLineId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      });
+    }
+  }
+
+  private async processDeliveryJob(
+    job: Job<{ deliveryId: string }>,
+  ): Promise<void> {
+    const delivery = await this.store.getDelivery(job.payload.deliveryId);
+    if (!delivery) {
+      throw new Error(`Webhook delivery not found: ${job.payload.deliveryId}`);
+    }
+    const attempt = job.attempts + 1;
+
+    try {
+      const result = await this.deliver(delivery);
+      await this.store.updateDelivery(delivery.id, {
+        status: 'delivered',
+        attempts: attempt,
+        responseStatus: result.status,
+        deliveredAt: new Date().toISOString(),
+        lastError: undefined,
+      });
+      log.info('outbound-webhook:delivered', {
+        deliveryId: delivery.id,
+        eventType: delivery.eventType,
+        attempt,
+      });
+    } catch (error) {
+      const lastError = error instanceof Error ? error.message : String(error);
+      const finalAttempt = attempt >= deliveryMaxAttempts(job);
+      await this.store.updateDelivery(delivery.id, {
+        status: finalAttempt ? 'dead_letter' : 'failed',
+        attempts: attempt,
+        lastError,
+        nextAttemptAt: finalAttempt
+          ? undefined
+          : new Date(Date.now() + this.config.initialBackoffMs).toISOString(),
+      });
+      log.error('outbound-webhook:delivery:failed', {
+        deliveryId: delivery.id,
+        eventType: delivery.eventType,
+        attempt,
+        finalAttempt,
+        error: lastError,
+      });
+      throw error;
+    }
+  }
+
+  private async deliver(
+    delivery: OutboundWebhookDelivery,
+  ): Promise<{ status: number }> {
+    const body = JSON.stringify(delivery.payload);
+    const signature = createHmac('sha256', this.config.secret)
+      .update(body, 'utf8')
+      .digest('hex');
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.config.timeoutMs);
+
+    try {
+      const response = await this.fetchImpl(delivery.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': `sha256=${signature}`,
+          'X-Webhook-Timestamp': new Date().toISOString(),
+          'User-Agent': 'Creditra-Webhook/1.0',
+        },
+        body,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return { status: response.status };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private payloadFor(event: CreditDomainEvent) {
+    return {
+      event: event.type,
+      timestamp: new Date().toISOString(),
+      data: {
+        creditLineId: event.creditLineId,
+        occurredAt: event.occurredAt,
+        ...event.payload,
+      },
+    };
+  }
+
+  private eventId(event: CreditDomainEvent): string {
+    return `${event.type}:${event.creditLineId}:${event.occurredAt}`;
+  }
+}
+
+function deliveryMaxAttempts(job: Job): number {
+  return Math.max(1, job.maxAttempts);
+}

--- a/src/services/outboundWebhookStore.ts
+++ b/src/services/outboundWebhookStore.ts
@@ -1,0 +1,358 @@
+import { randomUUID } from 'node:crypto';
+import type { DbClient } from '../db/client.js';
+
+export type OutboundWebhookStatus =
+  | 'queued'
+  | 'delivered'
+  | 'failed'
+  | 'dead_letter';
+
+export interface OutboundWebhookSubscription {
+  id: string;
+  url: string;
+  eventTypes: string[];
+  active: boolean;
+  secretRef: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OutboundWebhookDelivery {
+  id: string;
+  subscriptionId: string;
+  url: string;
+  eventType: string;
+  eventId: string;
+  status: OutboundWebhookStatus;
+  payload: unknown;
+  attempts: number;
+  responseStatus?: number;
+  lastError?: string;
+  nextAttemptAt?: string;
+  deliveredAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateDeliveryInput {
+  subscriptionId: string;
+  url: string;
+  eventType: string;
+  eventId: string;
+  payload: unknown;
+}
+
+export interface DeliveryPatch {
+  status?: OutboundWebhookStatus;
+  attempts?: number;
+  responseStatus?: number;
+  lastError?: string;
+  nextAttemptAt?: string;
+  deliveredAt?: string;
+}
+
+export interface DeliveryFilter {
+  status?: OutboundWebhookStatus;
+  limit?: number;
+}
+
+export interface OutboundWebhookStore {
+  upsertEnvSubscription(params: {
+    url: string;
+    eventTypes: string[];
+    secretRef: string;
+  }): Promise<OutboundWebhookSubscription>;
+  listSubscriptions(): Promise<OutboundWebhookSubscription[]>;
+  createDelivery(input: CreateDeliveryInput): Promise<OutboundWebhookDelivery>;
+  getDelivery(id: string): Promise<OutboundWebhookDelivery | null>;
+  findDelivery(
+    subscriptionId: string,
+    eventId: string,
+  ): Promise<OutboundWebhookDelivery | null>;
+  updateDelivery(
+    id: string,
+    patch: DeliveryPatch,
+  ): Promise<OutboundWebhookDelivery>;
+  listDeliveries(filter?: DeliveryFilter): Promise<OutboundWebhookDelivery[]>;
+}
+
+const nowIso = (): string => new Date().toISOString();
+
+export class InMemoryOutboundWebhookStore implements OutboundWebhookStore {
+  private readonly subscriptions = new Map<string, OutboundWebhookSubscription>();
+  private readonly deliveries = new Map<string, OutboundWebhookDelivery>();
+
+  async upsertEnvSubscription(params: {
+    url: string;
+    eventTypes: string[];
+    secretRef: string;
+  }): Promise<OutboundWebhookSubscription> {
+    const existing = [...this.subscriptions.values()].find(
+      (subscription) => subscription.url === params.url,
+    );
+    const timestamp = nowIso();
+    const subscription: OutboundWebhookSubscription = {
+      id: existing?.id ?? randomUUID(),
+      url: params.url,
+      eventTypes: [...params.eventTypes],
+      active: true,
+      secretRef: params.secretRef,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+    };
+    this.subscriptions.set(subscription.id, subscription);
+    return subscription;
+  }
+
+  async listSubscriptions(): Promise<OutboundWebhookSubscription[]> {
+    return [...this.subscriptions.values()]
+      .filter((subscription) => subscription.active)
+      .map((subscription) => ({ ...subscription }));
+  }
+
+  async createDelivery(
+    input: CreateDeliveryInput,
+  ): Promise<OutboundWebhookDelivery> {
+    const timestamp = nowIso();
+    const delivery: OutboundWebhookDelivery = {
+      id: randomUUID(),
+      ...input,
+      status: 'queued',
+      attempts: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    this.deliveries.set(delivery.id, delivery);
+    return { ...delivery };
+  }
+
+  async getDelivery(id: string): Promise<OutboundWebhookDelivery | null> {
+    const delivery = this.deliveries.get(id);
+    return delivery ? { ...delivery } : null;
+  }
+
+  async findDelivery(
+    subscriptionId: string,
+    eventId: string,
+  ): Promise<OutboundWebhookDelivery | null> {
+    const delivery = [...this.deliveries.values()].find(
+      (entry) =>
+        entry.subscriptionId === subscriptionId && entry.eventId === eventId,
+    );
+    return delivery ? { ...delivery } : null;
+  }
+
+  async updateDelivery(
+    id: string,
+    patch: DeliveryPatch,
+  ): Promise<OutboundWebhookDelivery> {
+    const existing = this.deliveries.get(id);
+    if (!existing) {
+      throw new Error(`Webhook delivery not found: ${id}`);
+    }
+    const updated = {
+      ...existing,
+      ...patch,
+      updatedAt: nowIso(),
+    };
+    this.deliveries.set(id, updated);
+    return { ...updated };
+  }
+
+  async listDeliveries(
+    filter: DeliveryFilter = {},
+  ): Promise<OutboundWebhookDelivery[]> {
+    const limit = Math.min(Math.max(filter.limit ?? 50, 1), 200);
+    return [...this.deliveries.values()]
+      .filter((delivery) => !filter.status || delivery.status === filter.status)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit)
+      .map((delivery) => ({ ...delivery }));
+  }
+}
+
+export class PostgresOutboundWebhookStore implements OutboundWebhookStore {
+  constructor(private readonly db: DbClient) {}
+
+  async upsertEnvSubscription(params: {
+    url: string;
+    eventTypes: string[];
+    secretRef: string;
+  }): Promise<OutboundWebhookSubscription> {
+    const result = await this.db.query(
+      `INSERT INTO outbound_webhook_subscriptions
+        (url, event_types, active, secret_ref, created_at, updated_at)
+       VALUES ($1, $2::jsonb, true, $3, now(), now())
+       ON CONFLICT (url) DO UPDATE SET
+         event_types = EXCLUDED.event_types,
+         active = true,
+         secret_ref = EXCLUDED.secret_ref,
+         updated_at = now()
+       RETURNING id, url, event_types, active, secret_ref, created_at, updated_at`,
+      [params.url, JSON.stringify(params.eventTypes), params.secretRef],
+    );
+    return mapSubscription(result.rows[0] as Record<string, unknown>);
+  }
+
+  async listSubscriptions(): Promise<OutboundWebhookSubscription[]> {
+    const result = await this.db.query(
+      `SELECT id, url, event_types, active, secret_ref, created_at, updated_at
+       FROM outbound_webhook_subscriptions
+       WHERE active = true
+       ORDER BY created_at ASC`,
+    );
+    return result.rows.map((row) =>
+      mapSubscription(row as Record<string, unknown>),
+    );
+  }
+
+  async createDelivery(
+    input: CreateDeliveryInput,
+  ): Promise<OutboundWebhookDelivery> {
+    const result = await this.db.query(
+      `INSERT INTO outbound_webhook_deliveries
+        (subscription_id, url, event_type, event_id, payload, status, attempts,
+         created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, 'queued', 0, now(), now())
+       RETURNING *`,
+      [
+        input.subscriptionId,
+        input.url,
+        input.eventType,
+        input.eventId,
+        JSON.stringify(input.payload),
+      ],
+    );
+    return mapDelivery(result.rows[0] as Record<string, unknown>);
+  }
+
+  async getDelivery(id: string): Promise<OutboundWebhookDelivery | null> {
+    const result = await this.db.query(
+      `SELECT * FROM outbound_webhook_deliveries WHERE id = $1`,
+      [id],
+    );
+    return result.rows[0]
+      ? mapDelivery(result.rows[0] as Record<string, unknown>)
+      : null;
+  }
+
+  async findDelivery(
+    subscriptionId: string,
+    eventId: string,
+  ): Promise<OutboundWebhookDelivery | null> {
+    const result = await this.db.query(
+      `SELECT * FROM outbound_webhook_deliveries
+       WHERE subscription_id = $1 AND event_id = $2
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [subscriptionId, eventId],
+    );
+    return result.rows[0]
+      ? mapDelivery(result.rows[0] as Record<string, unknown>)
+      : null;
+  }
+
+  async updateDelivery(
+    id: string,
+    patch: DeliveryPatch,
+  ): Promise<OutboundWebhookDelivery> {
+    const current = await this.getDelivery(id);
+    if (!current) {
+      throw new Error(`Webhook delivery not found: ${id}`);
+    }
+    const next = {
+      status: patch.status ?? current.status,
+      attempts: patch.attempts ?? current.attempts,
+      responseStatus: patch.responseStatus ?? current.responseStatus ?? null,
+      lastError: patch.lastError ?? current.lastError ?? null,
+      nextAttemptAt: patch.nextAttemptAt ?? current.nextAttemptAt ?? null,
+      deliveredAt: patch.deliveredAt ?? current.deliveredAt ?? null,
+    };
+    const result = await this.db.query(
+      `UPDATE outbound_webhook_deliveries
+       SET status = $2,
+           attempts = $3,
+           response_status = $4,
+           last_error = $5,
+           next_attempt_at = $6,
+           delivered_at = $7,
+           updated_at = now()
+       WHERE id = $1
+       RETURNING *`,
+      [
+        id,
+        next.status,
+        next.attempts,
+        next.responseStatus,
+        next.lastError,
+        next.nextAttemptAt,
+        next.deliveredAt,
+      ],
+    );
+    return mapDelivery(result.rows[0] as Record<string, unknown>);
+  }
+
+  async listDeliveries(
+    filter: DeliveryFilter = {},
+  ): Promise<OutboundWebhookDelivery[]> {
+    const limit = Math.min(Math.max(filter.limit ?? 50, 1), 200);
+    const params: unknown[] = [limit];
+    let where = '';
+    if (filter.status) {
+      params.push(filter.status);
+      where = 'WHERE status = $2';
+    }
+    const result = await this.db.query(
+      `SELECT * FROM outbound_webhook_deliveries
+       ${where}
+       ORDER BY created_at DESC
+       LIMIT $1`,
+      params,
+    );
+    return result.rows.map((row) =>
+      mapDelivery(row as Record<string, unknown>),
+    );
+  }
+}
+
+function mapSubscription(row: Record<string, unknown>): OutboundWebhookSubscription {
+  return {
+    id: String(row.id),
+    url: String(row.url),
+    eventTypes: Array.isArray(row.event_types)
+      ? (row.event_types as string[])
+      : JSON.parse(String(row.event_types ?? '[]')),
+    active: Boolean(row.active),
+    secretRef: String(row.secret_ref),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+  };
+}
+
+function mapDelivery(row: Record<string, unknown>): OutboundWebhookDelivery {
+  return {
+    id: String(row.id),
+    subscriptionId: String(row.subscription_id),
+    url: String(row.url),
+    eventType: String(row.event_type),
+    eventId: String(row.event_id),
+    status: row.status as OutboundWebhookStatus,
+    payload:
+      typeof row.payload === 'string'
+        ? JSON.parse(row.payload)
+        : (row.payload ?? {}),
+    attempts: Number(row.attempts ?? 0),
+    responseStatus:
+      row.response_status == null ? undefined : Number(row.response_status),
+    lastError: row.last_error == null ? undefined : String(row.last_error),
+    nextAttemptAt: row.next_attempt_at == null ? undefined : toIso(row.next_attempt_at),
+    deliveredAt: row.delivered_at == null ? undefined : toIso(row.delivered_at),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+  };
+}
+
+function toIso(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  return new Date(String(value)).toISOString();
+}


### PR DESCRIPTION
Closes Creditra/Creditra-Backend#182.

## Summary

- add durable outbound webhook schema for subscriptions and deliveries
- add an outbound webhook store with in-memory and Postgres-backed implementations
- add an async dispatcher that subscribes to credit lifecycle events, records delivery rows, signs payloads, queues delivery jobs, retries through the existing job queue, and marks exhausted attempts as dead-letter
- expose API-key-gated inspection and replay endpoints:
  - `GET /api/webhooks/subscriptions`
  - `GET /api/webhooks/deliveries`
  - `POST /api/webhooks/deliveries/:id/replay`
- update schema validation and webhook subscriber/operator docs

## Validation

- `node node_modules/vitest/vitest.mjs run src/services/__tests__/outboundWebhookDispatcher.test.ts src/db/validate-schema.test.ts`
- `node node_modules/eslint/bin/eslint.js src/services/outboundWebhookStore.ts src/services/outboundWebhookDispatcher.ts src/services/__tests__/outboundWebhookDispatcher.test.ts src/container/Container.ts src/routes/webhook.ts src/db/migrations.ts src/db/validate-schema.ts src/db/validate-schema.test.ts`
- `node --input-type=module -e "import fs from 'node:fs'; import yaml from 'yaml'; yaml.parse(fs.readFileSync('src/openapi.yaml','utf8')); yaml.parse(fs.readFileSync('openapi.yaml','utf8')); console.log('OpenAPI specs valid');"`
- `git diff --check`

Full `tsc --noEmit --pretty false` still fails on existing main-branch issues in `src/app.ts`, `src/middleware/requestLogger.ts`, `src/routes/creditBulk.ts`, `src/routes/simulation.ts`, legacy `src/services/drawWebhookService.ts` missing `log`, and existing route/container test typing. The touched files passed targeted ESLint and focused tests.

## Security notes

Webhook secrets are never persisted. Subscriptions store only `secret_ref` (`WEBHOOK_SECRET`), and delivery rows store signed payload metadata/status for operator inspection and replay.
