### PR TITLE
ci(security): add secret scanning guardrails

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,7 @@ The `backend-ci.yml` workflow provides comprehensive continuous integration for 
 - **OpenAPI Spec Validation**: Ensures API documentation is valid YAML
 - **Security Audit**: Runs `npm audit` to check for vulnerable dependencies
 - **Secret Detection**: Scans for hardcoded API keys, private keys, or secrets
+- **Gitleaks Scan**: The separate `secret-scanning.yml` workflow runs the pinned Gitleaks CLI with `.gitleaks.toml`
 
 ### 5. Security Checks
 The workflow includes checks for:
@@ -61,6 +62,9 @@ npm run test:coverage
 
 # Validate OpenAPI spec
 npm run validate:spec
+
+# Scan for committed secrets
+npm run security:secrets
 ```
 
 ## Coverage Requirements
@@ -94,6 +98,7 @@ None required for basic CI. For integration tests with Stellar:
 - Use `process.env` for all secrets
 - Stellar keys should be generated per environment
 - PII must not be in test fixtures
+- Secret scanner allowlists must stay limited to non-deployable placeholders
 
 ## Troubleshooting
 

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,49 @@
+name: Secret Scanning
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: secret-scanning-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Gitleaks CLI
+        env:
+          GITLEAKS_VERSION: 8.28.0
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan repository for secrets
+        run: |
+          gitleaks detect \
+            --source . \
+            --config .gitleaks.toml \
+            --no-git \
+            --redact \
+            --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,33 @@
+title = "Creditra Backend secret scanning"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "stellar-secret-key"
+description = "Stellar secret keys must never be committed"
+regex = '''\bS[A-Z2-7]{55}\b'''
+keywords = ["S"]
+
+[[allowlists]]
+description = "Documented placeholders and local examples are not deployable secrets"
+paths = [
+  '''(^|/)\.env\.example$''',
+  '''(^|/)docs/secret-scanning\.md$''',
+  '''(^|/)CONTRIBUTING\.md$''',
+]
+regexes = [
+  '''API_KEYS=change-me-before-any-real-traffic''',
+  '''DATABASE_URL=postgresql://user:password@localhost:5432/creditra''',
+  '''ADMIN_API_KEY=''',
+  '''your-api-key''',
+  '''JWT_SECRET''',
+  '''WEBHOOK_SECRET''',
+  '''HMAC_SECRET''',
+]
+
+[[allowlists]]
+description = "Gitleaks configuration documents the patterns it blocks"
+paths = [
+  '''(^|/)\.gitleaks\.toml$''',
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,13 @@ Before committing, format code:
 npm run lint
 ```
 
+Secret scanning:
+```bash
+npm run security:secrets
+npm run security:secrets:staged
+```
+The scan uses `.gitleaks.toml` and blocks private keys, API tokens, database URLs, and webhook secrets. Only documented placeholders in `.env.example` should be allowlisted.
+
 # Security
 Security is a priority.
 
@@ -235,6 +242,7 @@ Before requesting review, confirm:
 - [ ] `npm run lint` passes
 - [ ] `npm run typecheck` passes
 - [ ] `npm run validate:spec` passes (if OpenAPI changed)
+- [ ] `npm run security:secrets` passes
 - [ ] New code covered by tests; coverage ≥ 95 % on touched modules
 - [ ] No new secrets, credentials, or wallet pubkeys in code, tests, fixtures, or logs
 - [ ] All Zod schemas updated alongside any new route inputs

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ npm run test:coverage     # v8 coverage, lcov + text
 npm run test:watch        # vitest in watch mode
 npm run lint              # eslint src/
 npm run typecheck         # tsc --noEmit
