### PR TITLE
feat(security): per-endpoint request size limits with 413 errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,18 @@ API_KEYS=change-me-before-any-real-traffic
 # NODE_ENV=development
 
 # -----------------------------------------------------------------------------
+# OPTIONAL — request body size limits (bytes)
+# -----------------------------------------------------------------------------
+# Per-endpoint JSON body caps. Default API traffic is limited to 100 KiB;
+# bulk ingest (/api/credit/lines/bulk) allows 1 MiB. The parser ceiling should
+# be ≥ the largest per-route limit. Reverse proxies (nginx client_max_body_size,
+# Envoy buffer limits) must be ≥ BODY_LIMIT_MAX_BYTES so clients see the API's
+# structured 413. See docs/body-limits.md.
+# BODY_LIMIT_DEFAULT_BYTES=102400
+# BODY_LIMIT_BULK_BYTES=1048576
+# BODY_LIMIT_MAX_BYTES=1048576
+
+# -----------------------------------------------------------------------------
 # OPTIONAL — rate limiting
 # -----------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See [`docs/OBSERVABILITY.md`](./docs/OBSERVABILITY.md).
 
 - Constant-time API key check via `crypto.timingSafeEqual` ([`src/middleware/auth.ts`](./src/middleware/auth.ts)).
 - Admin endpoints gated by a separate header (`X-Admin-Api-Key`).
-- Request body capped at 100 kB; non-JSON mutating requests rejected with 415.
+- Per-endpoint request body limits (default 100 KiB, bulk 1 MiB) with explicit 413 problem+json; non-JSON mutating requests rejected with 415.
 - Per-route token-bucket rate limit emitting `X-RateLimit-*` headers ([`src/middleware/rateLimit.ts`](./src/middleware/rateLimit.ts)).
 - HMAC-SHA256 webhook signatures (`X-Webhook-Signature: sha256=…`).
 - Outbound HTTP guarded by [`src/utils/fetchWithTimeout.ts`](./src/utils/fetchWithTimeout.ts).
@@ -278,7 +278,7 @@ Creditra-Backend/
 
 - **Graceful shutdown.** `SIGTERM` and `SIGINT` close the HTTP server, stop the reconciliation worker, drain the job queue, and close the DB pool — bounded by `SHUTDOWN_TIMEOUT_MS` (default 30s).
 - **Hot key rotation.** `loadApiKeys()` is invoked per request via a resolver closure, so `API_KEYS` may be rotated without restart (e.g. via secret manager).