+npm run security:secrets  # Gitleaks secret scan
 ```
 
 ### Load
@@ -200,6 +201,7 @@ See [`docs/OBSERVABILITY.md`](./docs/OBSERVABILITY.md).
 - Per-route token-bucket rate limit emitting `X-RateLimit-*` headers ([`src/middleware/rateLimit.ts`](./src/middleware/rateLimit.ts)).
 - HMAC-SHA256 webhook signatures (`X-Webhook-Signature: sha256=…`).
 - Outbound HTTP guarded by [`src/utils/fetchWithTimeout.ts`](./src/utils/fetchWithTimeout.ts).
+- Committed secret guardrails run through [`.gitleaks.toml`](./.gitleaks.toml), [`npm run security:secrets`](./scripts/security/scan-secrets.mjs), and the [`Secret Scanning`](./.github/workflows/secret-scanning.yml) workflow.
 
 Full model: [`docs/SECURITY.md`](./docs/SECURITY.md) and [`SECURITY.md`](./SECURITY.md).
 
@@ -269,6 +271,7 @@ Creditra-Backend/
 | [`docs/load-testing.md`](./docs/load-testing.md) | k6 scripts and thresholds |
 | [`docs/security-checklist-backend.md`](./docs/security-checklist-backend.md) | Pre-deploy security checklist |
 | [`docs/security-pentest-checklist.md`](./docs/security-pentest-checklist.md) | Pentest prep checklist |
+| [`docs/secret-scanning.md`](./docs/secret-scanning.md) | Gitleaks CI/local guardrails and remediation steps |
 | [`docs/REPOSITORY_ARCHITECTURE.md`](./docs/REPOSITORY_ARCHITECTURE.md) | Repository / DIP layout |
 | [`docs/troubleshooting.md`](./docs/troubleshooting.md) | Common failure modes |
 

--- a/docs/secret-scanning.md
+++ b/docs/secret-scanning.md
@@ -1,0 +1,40 @@
+# Secret scanning
+
+Creditra blocks accidental commits of private keys, API tokens, database URLs, and webhook secrets with a dedicated Gitleaks scan.
+
+## CI guardrail
+
+The `Secret Scanning` workflow downloads a pinned Gitleaks CLI release and runs:
+
+```bash
+gitleaks detect --source . --config .gitleaks.toml --no-git --redact --verbose
+```
+
+The workflow fails the pull request when a secret is found in the current repository tree. It uses the open-source CLI directly instead of the Gitleaks GitHub Action so organization repositories do not need a `GITLEAKS_LICENSE` secret just to run the guardrail.
+
+## Local guardrail
+
+Run the full repository scan before opening a pull request:
+
+```bash
+npm run security:secrets
+```
+
+Run a staged-only check before committing:
+
+```bash
+npm run security:secrets:staged
+```
+
+Install Gitleaks locally from the upstream releases page, or set `GITLEAKS_BIN` to the scanner executable path.
+
+## Allowlist policy
+
+Allowed examples must be non-deployable placeholders, such as `.env.example` values. Do not allowlist a real token after it is found. Rotate the credential, remove it from git history when necessary, and then add a narrowly scoped placeholder allowlist only if the scanner needs it.
+
+## Remediation
+
+1. Revoke or rotate the exposed credential immediately.
+2. Remove the secret from the file and replace it with an environment variable reference.
+3. If the secret reached shared history, coordinate history cleanup with maintainers.
+4. Re-run `npm run security:secrets` and include the output summary in the pull request.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "db:validate": "tsx src/db/validate-cli.ts",
     "db:retention": "tsx src/db/data-retention-cli.ts",
     "validate:spec": "node --input-type=module -e \"import fs from 'node:fs'; import yaml from 'yaml'; yaml.parse(fs.readFileSync('src/openapi.yaml', 'utf8')); console.log('OpenAPI spec valid');\"",
+    "security:secrets": "node scripts/security/scan-secrets.mjs",
+    "security:secrets:staged": "node scripts/security/scan-secrets.mjs --staged",
     "load:smoke": "k6 run scripts/load/smoke.js",
     "load:stress": "k6 run scripts/load/stress.js",
     "load:spike": "k6 run scripts/load/spike.js"

--- a/scripts/security/scan-secrets.mjs
+++ b/scripts/security/scan-secrets.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const gitleaksBin = process.env.GITLEAKS_BIN || "gitleaks";
+const staged = process.argv.includes("--staged");
+const args = staged
+  ? ["protect", "--staged", "--config", ".gitleaks.toml", "--redact", "--verbose"]
+  : ["detect", "--source", ".", "--config", ".gitleaks.toml", "--no-git", "--redact", "--verbose"];
+
+const result = spawnSync(gitleaksBin, args, {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+if (result.error?.code === "ENOENT") {
+  console.error(
+    "Gitleaks is not installed. Install it from https://github.com/gitleaks/gitleaks, " +
+      "or set GITLEAKS_BIN to the scanner executable path.",
+  );
+  process.exit(127);
+}
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- add a dedicated `Secret Scanning` workflow using the pinned Gitleaks CLI
- add `.gitleaks.toml` with default Gitleaks coverage, a Creditra-specific Stellar secret-key rule, and narrow placeholder allowlists
- add local `npm run security:secrets` and `npm run security:secrets:staged` guardrails with contributor documentation

Closes #197.

## Validation

- `node --check scripts/security/scan-secrets.mjs`
- parsed `.github/workflows/secret-scanning.yml` and `package.json`
- `gitleaks detect --source . --config .gitleaks.toml --no-git --redact --verbose`
- `GITLEAKS_BIN=<local gitleaks.exe> node scripts/security/scan-secrets.mjs`
- `git diff --check`