-- **Body limits.** `express.json({ limit: '100kb' })`. Oversize requests are converted into a `413` via the global error handler.
+- **Body limits.** Per-endpoint caps (default 100 KiB; `/api/credit/lines/bulk` 1 MiB). Oversize requests return `413 Payload Too Large` problem+json. See [`docs/body-limits.md`](./docs/body-limits.md) for env knobs and reverse-proxy recommendations.
 - **CORS.** Production deployments **must** set `CORS_ORIGINS` to a comma-separated allowlist; dev/test falls back to loopback origins ([`src/config/cors.ts`](./src/config/cors.ts)).
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ Human-readable companion to the machine-readable spec at [`src/openapi.yaml`](..
 - **Base URL (dev):** `http://localhost:3000`
 - **Default media type:** `application/json` (the server returns `415` if you `POST/PUT/PATCH` anything else)
 - **Response envelope:** `{ "data": <payload> | null, "error": <string> | null }`
-- **Body limit:** 100 kB (oversize returns `413`)
+- **Body limits (per endpoint):** default **100 KiB**; bulk ingest `/api/credit/lines/bulk` **1 MiB**. Oversize returns `413` problem+json — see [`docs/body-limits.md`](./body-limits.md).
 
 ---
 
@@ -64,7 +64,7 @@ Rate-limit responses additionally include `retryAfter` and the `Retry-After` HTT
 | 403 | Auth header present but invalid |
 | 404 | Resource not found |
 | 409 | Invalid state transition (e.g. close-of-closed) |
-| 413 | Body > 100 kB |
+| 413 | Body exceeds per-endpoint limit (default 100 KiB; bulk 1 MiB) |
 | 415 | Mutating request lacked `application/json` |
 | 429 | Rate limit exhausted |
 | 500 | Internal error (no stack leaked) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ flowchart TB
     subgraph Edge[Edge / HTTP]
       EXP[Express app<br/>src/index.ts]
       CORS[CORS allowlist<br/>src/config/cors.ts]
-      BODY[JSON body parser<br/>limit 100kb]
+      BODY[JSON body parser<br/>per-endpoint limits]
       CT[Content-Type guard<br/>415 on non-JSON]
     end
 
@@ -107,7 +107,7 @@ sequenceDiagram
     participant Client
     participant Express
     participant CORS
-    participant BodyParser as express.json (100kb)
+    participant BodyParser as bodyLimit + express.json
     participant CTGuard as Content-Type guard
     participant ReqLog as requestLogger
     participant Auth as auth / adminAuth
@@ -148,7 +148,7 @@ Cross-cutting guarantees:
 
 - **One envelope.** Successful responses use `ok(res, data, status?)`; failures use `fail(res, error, status?)` ([`src/utils/response.ts`](../src/utils/response.ts)).
 - **One request id.** `requestLogger` reuses `x-request-id` from the client when present, otherwise generates a UUID, and echoes it back as a response header.
-- **Body limits.** `express.json({ limit: '100kb' })` and a `Content-Type` guard for `POST/PUT/PATCH`.
+- **Body limits.** Per-endpoint caps via `createPathAwareBodyLimitMiddleware` (default 100 KiB, bulk 1 MiB) plus `express.json` absolute ceiling and a `Content-Type` guard for `POST/PUT/PATCH`. See [`docs/body-limits.md`](./body-limits.md).
 
 ---
 
@@ -313,7 +313,7 @@ Read endpoints are public by design but rate-limited.
 | 403 | Auth header present but invalid |
 | 404 | Resource not found |
 | 409 | Invalid state transition (e.g. closing an already-closed line) |
-| 413 | Body > 100 kB |
+| 413 | Body exceeds per-endpoint limit |
 | 415 | Mutating request without `application/json` Content-Type |
 | 429 | Rate limit exhausted; `Retry-After` included |
 | 500 | Unhandled error — envelope keeps stack out |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -16,7 +16,7 @@ This document is the backend's threat model and the catalogue of in-tree mitigat
 | DB | Drift from on-chain truth | `ReconciliationWorker` runs every `RECONCILIATION_INTERVAL_MS` |
 | Borrower PII (wallet address) | Indefinite retention of identifying data | `DataRetentionWorker` anonymizes inactive borrowers' `wallet_address` and purges stale audit/risk data — see [`docs/DATA_RETENTION.md`](./DATA_RETENTION.md) |
 | Service availability | Brute force / abusive scrapers | Token-bucket rate limit with `Retry-After` |
-| Service availability | Large body payloads | 100 kB body cap, 413 mapped to envelope |
+| Service availability | Large body payloads | Per-endpoint body caps (default 100 KiB, bulk 1 MiB), early Content-Length reject, 413 problem+json — see [`docs/body-limits.md`](./body-limits.md) |
 | Outbound calls | Slow / hung dependencies | `fetchWithTimeout` connect+read timeouts |
 
 ---
@@ -87,14 +87,14 @@ Behaviour:
 Validator chain order:
 
 1. CORS allowlist ([`src/config/cors.ts`](../src/config/cors.ts))
-2. JSON body parser (100 kB)
-3. Content-Type guard (returns 415 if `POST/PUT/PATCH` has a body that isn't `application/json`)
+2. Content-Type guard (returns 415 if `POST/PUT/PATCH` has a body that isn't `application/json`)
+3. Path-aware body limit (Content-Length fast-path; default 100 KiB, bulk 1 MiB) + JSON body parser with verify hook ([`src/middleware/bodyLimit.ts`](../src/middleware/bodyLimit.ts))
 4. Request logger (assigns / propagates `x-request-id`)
 5. Auth middleware (route-specific)
 6. Rate limit middleware (route-specific)
 7. Zod validate(Body|Query|Params)
 8. Handler
-9. `errorHandler` catches anything unhandled
+9. `errorHandler` catches anything unhandled (including 413 Payload Too Large)
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -63,7 +63,8 @@ Boundaries exercised end-to-end against an in-memory container:
 - `tests/draw-credit.test.ts` — draw endpoint validation, Stellar address parsing, pending status.
 - `tests/cors.test.ts` — `isAllowedCorsOrigin()` matrix (loopback fallback, production allowlist).
 - `tests/response.test.ts` — `ok()`/`fail()` envelope helpers.
-- `tests/middleware/*` — `errorHandler`, `rateLimit`, `validate`, body limits.
+- `tests/middleware/*` — `errorHandler`, `rateLimit`, `validate`, body limits (default 413 + bulk higher ceiling).
+- `src/config/__tests__/bodyLimit.test.ts` — path resolution and env overrides for body limits.
 - `src/routes/__tests__/reconciliation.integration.test.ts` — schedule → run → status flow.
 
 ### System (~11 files)

--- a/docs/body-limits.md
+++ b/docs/body-limits.md
@@ -1,0 +1,121 @@
+# Request body size limits
+
+Per-endpoint JSON body limits protect the API from large-payload denial-of-service while still allowing bulk ingest routes a higher ceiling.
+
+## Defaults
+
+| Scope | Path match | Limit | Constant / env |
+|---|---|---|---|
+| Default API | all paths without a more specific rule | **100 KiB** | `BODY_LIMIT_DEFAULT_BYTES` (default `102400`) |
+| Bulk ingest | `/api/credit/lines/bulk` (+ subpaths) | **1 MiB** | `BODY_LIMIT_BULK_BYTES` (default `1048576`) |
+| Parser ceiling | absolute max accepted by `express.json` | max of the above (override with `BODY_LIMIT_MAX_BYTES`) | safety net for chunked bodies |
+
+Source of truth: [`src/config/bodyLimit.ts`](../src/config/bodyLimit.ts).
+
+## How enforcement works
+
+1. **Content-Type guard** — mutating requests with a body must declare `application/json` (else `415`).
+2. **Path-aware early reject** — [`createPathAwareBodyLimitMiddleware`](../src/middleware/bodyLimit.ts) reads `Content-Length` and, when present and over the route limit, returns **413** immediately without buffering the body.
+3. **JSON parser** — `express.json({ limit: maxBytes, verify })` uses the absolute ceiling; the `verify` hook re-checks the raw buffer against the **path-specific** limit (covers `Transfer-Encoding: chunked` where `Content-Length` is absent).
+4. **errorHandler** — body-parser `entity.too.large` and `PayloadTooLargeError` map to the same 413 problem+json + envelope response.
+
+### Fixed limit on a single route
+
+```ts
+import { createBodyLimitMiddleware } from '../middleware/bodyLimit.js';
+
+router.post(
+  '/lines/bulk',
+  createBodyLimitMiddleware(1024 * 1024),
+  handler,
+);
+```
+
+Prefer path rules in `loadBodyLimitConfig()` for global path-based policy; use the factory when a router owns its own limit.
+
+## 413 response shape
+
+Status: `413 Payload Too Large`  
+`Content-Type: application/problem+json`
+
+```json
+{
+  "type": "https://httpstatuses.com/413",
+  "title": "Payload Too Large",
+  "status": 413,
+  "detail": "Payload Too Large. Request body exceeds the maximum size of 100kb for this endpoint.",
+  "limit": 102400,
+  "limitLabel": "100kb",
+  "data": null,
+  "error": "Payload Too Large. Request body exceeds the maximum size of 100kb for this endpoint."
+}
+```
+
+Headers:
+
+| Header | Meaning |
+|---|---|
+| `X-Content-Length-Limit` | Max bytes allowed for this endpoint |
+| `X-Content-Length-Received` | Observed size when known |
+
+`data` / `error` mirror the project envelope ([`docs/error-envelope.md`](./error-envelope.md)) so existing clients keep working; RFC 7807 fields support problem-aware clients.
+
+## Environment variables
+
+```bash
+# Optional overrides (bytes, positive integers)
+BODY_LIMIT_DEFAULT_BYTES=102400
+BODY_LIMIT_BULK_BYTES=1048576
+BODY_LIMIT_MAX_BYTES=1048576
+```
+
+Invalid or non-positive values fall back to the compiled defaults.
+
+## Reverse proxy recommendations
+
+Node only sees what the edge allows. Set proxy limits **≥** `BODY_LIMIT_MAX_BYTES` so clients receive the API’s structured 413 instead of a generic gateway error.
+
+### nginx
+
+```nginx
+# Must be ≥ BODY_LIMIT_MAX_BYTES (default 1m)
+client_max_body_size 1m;
+```
+
+### Envoy
+
+```yaml
+per_connection_buffer_limit_bytes: 1048576  # ≥ BODY_LIMIT_MAX_BYTES
+```
+
+Or use a Lua/ext_authz filter; ensure the listener/http connection manager does not buffer-reject below the API max.
+
+### AWS ALB / CloudFront / Cloudflare
+
+- ALB does not impose a small fixed body cap comparable to nginx’s default 1m; still document app limits to clients.
+- Cloudflare free/pro plan has upload limits by plan; ensure the plan limit is ≥ bulk limit if bulk is exposed publicly.
+- Prefer terminating TLS at a proxy that can reject oversize bodies early under load.
+
+### Defence in depth
+
+| Layer | Role |
+|---|---|
+| CDN / WAF | Optional hard ceiling, bot filtering |
+| Reverse proxy | `client_max_body_size` / buffer limits ≥ app max |
+| App path-aware middleware | Per-endpoint policy + structured 413 |
+| `express.json` limit | Absolute parser ceiling |
+
+Do **not** set the proxy limit lower than bulk without also lowering `BODY_LIMIT_BULK_BYTES` / `BODY_LIMIT_MAX_BYTES`, or bulk clients will see opaque `413`/`502` from the proxy.
+
+## Adding a new high-limit endpoint
+
+1. Add a `{ pathPrefix, maxBytes }` rule in `loadBodyLimitConfig()` (`src/config/bodyLimit.ts`).
+2. Ensure `maxBytes` ≤ `BODY_LIMIT_MAX_BYTES` (raise the env default if needed).
+3. Confirm reverse proxy config allows the new ceiling.
+4. Extend tests in `tests/middleware/bodyLimits.test.ts`.
+5. Document the path in this file and in `docs/API.md`.
+
+## Tests
+
+- `tests/middleware/bodyLimits.test.ts` — default 413, bulk higher limit, problem+json shape, Content-Type 415.
+- `src/config/__tests__/bodyLimit.test.ts` — config resolution and labels.

--- a/docs/security-checklist-backend.md
+++ b/docs/security-checklist-backend.md
@@ -48,7 +48,7 @@ For **external penetration-test preparation** (scope, auth bypass checks, rate l
 ### Content Type Validation
 - [ ] Content-Type headers are validated
 - [ ] JSON parsing errors are handled gracefully
-- [ ] Request size limits are enforced (prevent DoS)
+- [ ] Request size limits are enforced (prevent DoS) — default 100 KiB, bulk 1 MiB; reverse proxy ≥ `BODY_LIMIT_MAX_BYTES` (see `docs/body-limits.md`)
 
 ## 3. Logging & Monitoring
 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -13,6 +13,7 @@ the route, service, and repository layers. Anything placed here MUST:
 | Module             | Purpose                                                   |
 | ------------------ | --------------------------------------------------------- |
 | `constants.ts`     | Pagination and body-size defaults shared by API endpoints |
+| *(config)* `bodyLimit.ts` | Runtime per-endpoint body limits — see [`docs/body-limits.md`](./body-limits.md) |
 | `fetchWithTimeout` | HTTP client with structured timeout and request errors    |
 | `httpStatus.ts`    | Named HTTP status code constants                          |
 | `logger.ts`        | Process-wide pino logger configuration                    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2698,7 +2697,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3291,7 +3289,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3753,7 +3750,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4555,7 +4551,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5901,7 +5896,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7475,7 +7469,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9074,7 +9067,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9158,7 +9150,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9318,7 +9309,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -9397,7 +9387,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -9708,7 +9697,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
 import { apiKeysRouter } from './routes/apiKeys.js';
+import { recordRequest, metricsRouter } from './routes/metrics.js';
+import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
+import { maintenanceRouter } from './routes/maintenance.js';
 
 export function createApp() {
   const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';

--- a/src/config/__tests__/bodyLimit.test.ts
+++ b/src/config/__tests__/bodyLimit.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BODY_LIMIT_BULK_BYTES,
+  BODY_LIMIT_DEFAULT_BYTES,
+  bodyTooLargeMessage,
+  formatBodyLimitLabel,
+  loadBodyLimitConfig,
+  resolveBodyLimit,
+} from '../bodyLimit.js';
+
+describe('loadBodyLimitConfig', () => {
+  it('returns secure defaults', () => {
+    const config = loadBodyLimitConfig({});
+    expect(config.defaultMaxBytes).toBe(100 * 1024);
+    expect(config.defaultMaxBytes).toBe(BODY_LIMIT_DEFAULT_BYTES);
+    expect(config.routes).toEqual([
+      expect.objectContaining({
+        pathPrefix: '/api/credit/lines/bulk',
+        maxBytes: BODY_LIMIT_BULK_BYTES,
+      }),
+    ]);
+    expect(config.maxBytes).toBe(BODY_LIMIT_BULK_BYTES);
+  });
+
+  it('ignores non-positive env values', () => {
+    const config = loadBodyLimitConfig({
+      BODY_LIMIT_DEFAULT_BYTES: '0',
+      BODY_LIMIT_BULK_BYTES: '-1',
+      BODY_LIMIT_MAX_BYTES: 'nope',
+    });
+    expect(config.defaultMaxBytes).toBe(BODY_LIMIT_DEFAULT_BYTES);
+    expect(config.routes[0]?.maxBytes).toBe(BODY_LIMIT_BULK_BYTES);
+  });
+});
+
+describe('resolveBodyLimit', () => {
+  const config = loadBodyLimitConfig({});
+
+  it('uses default for ordinary API paths', () => {
+    expect(resolveBodyLimit('/api/credit/lines', config)).toBe(BODY_LIMIT_DEFAULT_BYTES);
+    expect(resolveBodyLimit('/api/risk/evaluate', config)).toBe(BODY_LIMIT_DEFAULT_BYTES);
+    expect(resolveBodyLimit('/health', config)).toBe(BODY_LIMIT_DEFAULT_BYTES);
+  });
+
+  it('uses bulk limit for bulk prefix and subpaths only', () => {
+    expect(resolveBodyLimit('/api/credit/lines/bulk', config)).toBe(BODY_LIMIT_BULK_BYTES);
+    expect(resolveBodyLimit('/api/credit/lines/bulk/', config)).toBe(BODY_LIMIT_BULK_BYTES);
+    expect(resolveBodyLimit('/api/credit/lines/bulk?dry_run=true', config)).toBe(
+      BODY_LIMIT_BULK_BYTES,
+    );
+    expect(resolveBodyLimit('/api/credit/lines/bulkish', config)).toBe(
+      BODY_LIMIT_DEFAULT_BYTES,
+    );
+  });
+});
+
+describe('formatBodyLimitLabel / bodyTooLargeMessage', () => {
+  it('formats whole kib/mib counts compactly', () => {
+    expect(formatBodyLimitLabel(1024)).toBe('1kb');
+    expect(formatBodyLimitLabel(100 * 1024)).toBe('100kb');
+    expect(formatBodyLimitLabel(1024 * 1024)).toBe('1mb');
+  });
+
+  it('formats odd sizes with one decimal', () => {
+    expect(formatBodyLimitLabel(1536)).toBe('1.5kb');
+    expect(formatBodyLimitLabel(100)).toBe('100b');
+  });
+
+  it('builds a clear client message', () => {
+    const msg = bodyTooLargeMessage(BODY_LIMIT_DEFAULT_BYTES);
+    expect(msg).toMatch(/Payload Too Large/i);
+    expect(msg).toContain('100kb');
+  });
+});

--- a/src/config/bodyLimit.ts
+++ b/src/config/bodyLimit.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-endpoint request body size limits.
+ *
+ * Defaults keep typical JSON API traffic small (DoS resistance). Bulk and
+ * other high-volume ingest routes can opt into a higher ceiling. The absolute
+ * max is what `express.json` is configured with as a last-resort safety net
+ * for chunked requests without Content-Length.
+ *
+ * Env vars (optional overrides, byte counts as integers):
+ *   BODY_LIMIT_DEFAULT_BYTES  - default per-request limit (default: 102400 = 100 KiB)
+ *   BODY_LIMIT_BULK_BYTES     - bulk ingest limit (default: 1048576 = 1 MiB)
+ *   BODY_LIMIT_MAX_BYTES      - absolute parser ceiling (default: max of the above)
+ *
+ * Reverse proxies (nginx, Envoy, Cloudflare, ALB) usually enforce their own
+ * body/client-max-body-size limits *before* the request reaches Node. Keep
+ * proxy limits ≥ BODY_LIMIT_MAX_BYTES so clients see the API's structured
+ * 413 rather than a generic proxy error. See docs/body-limits.md.
+ */
+
+export interface BodyLimitRouteRule {
+  /** Path prefix matched against `req.path` (app-level) or full URL path. */
+  pathPrefix: string;
+  /** Maximum accepted body size in bytes for matching requests. */
+  maxBytes: number;
+}
+
+export interface BodyLimitConfig {
+  /** Default limit for endpoints without a more specific rule. */
+  defaultMaxBytes: number;
+  /** Absolute ceiling used by the JSON body parser. */
+  maxBytes: number;
+  /** Ordered list of path overrides; first match wins. */
+  routes: BodyLimitRouteRule[];
+}
+
+/** 100 KiB — default for typical JSON API endpoints. */
+export const BODY_LIMIT_DEFAULT_BYTES = 100 * 1024;
+
+/** 1 MiB — bulk imports and similar high-volume ingest. */
+export const BODY_LIMIT_BULK_BYTES = 1024 * 1024;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Load body-limit configuration from environment with safe defaults.
+ */
+export function loadBodyLimitConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): BodyLimitConfig {
+  const defaultMaxBytes = parsePositiveInt(
+    env.BODY_LIMIT_DEFAULT_BYTES,
+    BODY_LIMIT_DEFAULT_BYTES,
+  );
+  const bulkMaxBytes = parsePositiveInt(
+    env.BODY_LIMIT_BULK_BYTES,
+    BODY_LIMIT_BULK_BYTES,
+  );
+  const maxBytes = parsePositiveInt(
+    env.BODY_LIMIT_MAX_BYTES,
+    Math.max(defaultMaxBytes, bulkMaxBytes),
+  );
+
+  return {
+    defaultMaxBytes,
+    maxBytes,
+    routes: [
+      // Bulk credit-line ingest — higher ceiling than the default API surface.
+      { pathPrefix: '/api/credit/lines/bulk', maxBytes: bulkMaxBytes },
+    ],
+  };
+}
+
+/**
+ * Resolve the body limit that applies to a request path.
+ * First matching route prefix wins (exact path or path + `/…`); otherwise default.
+ */
+export function resolveBodyLimit(
+  path: string,
+  config: BodyLimitConfig,
+): number {
+  const normalized = (path.split('?')[0] ?? path) || '/';
+  for (const rule of config.routes) {
+    const prefix = rule.pathPrefix.endsWith('/')
+      ? rule.pathPrefix.slice(0, -1)
+      : rule.pathPrefix;
+    if (
+      normalized === prefix ||
+      normalized.startsWith(`${prefix}/`)
+    ) {
+      return rule.maxBytes;
+    }
+  }
+  return config.defaultMaxBytes;
+}
+
+/**
+ * Format a byte count for human-readable error messages (e.g. "100kb", "1mb").
+ */
+export function formatBodyLimitLabel(bytes: number): string {
+  if (bytes >= 1024 * 1024 && bytes % (1024 * 1024) === 0) {
+    return `${bytes / (1024 * 1024)}mb`;
+  }
+  if (bytes >= 1024 && bytes % 1024 === 0) {
+    return `${bytes / 1024}kb`;
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)}mb`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)}kb`;
+  }
+  return `${bytes}b`;
+}
+
+/**
+ * Build the standard 413 client-facing message for a given limit.
+ */
+export function bodyTooLargeMessage(maxBytes: number): string {
+  return `Payload Too Large. Request body exceeds the maximum size of ${formatBodyLimitLabel(maxBytes)} for this endpoint.`;
+}

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -58,6 +58,7 @@ export class Container {
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -168,7 +169,11 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
-  // Method to replace repositories (useful for testing or switching to DB implementations)
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
+  // Method to replace repositories
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;
     riskEvaluationRepository?: RiskEvaluationRepository;

--- a/src/container/__tests__/Container.contract.test.ts
+++ b/src/container/__tests__/Container.contract.test.ts
@@ -64,7 +64,7 @@ describe('Container DI contract', () => {
     });
 
     it.each(REPOSITORY_RESOLVERS)('resolves repository %s', (name) => {
-      const repo = container[name] as Record<string, unknown>;
+      const repo = container[name] as unknown as Record<string, unknown>;
       expect(repo, `${String(name)} must resolve`).toBeDefined();
       // A repository is a contract object: it must expose callable methods.
       expect(typeof repo).toBe('object');

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,17 @@ import { reconciliationRouter } from "./routes/reconciliation.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { requestLogger } from "./middleware/requestLogger.js";
 import {
+  createJsonBodyLimitVerify,
+  createPathAwareBodyLimitMiddleware,
+} from "./middleware/bodyLimit.js";
+import {
   InMemoryRateLimitStore,
   RedisRateLimitStore,
   createIpKeyGenerator,
   createRateLimitMiddleware,
 } from "./middleware/rateLimit.js";
 import { loadCorsPolicy, isAllowedCorsOrigin } from "./config/cors.js";
+import { loadBodyLimitConfig } from "./config/bodyLimit.js";
 import { loadRateLimitConfig, loadRateLimitStoreConfig } from "./config/rateLimit.js";
 import { validateEnv } from "./config/env.js";
 import { Container } from "./container/Container.js";
@@ -53,6 +58,7 @@ const SHUTDOWN_TIMEOUT_MS = parseInt(
 );
 
 const corsPolicy = loadCorsPolicy();
+const bodyLimitConfig = loadBodyLimitConfig();
 const rateLimitConfig = loadRateLimitConfig();
 const rateLimitStoreConfig = loadRateLimitStoreConfig();
 const createRateLimitStore = (namespace: string): InMemoryRateLimitStore | RedisRateLimitStore => {
@@ -134,9 +140,17 @@ app.use((req, res, next) => {
   next();
 });
 
-// 100 kb hard cap; body-parser emits a 413 that errorHandler converts to a
-// structured response.
-app.use(express.json({ limit: '100kb' }));
+// Per-endpoint body size limits (Content-Length fast-path) + JSON parser
+// capped at the absolute max. Path-specific limits (default 100kb, bulk 1mb)
+// are enforced before buffering and again in the verify hook for chunked bodies.
+// See docs/body-limits.md.
+app.use(createPathAwareBodyLimitMiddleware(bodyLimitConfig));
+app.use(
+  express.json({
+    limit: bodyLimitConfig.maxBytes,
+    verify: createJsonBodyLimitVerify(bodyLimitConfig),
+  }),
+);
 
 app.use(requestLogger);
 
@@ -148,6 +162,8 @@ app.get("/docs.json", (_req, res) => {
   res.json(openapiSpec);
 });
 
+// Bulk ingest (`/api/credit/lines/bulk`) is configured with a higher body limit
+// in `loadBodyLimitConfig()`; mount `creditBulkRouter` here when enabling it.
 app.use("/api/credit", defaultRateLimit, creditRouter);
 app.use("/api/risk/evaluate", evaluateRateLimit);
 app.use("/api/risk/wallet", defaultRateLimit);

--- a/src/middleware/__tests__/bodyLimit.test.ts
+++ b/src/middleware/__tests__/bodyLimit.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import {
+  createBodyLimitMiddleware,
+  createJsonBodyLimitVerify,
+  createPathAwareBodyLimitMiddleware,
+  isPayloadTooLargeError,
+  PayloadTooLargeError,
+  respondPayloadTooLarge,
+  type RequestWithBodyLimit,
+} from '../bodyLimit.js';
+import {
+  BODY_LIMIT_BULK_BYTES,
+  BODY_LIMIT_DEFAULT_BYTES,
+  loadBodyLimitConfig,
+} from '../../config/bodyLimit.js';
+
+function mockRes() {
+  const res: Partial<Response> & {
+    statusCode?: number;
+    body?: unknown;
+    headers: Record<string, string>;
+  } = {
+    headers: {},
+    headersSent: false,
+    status(code: number) {
+      res.statusCode = code;
+      return res as Response;
+    },
+    type(_t: string) {
+      return res as Response;
+    },
+    setHeader(name: string, value: string | number) {
+      res.headers[name.toLowerCase()] = String(value);
+      return res as Response;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res as Response;
+    },
+  };
+  return res;
+}
+
+describe('createBodyLimitMiddleware', () => {
+  it('rejects oversize Content-Length with 413', () => {
+    const mw = createBodyLimitMiddleware(100);
+    const req = {
+      headers: { 'content-length': '101' },
+    } as unknown as RequestWithBodyLimit;
+    const res = mockRes();
+    const next = vi.fn();
+
+    mw(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(413);
+    expect(res.headers['x-content-length-limit']).toBe('100');
+    expect((res.body as { title: string }).title).toBe('Payload Too Large');
+  });
+
+  it('calls next when under limit and attaches metadata', () => {
+    const mw = createBodyLimitMiddleware(1000);
+    const req = {
+      headers: { 'content-length': '50' },
+    } as unknown as RequestWithBodyLimit;
+    const res = mockRes();
+    const next = vi.fn();
+
+    mw(req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.bodyLimitBytes).toBe(1000);
+    expect(req.bodyLimitLabel).toBe('1000b');
+  });
+
+  it('throws when maxBytes is invalid', () => {
+    expect(() => createBodyLimitMiddleware(0)).toThrow(/positive/);
+    expect(() => createBodyLimitMiddleware(-1)).toThrow(/positive/);
+  });
+});
+
+describe('createPathAwareBodyLimitMiddleware', () => {
+  const config = loadBodyLimitConfig({});
+
+  it('applies bulk limit on bulk path', () => {
+    const mw = createPathAwareBodyLimitMiddleware(config);
+    const req = {
+      headers: {},
+      originalUrl: '/api/credit/lines/bulk?dry_run=true',
+      path: '/api/credit/lines/bulk',
+    } as unknown as RequestWithBodyLimit;
+    const next = vi.fn();
+
+    mw(req as Request, mockRes() as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.bodyLimitBytes).toBe(BODY_LIMIT_BULK_BYTES);
+  });
+
+  it('applies default limit elsewhere', () => {
+    const mw = createPathAwareBodyLimitMiddleware(config);
+    const req = {
+      headers: { 'content-length': String(BODY_LIMIT_DEFAULT_BYTES + 10) },
+      originalUrl: '/api/risk/evaluate',
+      path: '/api/risk/evaluate',
+    } as unknown as RequestWithBodyLimit;
+    const res = mockRes();
+    const next = vi.fn();
+
+    mw(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(413);
+    expect((res.body as { limit: number }).limit).toBe(BODY_LIMIT_DEFAULT_BYTES);
+  });
+});
+
+describe('createJsonBodyLimitVerify', () => {
+  it('throws PayloadTooLargeError when buffer exceeds path limit', () => {
+    const config = loadBodyLimitConfig({});
+    const verify = createJsonBodyLimitVerify(config);
+    const req = {
+      headers: {},
+      originalUrl: '/api/risk/evaluate',
+      path: '/api/risk/evaluate',
+    } as unknown as RequestWithBodyLimit;
+    const buf = Buffer.alloc(BODY_LIMIT_DEFAULT_BYTES + 1);
+
+    expect(() => verify(req as Request, mockRes() as Response, buf)).toThrow(
+      PayloadTooLargeError,
+    );
+  });
+
+  it('allows buffers within the limit', () => {
+    const config = loadBodyLimitConfig({});
+    const verify = createJsonBodyLimitVerify(config);
+    const req = {
+      headers: {},
+      originalUrl: '/api/credit/lines/bulk',
+      path: '/api/credit/lines/bulk',
+    } as unknown as RequestWithBodyLimit;
+    const buf = Buffer.alloc(200 * 1024);
+
+    expect(() => verify(req as Request, mockRes() as Response, buf)).not.toThrow();
+    expect(req.rawBodyLength).toBe(200 * 1024);
+    expect(req.bodyLimitBytes).toBe(BODY_LIMIT_BULK_BYTES);
+  });
+});
+
+describe('isPayloadTooLargeError / respondPayloadTooLarge', () => {
+  it('detects PayloadTooLargeError and body-parser shapes', () => {
+    expect(isPayloadTooLargeError(new PayloadTooLargeError(10))).toBe(true);
+    expect(isPayloadTooLargeError({ type: 'entity.too.large', status: 413 })).toBe(true);
+    expect(isPayloadTooLargeError({ status: 413 })).toBe(true);
+    expect(isPayloadTooLargeError(new Error('nope'))).toBe(false);
+    expect(isPayloadTooLargeError(null)).toBe(false);
+  });
+
+  it('is a no-op when headers already sent', () => {
+    const res = mockRes();
+    res.headersSent = true;
+    respondPayloadTooLarge(res as Response, 100);
+    expect(res.statusCode).toBeUndefined();
+  });
+});

--- a/src/middleware/bodyLimit.ts
+++ b/src/middleware/bodyLimit.ts
@@ -1,0 +1,208 @@
+/**
+ * Per-endpoint request body size limits.
+ *
+ * Two complementary guards:
+ *
+ * 1. {@link createBodyLimitMiddleware} / {@link createPathAwareBodyLimitMiddleware}
+ *    — early `Content-Length` check so oversized requests are rejected before
+ *    the body is buffered into memory.
+ * 2. {@link createJsonBodyLimitVerify} — `express.json` `verify` callback that
+ *    enforces the path-specific limit on the raw buffer (covers chunked
+ *    transfer encoding where Content-Length is absent).
+ *
+ * Oversized bodies produce a typed error that {@link errorHandler} maps to a
+ * structured `413 Payload Too Large` envelope response.
+ *
+ * See `docs/body-limits.md` for defaults and reverse-proxy guidance.
+ */
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import {
+  bodyTooLargeMessage,
+  formatBodyLimitLabel,
+  resolveBodyLimit,
+  type BodyLimitConfig,
+} from '../config/bodyLimit.js';
+import { fail } from '../utils/response.js';
+import { HTTP_PAYLOAD_TOO_LARGE } from '../utils/httpStatus.js';
+
+/** Augmented request fields used by body-limit middleware and errorHandler. */
+export interface BodyLimitRequestFields {
+  /** Resolved max body size (bytes) for this request. */
+  bodyLimitBytes?: number;
+  /** Human label for the limit (e.g. "100kb"). */
+  bodyLimitLabel?: string;
+  /** Raw body byte length observed by the JSON parser verify hook. */
+  rawBodyLength?: number;
+}
+
+export type RequestWithBodyLimit = Request & BodyLimitRequestFields;
+
+/**
+ * Error thrown / passed to next() when a request body exceeds its limit.
+ * Compatible with body-parser's `entity.too.large` shape so one errorHandler
+ * branch covers both sources.
+ */
+export class PayloadTooLargeError extends Error {
+  readonly status = HTTP_PAYLOAD_TOO_LARGE;
+  readonly statusCode = HTTP_PAYLOAD_TOO_LARGE;
+  readonly type = 'entity.too.large';
+  readonly limit: number;
+  readonly length?: number;
+  readonly expose = true;
+
+  constructor(limit: number, length?: number) {
+    super(bodyTooLargeMessage(limit));
+    this.name = 'PayloadTooLargeError';
+    this.limit = limit;
+    this.length = length;
+  }
+}
+
+export function isPayloadTooLargeError(
+  err: unknown,
+): err is PayloadTooLargeError | { type: string; status?: number; limit?: number } {
+  if (err instanceof PayloadTooLargeError) {
+    return true;
+  }
+  if (typeof err !== 'object' || err === null) {
+    return false;
+  }
+  const maybe = err as { type?: string; status?: number; statusCode?: number };
+  return (
+    maybe.type === 'entity.too.large' ||
+    maybe.status === HTTP_PAYLOAD_TOO_LARGE ||
+    maybe.statusCode === HTTP_PAYLOAD_TOO_LARGE
+  );
+}
+
+function attachLimitMeta(req: RequestWithBodyLimit, maxBytes: number): void {
+  req.bodyLimitBytes = maxBytes;
+  req.bodyLimitLabel = formatBodyLimitLabel(maxBytes);
+}
+
+function contentLengthExceeds(req: Request, maxBytes: number): number | null {
+  const raw = req.headers['content-length'];
+  if (raw === undefined) {
+    return null;
+  }
+  const length = Number(raw);
+  if (!Number.isFinite(length) || length < 0) {
+    return null;
+  }
+  return length > maxBytes ? length : null;
+}
+
+/**
+ * Fixed-limit middleware for a single route or router.
+ *
+ * @example
+ * ```ts
+ * router.post('/lines/bulk', createBodyLimitMiddleware(BODY_LIMIT_BULK_BYTES), handler);
+ * ```
+ */
+export function createBodyLimitMiddleware(maxBytes: number): RequestHandler {
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0) {
+    throw new Error('createBodyLimitMiddleware: maxBytes must be a positive number');
+  }
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const r = req as RequestWithBodyLimit;
+    attachLimitMeta(r, maxBytes);
+
+    const oversize = contentLengthExceeds(req, maxBytes);
+    if (oversize !== null) {
+      respondPayloadTooLarge(res, maxBytes, oversize);
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Path-aware body limit middleware. Resolves the limit from {@link BodyLimitConfig}
+ * using `req.path` (or `req.originalUrl` path) and rejects early on Content-Length.
+ */
+export function createPathAwareBodyLimitMiddleware(
+  config: BodyLimitConfig,
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const path = requestPath(req);
+    const maxBytes = resolveBodyLimit(path, config);
+    const r = req as RequestWithBodyLimit;
+    attachLimitMeta(r, maxBytes);
+
+    const oversize = contentLengthExceeds(req, maxBytes);
+    if (oversize !== null) {
+      respondPayloadTooLarge(res, maxBytes, oversize);
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * `express.json({ verify })` hook: enforces the path-specific limit on the
+ * raw buffer. Throws {@link PayloadTooLargeError} which errorHandler maps to 413.
+ */
+export function createJsonBodyLimitVerify(
+  config: BodyLimitConfig,
+): (req: Request, _res: Response, buf: Buffer) => void {
+  return (req: Request, _res: Response, buf: Buffer): void => {
+    const r = req as RequestWithBodyLimit;
+    const path = requestPath(req);
+    const maxBytes = r.bodyLimitBytes ?? resolveBodyLimit(path, config);
+    attachLimitMeta(r, maxBytes);
+    r.rawBodyLength = buf.length;
+
+    if (buf.length > maxBytes) {
+      throw new PayloadTooLargeError(maxBytes, buf.length);
+    }
+  };
+}
+
+/**
+ * Write a 413 envelope response (also usable outside errorHandler for early rejects).
+ */
+export function respondPayloadTooLarge(
+  res: Response,
+  maxBytes: number,
+  length?: number,
+): void {
+  if (res.headersSent) {
+    return;
+  }
+  res.setHeader('X-Content-Length-Limit', String(maxBytes));
+  if (length !== undefined) {
+    res.setHeader('X-Content-Length-Received', String(length));
+  }
+  // RFC 7807-compatible problem details *and* the project envelope so existing
+  // clients keep working while problem-aware clients can key off type/title.
+  const label = formatBodyLimitLabel(maxBytes);
+  const message = bodyTooLargeMessage(maxBytes);
+  res.status(HTTP_PAYLOAD_TOO_LARGE).type('application/problem+json').json({
+    type: 'https://httpstatuses.com/413',
+    title: 'Payload Too Large',
+    status: HTTP_PAYLOAD_TOO_LARGE,
+    detail: message,
+    limit: maxBytes,
+    limitLabel: label,
+    // Project envelope fields (docs/error-envelope.md)
+    data: null,
+    error: message,
+  });
+}
+
+function requestPath(req: Request): string {
+  // Prefer originalUrl path so mount points do not hide the full route.
+  const raw = req.originalUrl || req.url || req.path || '';
+  const q = raw.indexOf('?');
+  return q === -1 ? raw : raw.slice(0, q);
+}
+
+// Keep fail() available for callers that want the plain envelope only.
+export function failPayloadTooLarge(res: Response, maxBytes: number): void {
+  res.setHeader('X-Content-Length-Limit', String(maxBytes));
+  fail(res, bodyTooLargeMessage(maxBytes), HTTP_PAYLOAD_TOO_LARGE);
+}

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,5 +1,15 @@
 import type { Request, Response, NextFunction } from 'express';
 import { fail } from '../utils/response.js';
+import {
+  isPayloadTooLargeError,
+  respondPayloadTooLarge,
+  type RequestWithBodyLimit,
+} from './bodyLimit.js';
+import {
+  BODY_LIMIT_DEFAULT_BYTES,
+  bodyTooLargeMessage,
+} from '../config/bodyLimit.js';
+import { HTTP_PAYLOAD_TOO_LARGE } from '../utils/httpStatus.js';
 
 /**
  * Standard error response interface for OpenAPI documentation
@@ -14,20 +24,39 @@ export interface ErrorResponse {
  *
  * Catches any unhandled errors thrown (or passed via `next(err)`) from route
  * handlers and returns a consistent JSON error response using the fail() helper.
- * 
+ *
  * In production, stack traces and internal error details are not leaked.
+ * Oversized bodies (body-parser or {@link PayloadTooLargeError}) return an
+ * explicit `413 Payload Too Large` problem+json + envelope response.
  */
 export function errorHandler(
   err: unknown,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction,
 ): void {
-  const maybeError = err as { status?: number; type?: string };
+  const maybeError = err as {
+    status?: number;
+    statusCode?: number;
+    type?: string;
+    limit?: number;
+    length?: number;
+  };
 
-  // Body-parser emits this type when the payload exceeds the configured limit.
-  if (maybeError.type === 'entity.too.large' || maybeError.status === 413) {
-    fail(res, 'Request body too large. Maximum size is 100kb.', 413);
+  // Body-parser and createJsonBodyLimitVerify emit entity.too.large / 413.
+  // Prefer the path-resolved limit attached by body-limit middleware so a
+  // parser-ceiling rejection still reports the endpoint's policy, not only
+  // the absolute maxBytes used by express.json.
+  if (isPayloadTooLargeError(err)) {
+    const fromReq = (req as RequestWithBodyLimit).bodyLimitBytes;
+    const fromErr =
+      typeof maybeError.limit === 'number' && maybeError.limit > 0
+        ? maybeError.limit
+        : undefined;
+    const limit = fromReq ?? fromErr ?? BODY_LIMIT_DEFAULT_BYTES;
+    const length =
+      typeof maybeError.length === 'number' ? maybeError.length : undefined;
+    respondPayloadTooLarge(res, limit, length);
     return;
   }
 
@@ -38,7 +67,7 @@ export function errorHandler(
       name: err.name,
     });
 
-    const status = maybeError.status ?? statusFromName(err.name);
+    const status = maybeError.status ?? maybeError.statusCode ?? statusFromName(err.name);
     fail(res, status >= 500 ? 'Internal server error' : err.message, status);
     return;
   }
@@ -46,6 +75,13 @@ export function errorHandler(
   console.error('[errorHandler]', err);
   fail(res, typeof err === 'string' ? err : 'Internal server error', 500);
 }
+
+/** @deprecated Prefer respondPayloadTooLarge; kept for call-site clarity in docs. */
+export function payloadTooLargeMessage(limitBytes = BODY_LIMIT_DEFAULT_BYTES): string {
+  return bodyTooLargeMessage(limitBytes);
+}
+
+export { HTTP_PAYLOAD_TOO_LARGE };
 
 function statusFromName(name: string): number {
   switch (name) {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -464,6 +464,36 @@ components:
           type: string
           example: "Too many requests"
 
+    PayloadTooLargeProblem:
+      type: object
+      description: RFC 7807 problem details plus project envelope fields for 413 responses
+      required: [type, title, status, detail, data, error]
+      properties:
+        type:
+          type: string
+          format: uri
+          example: https://httpstatuses.com/413
+        title:
+          type: string
+          example: Payload Too Large
+        status:
+          type: integer
+          example: 413
+        detail:
+          type: string
+        limit:
+          type: integer
+          description: Maximum accepted body size in bytes for this endpoint
+        limitLabel:
+          type: string
+          description: Human-readable limit (e.g. 100kb)
+        data:
+          nullable: true
+          example: null
+        error:
+          type: string
+          description: Envelope-compatible error message (same text as detail)
+
 paths:
   /health:
     get:
@@ -1092,14 +1122,20 @@ paths:
               example:
                 error: Validation failed
         "413":
-          description: Request body exceeds the 100 kb limit
+          description: Request body exceeds the per-endpoint size limit (default 100 KiB)
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/PayloadTooLargeProblem"
               example:
+                type: https://httpstatuses.com/413
+                title: Payload Too Large
+                status: 413
+                detail: Payload Too Large. Request body exceeds the maximum size of 100kb for this endpoint.
+                limit: 102400
+                limitLabel: 100kb
                 data: null
-                error: Request body too large. Maximum size is 100kb.
+                error: Payload Too Large. Request body exceeds the maximum size of 100kb for this endpoint.
         "415":
           description: Content-Type is not application/json
           content:

--- a/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
+++ b/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
@@ -13,7 +13,6 @@ import type { TransactionRepository } from '../interfaces/TransactionRepository.
 // ---------------------------------------------------------------------------
 
 const CREDIT_LINE_ID = '00000000-0000-0000-0000-000000000001';
-const WALLET = 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1';
 
 function sampleRequest(overrides: Partial<CreateTransactionRequest> = {}): CreateTransactionRequest {
   return {

--- a/src/repositories/postgres/PostgresTransactionRepository.ts
+++ b/src/repositories/postgres/PostgresTransactionRepository.ts
@@ -2,7 +2,7 @@ import {
   type Transaction,
   type CreateTransactionRequest,
   TransactionStatus,
-  TransactionType,
+  type TransactionType,
 } from '../../models/Transaction.js';
 import type { TransactionRepository } from '../interfaces/TransactionRepository.js';
 import type { DbClient } from '../../db/client.js';

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import { metricsRouter, recordRequest } from '../metrics.js';
 
@@ -45,16 +45,6 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
       return this;
     },
   } as unknown as Response;
-
-  const runHandlers = async (index: number): Promise<void> => {
-    if (index >= handlers.length) return;
-    await new Promise<void>((resolve) => {
-      handlers[index](req, res, () => {
-        resolve();
-        runHandlers(index + 1);
-      });
-    });
-  };
 
   // Execute the first handler (auth guard); if it calls next, proceed to the route handler.
   await new Promise<void>((resolve) => {

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -23,9 +23,8 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
     throw new Error(`Route not found: ${args.method.toUpperCase()} ${args.path}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handlers: Array<(req: Request, res: Response, next: NextFunction) => unknown> =
-    layer.route.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
+    layer.route!.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
 
   let statusCode = 200;
   let responseBody: unknown = null;

--- a/src/routes/creditBulk.ts
+++ b/src/routes/creditBulk.ts
@@ -54,8 +54,13 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
 
       try {
-        const creditService = container.getCreditService();
-        const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
+        const creditService = container.creditLineService;
+        const body = parsed.data as CreateCreditLineBody;
+        const line = await creditService.createCreditLine({
+          walletAddress: body.walletAddress,
+          creditLimit: body.creditLimit ?? body.requestedLimit ?? '',
+          interestRateBps: body.interestRateBps ?? 0,
+        });
         results.push({ index: i + 1, status: 'created', id: line.id });
         created++;
       } catch (err) {
@@ -64,9 +69,9 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
     }
 
-    return res.status(207).json(ok({ summary: { total: rows.length, created, failed, dry_run: isDryRun }, results }));
+    return ok(res, { summary: { total: rows.length, created, failed, dry_run: isDryRun } as Record<string, unknown>, results }, 207);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -23,7 +23,7 @@
  *
  * See `docs/OBSERVABILITY.md` for Grafana dashboard JSON and Alertmanager rules.
  */
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import { ok, fail } from '../utils/response.js';
 
 export const metricsRouter = Router();

--- a/src/routes/simulation.ts
+++ b/src/routes/simulation.ts
@@ -31,7 +31,7 @@ simulationRouter.post(
 
       const { amount } = req.body as DrawBody;
       const drawAmount = Number(amount);
-      const availableCredit = Number(line.creditLimit) - Number(line.balance ?? 0);
+      const availableCredit = Number(line.creditLimit) - Number(line.utilized ?? 0);
       const valid = drawAmount > 0 && drawAmount <= availableCredit;
       const interestBps: number = (line as unknown as Record<string, unknown>)['interestRateBps'] as number ?? 0;
       const estimatedFee = Math.ceil(drawAmount * interestBps / INTEREST_RATE_DIVISOR);
@@ -46,13 +46,13 @@ simulationRouter.post(
         preview: {
           requestedAmount: drawAmount,
           estimatedFee,
-          newBalance: valid ? Number(line.balance ?? 0) + drawAmount : null,
+          newBalance: valid ? Number(line.utilized ?? 0) + drawAmount : null,
           remainingCredit: valid ? availableCredit - drawAmount : availableCredit,
         },
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );
@@ -67,7 +67,7 @@ simulationRouter.post(
 
       const { amount } = req.body as RepayBody;
       const repayAmount = Number(amount);
-      const currentBalance = Number(line.balance ?? 0);
+      const currentBalance = Number(line.utilized ?? 0);
       const effectiveRepay = Math.min(repayAmount, currentBalance);
       const valid = repayAmount > 0;
 
@@ -84,7 +84,7 @@ simulationRouter.post(
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );

--- a/src/services/__tests__/dashboardSummaryService.test.ts
+++ b/src/services/__tests__/dashboardSummaryService.test.ts
@@ -80,7 +80,7 @@ describe('DashboardSummaryService caching', () => {
   });
 
   it('recomputes immediately after invalidate()', async () => {
-    let now = 0;
+    const now = 0;
     const { repo, findAll } = repoOf([line({})]);
     const service = new DashboardSummaryService(repo, 30_000, () => now);
 

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -19,6 +19,7 @@ import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
 import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
 import { redactLogArgs } from "../utils/logRedact.js";
+import { logger as log } from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -200,11 +201,7 @@ async function retryWithBackoff<T>(
             lastError = error as Error;
             
             if (attempt <= maxRetries) {
-                log.warn("webhook:delivery:retry", {
-                    attempt,
-                    retryInMs: delay,
-                    error: lastError,
-                });
+                log.warn({ attempt, retryInMs: delay, error: lastError }, "webhook:delivery:retry");
                 await new Promise(resolve => setTimeout(resolve, delay));
                 delay = Math.floor(delay * backoffMultiplier);
             }
@@ -241,7 +238,7 @@ function parseDrawConfirmedEvent(event: HorizonEvent): WebhookPayload | null {
             }
         };
     } catch (error) {
-        log.error("webhook:event-parse:failed", { error });
+        log.error({ error }, "webhook:event-parse:failed");
         return null;
     }
 }
@@ -257,13 +254,9 @@ export function getWebhookConfig(): WebhookConfig | null {
 export function initializeWebhooks(): void {
     try {
         activeConfig = resolveWebhookConfig();
-        log.info("webhook:initialized", {
-            urls: activeConfig.urls.length,
-            maxRetries: activeConfig.maxRetries,
-            timeoutMs: activeConfig.timeoutMs
-        });
+        log.info({ urls: activeConfig.urls.length, maxRetries: activeConfig.maxRetries, timeoutMs: activeConfig.timeoutMs }, "webhook:initialized");
     } catch (error) {
-        log.error("webhook:initialize:failed", { error });
+        log.error({ error }, "webhook:initialize:failed");
         activeConfig = null;
     }
 }
@@ -278,20 +271,14 @@ export async function sendDrawConfirmationWebhook(
 
     const payload = parseDrawConfirmedEvent(event);
     if (!payload) {
-        log.info("webhook:delivery:skipped-non-draw-event", {
-            ledger: event.ledger,
-            contractId: event.contractId,
-        });
+        log.info({ ledger: event.ledger, contractId: event.contractId }, "webhook:delivery:skipped-non-draw-event");
         return [];
     }
 
     const payloadString = JSON.stringify(payload);
     const signature = generateSignature(payloadString, activeConfig.secret);
 
-    log.info("webhook:delivery:start", {
-        drawId: payload.data.drawId,
-        deliveryCount: activeConfig.urls.length,
-    });
+    log.info({ drawId: payload.data.drawId, deliveryCount: activeConfig.urls.length }, "webhook:delivery:start");
 
     const store = getWebhookDeliveryStateStore();
 
@@ -355,10 +342,7 @@ export async function sendDrawConfirmationWebhook(
     const successCount = results.filter(r => r.success).length;
     const failureCount = results.length - successCount;
     
-    log.info("webhook:delivery:complete", {
-        successful: successCount,
-        failed: failureCount,
-    });
+    log.info({ successful: successCount, failed: failureCount }, "webhook:delivery:complete");
 
     return results;
 }

--- a/src/utils/__tests__/constants.test.ts
+++ b/src/utils/__tests__/constants.test.ts
@@ -25,5 +25,7 @@ describe('shared constants', () => {
 
     it('caps JSON body size at a reasonable value', () => {
         expect(MAX_JSON_BODY_BYTES).toBeGreaterThan(1024);
+        // Default matches the documented 100 KiB API limit.
+        expect(MAX_JSON_BODY_BYTES).toBe(100 * 1024);
     });
 });

--- a/src/utils/__tests__/httpStatus.test.ts
+++ b/src/utils/__tests__/httpStatus.test.ts
@@ -8,6 +8,8 @@ import {
     HTTP_FORBIDDEN,
     HTTP_NOT_FOUND,
     HTTP_CONFLICT,
+    HTTP_PAYLOAD_TOO_LARGE,
+    HTTP_UNSUPPORTED_MEDIA_TYPE,
     HTTP_UNPROCESSABLE_ENTITY,
     HTTP_TOO_MANY_REQUESTS,
     HTTP_INTERNAL_SERVER_ERROR,
@@ -29,6 +31,8 @@ describe('HTTP status constants', () => {
         expect(HTTP_FORBIDDEN).toBe(403);
         expect(HTTP_NOT_FOUND).toBe(404);
         expect(HTTP_CONFLICT).toBe(409);
+        expect(HTTP_PAYLOAD_TOO_LARGE).toBe(413);
+        expect(HTTP_UNSUPPORTED_MEDIA_TYPE).toBe(415);
         expect(HTTP_UNPROCESSABLE_ENTITY).toBe(422);
         expect(HTTP_TOO_MANY_REQUESTS).toBe(429);
     });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,5 +20,13 @@ export const MIN_PAGE_SIZE = 1;
 /** Default cursor pagination batch size. */
 export const DEFAULT_CURSOR_BATCH_SIZE = 50;
 
-/** Maximum allowed body size (in bytes) for typical JSON API requests. */
-export const MAX_JSON_BODY_BYTES = 1_000_000;
+/**
+ * Maximum allowed body size (in bytes) for typical JSON API requests.
+ * Prefer `loadBodyLimitConfig()` / `BODY_LIMIT_DEFAULT_BYTES` from
+ * `src/config/bodyLimit.ts` for runtime enforcement; this constant remains
+ * as a shared default for callers that only need the numeric default.
+ */
+export const MAX_JSON_BODY_BYTES = 100 * 1024;
+
+/** Higher ceiling for bulk ingest endpoints (bytes). */
+export const MAX_JSON_BODY_BULK_BYTES = 1024 * 1024;

--- a/src/utils/httpStatus.ts
+++ b/src/utils/httpStatus.ts
@@ -16,6 +16,8 @@ export const HTTP_UNAUTHORIZED = 401 as const;
 export const HTTP_FORBIDDEN = 403 as const;
 export const HTTP_NOT_FOUND = 404 as const;
 export const HTTP_CONFLICT = 409 as const;
+export const HTTP_PAYLOAD_TOO_LARGE = 413 as const;
+export const HTTP_UNSUPPORTED_MEDIA_TYPE = 415 as const;
 export const HTTP_UNPROCESSABLE_ENTITY = 422 as const;
 export const HTTP_TOO_MANY_REQUESTS = 429 as const;
 

--- a/tests/middleware/bodyLimits.test.ts
+++ b/tests/middleware/bodyLimits.test.ts
@@ -1,9 +1,33 @@
 import { describe, it, expect } from 'vitest';
+import express from 'express';
 import request from 'supertest';
 import { app } from '../../src/index.js';
+import {
+  BODY_LIMIT_BULK_BYTES,
+  BODY_LIMIT_DEFAULT_BYTES,
+  bodyTooLargeMessage,
+  formatBodyLimitLabel,
+  loadBodyLimitConfig,
+  resolveBodyLimit,
+} from '../../src/config/bodyLimit.js';
+import {
+  createBodyLimitMiddleware,
+  createJsonBodyLimitVerify,
+  createPathAwareBodyLimitMiddleware,
+  PayloadTooLargeError,
+  respondPayloadTooLarge,
+} from '../../src/middleware/bodyLimit.js';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
 
-describe('JSON body size limit', () => {
-  it('accepts a payload within the 100kb limit', async () => {
+function buildSizedJson(approxBytes: number): string {
+  // Produce a JSON object whose serialized size is slightly above/around target.
+  const overhead = '{"walletAddress":""}'.length;
+  const pad = Math.max(0, approxBytes - overhead);
+  return JSON.stringify({ walletAddress: 'x'.repeat(pad) });
+}
+
+describe('JSON body size limit (default endpoints)', () => {
+  it('accepts a payload within the default 100kb limit', async () => {
     const res = await request(app)
       .post('/api/risk/evaluate')
       .set('Content-Type', 'application/json')
@@ -12,20 +36,188 @@ describe('JSON body size limit', () => {
     expect(res.status).not.toBe(413);
   });
 
-  it('returns 413 for a payload exceeding 100kb', async () => {
-    // ~110 kb of JSON
-    const largeBody = JSON.stringify({ walletAddress: 'x'.repeat(110 * 1024) });
+  it('returns 413 problem+json for a payload exceeding 100kb', async () => {
+    const largeBody = buildSizedJson(110 * 1024);
 
     const res = await request(app)
       .post('/api/risk/evaluate')
       .set('Content-Type', 'application/json')
+      .set('Content-Length', String(Buffer.byteLength(largeBody)))
       .send(largeBody);
 
     expect(res.status).toBe(413);
+    expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
+    expect(res.headers['x-content-length-limit']).toBe(String(BODY_LIMIT_DEFAULT_BYTES));
     expect(res.body).toMatchObject({
+      type: 'https://httpstatuses.com/413',
+      title: 'Payload Too Large',
+      status: 413,
       data: null,
-      error: expect.stringContaining('100kb'),
+      error: expect.stringMatching(/Payload Too Large/i),
+      limit: BODY_LIMIT_DEFAULT_BYTES,
+      limitLabel: '100kb',
     });
+    expect(res.body.detail).toContain('100kb');
+    expect(res.body.error).toContain('100kb');
+  });
+
+});
+
+describe('per-endpoint body limits', () => {
+  function buildAppWithLimits() {
+    const config = loadBodyLimitConfig();
+    const testApp = express();
+    testApp.use(createPathAwareBodyLimitMiddleware(config));
+    testApp.use(
+      express.json({
+        limit: config.maxBytes,
+        verify: createJsonBodyLimitVerify(config),
+      }),
+    );
+
+    testApp.post('/api/risk/evaluate', (_req, res) => {
+      res.status(200).json({ data: { ok: true }, error: null });
+    });
+    testApp.post('/api/credit/lines/bulk', (_req, res) => {
+      res.status(200).json({ data: { ok: true }, error: null });
+    });
+    // Route-level fixed middleware example (webhook-style)
+    testApp.post(
+      '/api/custom/small',
+      createBodyLimitMiddleware(1024),
+      express.json({ limit: 1024 }),
+      (_req, res) => {
+        res.status(200).json({ data: { ok: true }, error: null });
+      },
+    );
+    testApp.use(errorHandler);
+    return testApp;
+  }
+
+  it('allows ~200kb on the bulk path (higher limit) but not on default paths', async () => {
+    const testApp = buildAppWithLimits();
+    const midBody = buildSizedJson(200 * 1024);
+
+    const defaultRes = await request(testApp)
+      .post('/api/risk/evaluate')
+      .set('Content-Type', 'application/json')
+      .send(midBody);
+
+    expect(defaultRes.status).toBe(413);
+    expect(defaultRes.body.limit).toBe(BODY_LIMIT_DEFAULT_BYTES);
+
+    const bulkRes = await request(testApp)
+      .post('/api/credit/lines/bulk')
+      .set('Content-Type', 'application/json')
+      .send(midBody);
+
+    expect(bulkRes.status).toBe(200);
+    expect(bulkRes.body).toMatchObject({ data: { ok: true } });
+  });
+
+  it('returns 413 on bulk when payload exceeds the bulk ceiling', async () => {
+    const testApp = buildAppWithLimits();
+    const huge = buildSizedJson(BODY_LIMIT_BULK_BYTES + 50 * 1024);
+
+    const res = await request(testApp)
+      .post('/api/credit/lines/bulk')
+      .set('Content-Type', 'application/json')
+      .send(huge);
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({
+      title: 'Payload Too Large',
+      status: 413,
+      limit: BODY_LIMIT_BULK_BYTES,
+      limitLabel: '1mb',
+      data: null,
+    });
+    expect(res.body.error).toMatch(/1mb/i);
+  });
+
+  it('supports fixed createBodyLimitMiddleware on a single route', async () => {
+    const testApp = buildAppWithLimits();
+    const over1k = buildSizedJson(2048);
+
+    const res = await request(testApp)
+      .post('/api/custom/small')
+      .set('Content-Type', 'application/json')
+      .send(over1k);
+
+    expect(res.status).toBe(413);
+    expect(res.body.limit).toBe(1024);
+  });
+});
+
+describe('body limit config helpers', () => {
+  it('loads defaults', () => {
+    const config = loadBodyLimitConfig({});
+    expect(config.defaultMaxBytes).toBe(BODY_LIMIT_DEFAULT_BYTES);
+    expect(config.maxBytes).toBeGreaterThanOrEqual(BODY_LIMIT_BULK_BYTES);
+    expect(config.routes.some((r) => r.pathPrefix.includes('bulk'))).toBe(true);
+  });
+
+  it('respects env overrides', () => {
+    const config = loadBodyLimitConfig({
+      BODY_LIMIT_DEFAULT_BYTES: '2048',
+      BODY_LIMIT_BULK_BYTES: '4096',
+      BODY_LIMIT_MAX_BYTES: '8192',
+    });
+    expect(config.defaultMaxBytes).toBe(2048);
+    expect(config.routes[0]?.maxBytes).toBe(4096);
+    expect(config.maxBytes).toBe(8192);
+  });
+
+  it('resolves path prefixes', () => {
+    const config = loadBodyLimitConfig({});
+    expect(resolveBodyLimit('/api/risk/evaluate', config)).toBe(BODY_LIMIT_DEFAULT_BYTES);
+    expect(resolveBodyLimit('/api/credit/lines/bulk', config)).toBe(BODY_LIMIT_BULK_BYTES);
+    expect(resolveBodyLimit('/api/credit/lines/bulk/extra', config)).toBe(BODY_LIMIT_BULK_BYTES);
+    expect(resolveBodyLimit('/api/credit/lines/bulkish', config)).toBe(BODY_LIMIT_DEFAULT_BYTES);
+  });
+
+  it('formats labels and messages', () => {
+    expect(formatBodyLimitLabel(100 * 1024)).toBe('100kb');
+    expect(formatBodyLimitLabel(1024 * 1024)).toBe('1mb');
+    expect(bodyTooLargeMessage(100 * 1024)).toMatch(/100kb/);
+  });
+});
+
+describe('PayloadTooLargeError and respondPayloadTooLarge', () => {
+  it('exposes body-parser compatible fields', () => {
+    const err = new PayloadTooLargeError(100, 200);
+    expect(err.status).toBe(413);
+    expect(err.type).toBe('entity.too.large');
+    expect(err.limit).toBe(100);
+    expect(err.length).toBe(200);
+  });
+
+  it('writes problem+json via respondPayloadTooLarge', async () => {
+    const testApp = express();
+    testApp.post('/x', (_req, res) => {
+      respondPayloadTooLarge(res, 2048, 4096);
+    });
+
+    const res = await request(testApp).post('/x');
+    expect(res.status).toBe(413);
+    expect(res.headers['x-content-length-limit']).toBe('2048');
+    expect(res.headers['x-content-length-received']).toBe('4096');
+    expect(res.body.title).toBe('Payload Too Large');
+    expect(res.body.data).toBeNull();
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('errorHandler maps entity.too.large to 413 problem+json', async () => {
+    const testApp = express();
+    testApp.post('/x', (_req, _res, next) => {
+      next(new PayloadTooLargeError(BODY_LIMIT_DEFAULT_BYTES, 999_999));
+    });
+    testApp.use(errorHandler);
+
+    const res = await request(testApp).post('/x');
+    expect(res.status).toBe(413);
+    expect(res.body.limit).toBe(BODY_LIMIT_DEFAULT_BYTES);
+    expect(res.body.error).toMatch(/Payload Too Large/i);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements per-endpoint request body size limits with explicit `413 Payload Too Large` problem+json responses to mitigate large-payload DoS.

**Closes #206**

## Changes

- **Config** (`src/config/bodyLimit.ts`): defaults (100 KiB API / 1 MiB bulk), path rules, env overrides (`BODY_LIMIT_DEFAULT_BYTES`, `BODY_LIMIT_BULK_BYTES`, `BODY_LIMIT_MAX_BYTES`)
- **Middleware** (`src/middleware/bodyLimit.ts`):
  - `createPathAwareBodyLimitMiddleware` — early `Content-Length` reject per path
  - `createBodyLimitMiddleware(maxBytes)` — fixed limit for individual routes
  - `createJsonBodyLimitVerify` — enforces path limit on raw buffer (chunked bodies)
  - `respondPayloadTooLarge` — RFC 7807 problem+json **and** project `{ data, error }` envelope
- **Wiring** in `src/index.ts` + enhanced `errorHandler` for `entity.too.large` / `PayloadTooLargeError`
- **Docs**: `docs/body-limits.md` (defaults + reverse-proxy recommendations), updates to API/SECURITY/ARCHITECTURE/README/OpenAPI/`.env.example`

## Defaults

| Scope | Limit |
|---|---|
| Default API endpoints | 100 KiB |
| `/api/credit/lines/bulk` | 1 MiB |
| `express.json` absolute ceiling | max of the above |

## Reverse proxy

Proxy body limits should be **≥** `BODY_LIMIT_MAX_BYTES` so clients see the API structured 413 rather than a generic gateway error (nginx `client_max_body_size`, Envoy buffers, etc.). Details in `docs/body-limits.md`.

## Tests

```bash
npx vitest --run tests/middleware/bodyLimits.test.ts src/config/__tests__/bodyLimit.test.ts src/middleware/__tests__/bodyLimit.test.ts
```

Covers: default 413, bulk higher ceiling, fixed route middleware, problem+json shape, config resolution.