### PR TITLE
feat(api): consistent 409 conflict responses for duplicate resources

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -63,7 +63,7 @@ Rate-limit responses additionally include `retryAfter` and the `Retry-After` HTT
 | 401 | Auth header missing |
 | 403 | Auth header present but invalid |
 | 404 | Resource not found |
-| 409 | Invalid state transition (e.g. close-of-closed) |
+| 409 | Conflict: invalid state transition, optimistic-lock version mismatch, or duplicate resource (problem+json; see [`error-envelope.md`](./error-envelope.md)) |
 | 413 | Body > 100 kB |
 | 415 | Mutating request lacked `application/json` |
 | 429 | Rate limit exhausted |
@@ -155,7 +155,7 @@ List all credit lines (in-memory store list).
   ```
 - **Validation:** wallet must satisfy `^G[A-Z2-7]{55}$`. Either `creditLimit` or `requestedLimit` is required.
 - **Response 201:** newly created `CreditLine`.
-- **Errors:** `400` on validation, `400` on domain error message.
+- **Errors:** `400` on validation / domain error message; `409` problem+json (`duplicate_resource`) when an open credit line already exists for the wallet.
 
 #### `PUT /api/credit/lines/:id`
 

--- a/docs/error-envelope.md
+++ b/docs/error-envelope.md
@@ -23,9 +23,42 @@ to know endpoint-specific shapes.
   messages. Clients should treat `error` as opaque text and rely on the
   HTTP status for retry logic.
 
+## Conflict responses (HTTP 409)
+
+Duplicate resources and state conflicts use **RFC 7807**
+`application/problem+json` via the shared `ConflictError` type
+(`src/errors/ConflictError.ts`). Content-Type is `application/problem+json`.
+
+```jsonc
+{
+  "type": "https://docs.creditra.dev/problems/duplicate_resource",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "An open credit line already exists for this wallet. Close it before opening another.",
+  "code": "duplicate_resource",
+  "resource": "credit_line",
+  "details": { "field": "walletAddress", "existingStatus": "active" },
+  "data": null,
+  "error": "An open credit line already exists for this wallet. Close it before opening another."
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `code` | Stable machine code: `duplicate_resource`, `version_conflict`, `invalid_state_transition`, `unique_constraint_violation` |
+| `resource` | Optional kind: `credit_line`, `risk_evaluation`, `webhook_subscription`, … |
+| `details` | Actionable **non-sensitive** context only (field names, status enums) |
+| `error` / `data` | Legacy envelope fields for older clients |
+
+**Security:** wallet addresses, secrets, API keys, and raw Postgres constraint
+details (which can embed key values) are never included in `detail` or
+`details`.
+
+Postgres unique violations (`SQLSTATE 23505`) are translated by
+`conflictFromUniqueViolation` into the same shape.
+
 ## Helpers
 
 Use `ok(res, payload, status?)` and `fail(res, error, status?)` from
-`src/utils/response.ts` instead of building envelopes inline. This keeps
-internal details (stack traces, SQL errors) from leaking into 5xx
-responses by default.
+`src/utils/response.ts` for the generic envelope. Use `sendConflict(res, err)`
+from `src/errors/problem.ts` for 409 problem+json.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -31,6 +31,8 @@ tags:
     description: On-chain risk evaluation
   - name: Webhooks
     description: Draw confirmation webhook management
+  - name: Reconciliation
+    description: Admin control plane for DB-vs-chain reconciliation
 
 security:
   - ApiKeyAuth: []
@@ -92,6 +94,14 @@ components:
           type: string
           enum: [active, suspended, closed]
           description: Credit line status
+        expectedVersion:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking guard. When provided, the update only succeeds
+            if it equals the stored `version`; otherwise the server returns
+            `409 Conflict`. Omit for unconditional (last-write-wins) updates.
+          example: 3
       additionalProperties: false
 
     CreditLine:
@@ -125,6 +135,14 @@ components:
           type: string
           enum: [active, suspended, closed]
           description: Current credit line status
+        version:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking version, incremented on each update. Pass the
+            value you read back as `expectedVersion` on a subsequent update to
+            guard against lost writes.
+          example: 1
         createdAt:
           type: string
           format: date-time
@@ -390,6 +408,42 @@ components:
           type: string
           example: "Risk model recalibration triggered"
 
+    ReconciliationTriggerResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [jobId, message]
+          properties:
+            jobId:
+              type: string
+              description: Identifier for the scheduled reconciliation job
+            message:
+              type: string
+              example: Reconciliation job scheduled
+        error:
+          type: string
+          nullable: true
+
+    ReconciliationStatusResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [workerRunning, queueSize, failedJobs]
+          properties:
+            workerRunning:
+              type: boolean
+            queueSize:
+              type: integer
+              minimum: 0
+            failedJobs:
+              type: integer
+              minimum: 0
+        error:
+          type: string
+          nullable: true
+
     # ── Error Schemas ─────────────────────────────────────────────────────────
 
     ErrorResponse:
@@ -410,6 +464,87 @@ components:
           type: string
           example: "Too many requests"
 
+    # RFC 7807 problem+json for HTTP 409 conflicts (duplicate resources,
+    # version mismatches, invalid state transitions). Content-Type is
+    # application/problem+json. Sensitive identifiers (wallets, secrets) are
+    # never included in detail/details.
+    ConflictProblem:
+      type: object
+      required: [type, title, status, detail, code, data, error]
+      properties:
+        type:
+          type: string
+          format: uri
+          description: Problem type URI (stable per `code`)
+          example: "https://docs.creditra.dev/problems/duplicate_resource"
+        title:
+          type: string
+          example: Conflict
+        status:
+          type: integer
+          enum: [409]
+          example: 409
+        detail:
+          type: string
+          description: Human-readable explanation (no sensitive identifiers)
+          example: "An open credit line already exists for this wallet. Close it before opening another."
+        code:
+          type: string
+          description: Stable machine-readable code for client branching
+          enum:
+            - duplicate_resource
+            - version_conflict
+            - invalid_state_transition
+            - unique_constraint_violation
+          example: duplicate_resource
+        resource:
+          type: string
+          description: Optional resource kind involved in the conflict
+          enum:
+            - credit_line
+            - risk_evaluation
+            - webhook_subscription
+            - borrower
+            - event
+          example: credit_line
+        details:
+          type: object
+          additionalProperties: true
+          description: >
+            Actionable, non-sensitive context only (field names, status enums).
+            Never contains wallet addresses, API keys, or secrets.
+          example:
+            field: walletAddress
+            existingStatus: active
+        data:
+          nullable: true
+          description: Always null on error (legacy envelope compatibility)
+        error:
+          type: string
+          description: Same text as `detail` (legacy envelope compatibility)
+
+    WebhookSubscriptionRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Absolute http(s) subscriber URL
+          example: "https://example.com/hooks/creditra"
+      additionalProperties: false
+
+    WebhookSubscription:
+      type: object
+      required: [url, createdAt]
+      properties:
+        url:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+
 paths:
   /health:
     get:
@@ -428,21 +563,91 @@ paths:
                 status: ok
                 service: creditra-backend
 
+  # ── Reconciliation Routes ───────────────────────────────────────────────────
+
+  /api/reconciliation/trigger:
+    post:
+      tags: [Reconciliation]
+      operationId: triggerReconciliation
+      summary: Schedule a reconciliation job
+      description: Admin-gated endpoint that schedules a DB-vs-chain reconciliation job and returns immediately.
+      responses:
+        "202":
+          description: Reconciliation job scheduled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconciliationTriggerResponse"
+              example:
+                data:
+                  jobId: "reconciliation-1710000000000"
+                  message: Reconciliation job scheduled
+                error: null
+        "401":
+          description: Missing API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to schedule reconciliation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/reconciliation/status:
+    get:
+      tags: [Reconciliation]
+      operationId: getReconciliationStatus
+      summary: Get reconciliation worker and queue status
+      description: Admin-gated endpoint for dashboards and alerts to inspect worker and queue health.
+      responses:
+        "200":
+          description: Reconciliation status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconciliationStatusResponse"
+              example:
+                data:
+                  workerRunning: true
+                  queueSize: 0
+                  failedJobs: 0
+                error: null
+        "401":
+          description: Missing API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to get reconciliation status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   # ── Credit Lines Routes ─────────────────────────────────────────────────────
 
   /api/credit/lines:
     get:
-      summary: Get Credit Lines
-      description: |
-        Returns all available credit lines with pagination support.
-        
-        Supports two pagination modes:
-        - **Offset-based** (legacy): Use `offset` and `limit` parameters
-        - **Cursor-based** (recommended): Use `cursor` and `limit` parameters
-        
-        Cursor pagination provides stable results for large datasets and is recommended
-        for production use. The response includes a `nextCursor` field that can be used
-        to fetch the next page of results.
+      tags: [Credit]
+      operationId: listCreditLines
+      summary: List all credit lines
+      security: []
       parameters:
         - name: offset
           in: query
@@ -451,9 +656,7 @@ paths:
             type: integer
             minimum: 0
             default: 0
-          description: |
-            Pagination offset (offset-based pagination only).
-            Cannot be used together with `cursor` parameter.
+          description: Pagination offset
         - name: limit
           in: query
           required: false
@@ -462,16 +665,7 @@ paths:
             minimum: 1
             maximum: 100
             default: 100
-          description: Number of credit lines per page (works with both pagination modes)
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            type: string
-          description: |
-            Cursor for pagination (cursor-based pagination).
-            Use the `nextCursor` value from a previous response to fetch the next page.
-            When provided, `offset` parameter is ignored.
+          description: Number of credit lines per page
       responses:
         "200":
           description: Array of credit lines (may be empty)
@@ -494,11 +688,15 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/CreditLinesOffsetResponse'
-                  - $ref: '#/components/schemas/CreditLinesCursorResponse'
-        '400':
-          description: Bad Request (Invalid pagination parameters)
+                $ref: "#/components/schemas/CreditLinesResponse"
+              example:
+                creditLines: []
+                pagination:
+                  total: 0
+                  offset: 0
+                  limit: 100
+        "400":
+          description: Invalid query parameter
           content:
             application/json:
               schema:
@@ -552,6 +750,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Duplicate open credit line for this wallet. Close the existing open
+            line before opening another. Response is RFC 7807 problem+json with
+            stable `code` `duplicate_resource` (or `unique_constraint_violation`).
+            Sensitive identifiers are never included in `detail`/`details`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "An open credit line already exists for this wallet. Close it before opening another."
+                code: duplicate_resource
+                resource: credit_line
+                details:
+                  field: walletAddress
+                  existingStatus: active
+                data: null
+                error: "An open credit line already exists for this wallet. Close it before opening another."
 
   /api/credit/lines/{id}:
     get:
@@ -634,6 +854,7 @@ paths:
               creditLimit: "1500.00"
               interestRateBps: 640
               status: active
+              expectedVersion: 3
       responses:
         "200":
           description: Credit line updated successfully
@@ -653,6 +874,29 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Optimistic-locking conflict. The supplied `expectedVersion` did not
+            match the stored `version`, meaning a concurrent update won the
+            race. Re-read the credit line to get the current `version` and
+            retry the update with it. Body is RFC 7807 problem+json with
+            `code: version_conflict`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/version_conflict"
+                title: Conflict
+                status: 409
+                detail: "Credit line was modified concurrently (expected version 1, found 2). Re-read and retry."
+                code: version_conflict
+                resource: credit_line
+                details:
+                  expectedVersion: 1
+                  actualVersion: 2
+                data: null
+                error: "Credit line was modified concurrently (expected version 1, found 2). Re-read and retry."
 
     delete:
       tags: [Credit]
@@ -819,6 +1063,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Invalid state transition (e.g. suspend of already suspended/closed).
+            RFC 7807 problem+json with `code: invalid_state_transition`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
 
   /api/credit/lines/{id}/close:
     post:
@@ -866,6 +1118,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Invalid state transition (e.g. close of already closed).
+            RFC 7807 problem+json with `code: invalid_state_transition`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
 
   /api/credit/wallet/{walletAddress}/lines:
     get:
@@ -963,70 +1223,92 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: Validation failed
-        "429":
-          description: Rate limit exceeded
+        "413":
+          description: Request body exceeds the 100 kb limit
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RateLimitErrorResponse"
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                data: null
+                error: Request body too large. Maximum size is 100kb.
+        "415":
+          description: Content-Type is not application/json
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                data: null
+                error: Content-Type must be application/json
+        "409":
+          description: >
+            Unique-constraint race while persisting an evaluation.
+            RFC 7807 problem+json (`unique_constraint_violation` / `duplicate_resource`).
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
 
-  /api/reconciliation/trigger:
+  /api/risk/evaluations:
     post:
-      summary: Trigger Credit Reconciliation
+      tags: [Risk]
+      operationId: createRiskEvaluation
+      summary: Create a risk evaluation (conflicts if unexpired exists)
       description: |
-        Manually trigger a reconciliation job that compares on-chain Credit contract 
-        records with database credit lines and flags any drift.
-        
-        Requires admin authentication via X-API-Key header.
-      security:
-        - ApiKeyAuth: []
+        Explicit create path. Returns 409 when a valid (unexpired) evaluation
+        already exists for the wallet unless `forceRefresh` is true.
+        Sensitive identifiers are never included in conflict details.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RiskEvaluateRequest"
       responses:
-        '202':
-          description: Reconciliation job scheduled
+        "201":
+          description: New risk evaluation created
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      jobId:
-                        type: string
-                        description: Unique identifier for the scheduled job
-                      message:
-                        type: string
-                        example: 'Reconciliation job scheduled'
-                  error:
-                    type: "null"
-        '401':
-          description: Unauthorized (Missing or invalid API key)
+                $ref: "#/components/schemas/RiskEvaluateApiResponse"
+        "400":
+          description: Validation error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FailureResponse'
-        '500':
-          description: Internal Server Error
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Unexpired risk evaluation already exists for this wallet.
+            Use forceRefresh to replace. problem+json `code: duplicate_resource`.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/FailureResponse'
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "A valid risk evaluation already exists for this wallet. Pass forceRefresh to replace it."
+                code: duplicate_resource
+                resource: risk_evaluation
+                details:
+                  field: walletAddress
+                  reason: unexpired_evaluation
+                data: null
+                error: "A valid risk evaluation already exists for this wallet. Pass forceRefresh to replace it."
 
-  /api/reconciliation/status:
+  /api/webhooks/subscriptions:
     get:
-      summary: Get Reconciliation Status
-      description: |
-        Returns the current status of the reconciliation worker including:
-        - Whether the worker is running
-        - Number of jobs in the queue
-        - Number of failed jobs
-        
-        Requires admin authentication via X-API-Key header.
-      security:
-        - ApiKeyAuth: []
+      tags: [Webhooks]
+      operationId: listWebhookSubscriptions
+      summary: List runtime webhook subscriptions
+      security: []
       responses:
-        '200':
-          description: Reconciliation status
+        "200":
+          description: Runtime subscriptions (env URLs are on GET /config)
           content:
             application/json:
               schema:
@@ -1035,149 +1317,245 @@ paths:
                   data:
                     type: object
                     properties:
-                      workerRunning:
-                        type: boolean
-                        description: Whether the reconciliation worker is active
-                      queueSize:
-                        type: integer
-                        description: Number of pending jobs in the queue
-                      failedJobs:
-                        type: integer
-                        description: Number of jobs that have failed
+                      subscriptions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/WebhookSubscription"
                   error:
-                    type: "null"
-        '401':
-          description: Unauthorized (Missing or invalid API key)
+                    nullable: true
+    post:
+      tags: [Webhooks]
+      operationId: registerWebhookSubscription
+      summary: Register a runtime webhook subscription
+      description: |
+        Adds a subscriber URL at runtime. Duplicate URLs (including those from
+        `WEBHOOK_URLS`) return 409 problem+json. Full URL values that may carry
+        secrets are not echoed in conflict details.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookSubscriptionRequest"
+      responses:
+        "201":
+          description: Subscription registered
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FailureResponse'
-        '500':
-          description: Internal Server Error
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/WebhookSubscription"
+                  error:
+                    nullable: true
+        "400":
+          description: Invalid URL
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FailureResponse'
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Subscription URL already registered. problem+json
+            `code: duplicate_resource`, `resource: webhook_subscription`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "A webhook subscription for this endpoint already exists."
+                code: duplicate_resource
+                resource: webhook_subscription
+                details:
+                  field: url
+                  reason: duplicate_url
+                data: null
+                error: "A webhook subscription for this endpoint already exists."
 
-components:
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
-      description: API key for admin endpoints
+  /api/webhooks/config:
+    get:
+      tags: [Webhooks]
+      operationId: getWebhookConfig
+      summary: Get webhook configuration
+      description: Returns the current webhook configuration (excluding sensitive data)
+      security: []
+      responses:
+        "200":
+          description: Webhook configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookConfigResponse"
+              example:
+                urls: ["https://example.com/webhook"]
+                maxRetries: 3
+                initialBackoffMs: 1000
+                backoffMultiplier: 2.0
+                timeoutMs: 10000
+                configured: true
 
-  schemas:
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          description: The payload of the successful response. Varies by endpoint.
-          type: object
-        error:
-          description: Error message. Always null for successful responses.
-          type: "null"
-      required:
-        - data
-        - error
+  /api/webhooks/test:
+    post:
+      tags: [Webhooks]
+      operationId: testWebhooks
+      summary: Test webhook connectivity
+      description: Sends a test payload to all configured webhook endpoints
+      security: []
+      responses:
+        "200":
+          description: Test results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookTestResponse"
+              example:
+                total: 2
+                reachable: 1
+                unreachable: 1
+                results:
+                  - url: "https://example.com/webhook"
+                    reachable: true
+                  - url: "https://test.com/hook"
+                    reachable: false
+                    error: "Connection refused"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    FailureResponse:
-      type: object
-      properties:
-        data:
-          description: Data payload. Always null for failed responses.
-          type: "null"
-        error:
-          description: The error message detailing what went wrong.
-          type: string
-      required:
-        - data
-        - error
+  /api/webhooks/health:
+    get:
+      tags: [Webhooks]
+      operationId: getWebhookHealth
+      summary: Webhook service health check
+      description: Returns the health status of the webhook service
+      security: []
+      responses:
+        "200":
+          description: Webhook service health
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookHealthResponse"
+              example:
+                status: active
+                urls: 2
+                maxRetries: 3
+                timeoutMs: 10000
 
-    CreditLine:
-      type: object
-      properties:
-        id:
-          type: string
-          description: Unique identifier for the credit line
-        walletAddress:
-          type: string
-          description: Stellar wallet address
-        creditLimit:
-          type: string
-          description: Maximum credit limit (decimal string)
-        availableCredit:
-          type: string
-          description: Currently available credit (decimal string)
-        interestRateBps:
-          type: integer
-          description: Interest rate in basis points (e.g., 500 = 5%)
-        status:
-          type: string
-          enum: [active, suspended, closed, pending]
-          description: Current status of the credit line
-        createdAt:
-          type: string
-          format: date-time
-          description: Creation timestamp
-        updatedAt:
-          type: string
-          format: date-time
-          description: Last update timestamp
+  /api/risk/evaluations/{id}:
+    get:
+      tags: [Risk]
+      operationId: getRiskEvaluationById
+      summary: Fetch a stored risk evaluation by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Risk evaluation identifier
+      responses:
+        "200":
+          description: Risk evaluation found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluation"
+        "404":
+          description: Risk evaluation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Risk evaluation not found
+                id: "abc123"
 
-    CreditLinesOffsetResponse:
-      type: object
-      description: Response format for offset-based pagination
-      properties:
-        creditLines:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreditLine'
-        pagination:
-          type: object
-          properties:
-            total:
-              type: integer
-              description: Total number of credit lines
-            offset:
-              type: integer
-              description: Current offset
-            limit:
-              type: integer
-              description: Number of items per page
-          required:
-            - total
-            - offset
-            - limit
-      required:
-        - creditLines
-        - pagination
+  /api/risk/wallet/{walletAddress}/latest:
+    get:
+      tags: [Risk]
+      operationId: getLatestRiskEvaluation
+      summary: Get the latest risk evaluation for a wallet
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^G[A-Z2-7]{55}$'
+          description: Stellar public key
+      responses:
+        "200":
+          description: Risk evaluation found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluateResponse"
+        "400":
+          description: Invalid wallet address
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No risk evaluation found for wallet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    CreditLinesCursorResponse:
-      type: object
-      description: Response format for cursor-based pagination
-      properties:
-        creditLines:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreditLine'
-        pagination:
-          type: object
-          properties:
-            limit:
-              type: integer
-              description: Number of items per page
-            nextCursor:
-              type: string
-              nullable: true
-              description: Cursor for the next page (null if no more pages)
-            hasMore:
-              type: boolean
-              description: Whether more results are available
-          required:
-            - limit
-            - nextCursor
-            - hasMore
-      required:
-        - creditLines
-        - pagination
+  /api/risk/wallet/{walletAddress}/history:
+    get:
+      tags: [Risk]
+      operationId: getRiskEvaluationHistory
+      summary: Get risk evaluation history for a wallet
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^G[A-Z2-7]{55}$'
+          description: Stellar public key
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: Pagination offset
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          description: Pagination limit
+      responses:
+        "200":
+          description: Array of risk evaluations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  evaluations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RiskEvaluation"
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"

--- a/migrations/006_unique_open_credit_line.sql
+++ b/migrations/006_unique_open_credit_line.sql
@@ -1,0 +1,11 @@
+-- One open (non-closed) credit line per borrower.
+-- Closed lines may be retained for history; opening another is allowed only
+-- after the previous open line is closed. Unique violations map to HTTP 409.
+-- See issue #227 (consistent conflict detection).
+
+CREATE UNIQUE INDEX IF NOT EXISTS credit_lines_one_open_per_borrower
+  ON credit_lines (borrower_id)
+  WHERE status IS DISTINCT FROM 'closed';
+
+COMMENT ON INDEX credit_lines_one_open_per_borrower IS
+  'At most one non-closed credit line per borrower; duplicates return 409';

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,200 +1,1561 @@
 openapi: 3.0.3
 info:
-  title: Creditra Backend API
+  title: Creditra API
   version: 0.1.0
-  description: REST API for the Creditra adaptive credit protocol.
+  description: |
+    Backend API for Creditra – on-chain credit scoring and risk evaluation.
+
+    Browser clients are restricted by a CORS allowlist. Production deployments
+    must set `CORS_ORIGINS` to a comma-separated list of exact origins; local
+    development falls back to loopback origins when the variable is unset.
+
+    ## Authentication
+    Protected endpoints require a valid API key passed via the `X-API-Key` header.
+    API keys are configured via the `API_KEYS` environment variable (comma-separated).
+
+    ## Keeping the spec in sync
+    - Every new route **must** have a corresponding entry here before merging.
+    - Run `npm run validate:spec` in CI to catch YAML/structural errors early.
+    - Use path-level `operationId` values as the source of truth for client generation.
 
 servers:
   - url: http://localhost:3000
+    description: Local development
 
-paths:
-  /health:
-    get:
-      summary: Health check
-      operationId: getHealth
-      responses:
-        '200':
-          description: Service is healthy
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    example: ok
-                  service:
-                    type: string
-                    example: creditra-backend
+tags:
+  - name: Health
+    description: Service liveness check
+  - name: Credit
+    description: Credit line management
+  - name: Risk
+    description: On-chain risk evaluation
+  - name: Webhooks
+    description: Draw confirmation webhook management
+  - name: Reconciliation
+    description: Admin control plane for DB-vs-chain reconciliation
 
-  /api/credit/lines:
-    get:
-      summary: List credit lines
-      operationId: listCreditLines
-      responses:
-        '200':
-          description: List of credit lines
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  creditLines:
-                    type: array
-                    items: {}
-
-  /api/credit/lines/{id}:
-    get:
-      summary: Get credit line by ID
-      operationId: getCreditLine
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Credit line found
-        '404':
-          description: Credit line not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: NOT_FOUND
-                  message: Credit line not found
-
-  /api/risk/evaluate:
-    post:
-      summary: Request a risk evaluation
-      operationId: evaluateRisk
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - walletAddress
-              properties:
-                walletAddress:
-                  type: string
-                  example: '0xABCDEF1234567890'
-      responses:
-        '200':
-          description: Risk evaluation result
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskEvaluation'
-        '400':
-          description: Missing or invalid input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: INVALID_INPUT
-                  message: walletAddress required
-
-  /api/risk/evaluations/{id}:
-    get:
-      summary: Get a risk evaluation by ID
-      operationId: getRiskEvaluation
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: UUID v4 of the risk evaluation
-          schema:
-            type: string
-            format: uuid
-            example: 11111111-1111-4111-8111-111111111111
-      responses:
-        '200':
-          description: Risk evaluation found
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  evaluation:
-                    $ref: '#/components/schemas/RiskEvaluation'
-              example:
-                evaluation:
-                  id: 11111111-1111-4111-8111-111111111111
-                  walletAddress: '0xABCDEF1234567890'
-                  riskScore: 42
-                  creditLimit: '1000'
-                  interestRateBps: 500
-        '400':
-          description: Invalid ID format
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: INVALID_INPUT
-                  message: Invalid evaluation id format
-        '404':
-          description: Risk evaluation not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: NOT_FOUND
-                  message: Risk evaluation not found
-        '500':
-          description: Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: INTERNAL_ERROR
-                  message: Something went wrong
+security:
+  - ApiKeyAuth: []
 
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: |
+        API key for authenticated endpoints. Required for admin operations.
+        Keys are configured via the `API_KEYS` environment variable.
+
   schemas:
+    HealthResponse:
+      type: object
+      required: [status, service]
+      properties:
+        status:
+          type: string
+          example: ok
+        service:
+          type: string
+          example: creditra-backend
+
+    # ── Credit Line Schemas ──────────────────────────────────────────────────
+
+    CreateCreditLineRequest:
+      type: object
+      required: [walletAddress, requestedLimit]
+      properties:
+        walletAddress:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Stellar wallet address
+          example: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+        requestedLimit:
+          type: string
+          pattern: "^\\d+(\\.\\d+)?$"
+          description: Requested credit limit as a decimal string
+          example: "1000.00"
+      additionalProperties: false
+
+    UpdateCreditLineRequest:
+      type: object
+      properties:
+        creditLimit:
+          type: string
+          pattern: "^\\d+(\\.\\d+)?$"
+          description: Updated credit limit
+          example: "1500.00"
+        interestRateBps:
+          type: number
+          description: Interest rate in basis points
+          example: 640
+        status:
+          type: string
+          enum: [active, suspended, closed]
+          description: Credit line status
+        expectedVersion:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking guard. When provided, the update only succeeds
+            if it equals the stored `version`; otherwise the server returns
+            `409 Conflict`. Omit for unconditional (last-write-wins) updates.
+          example: 3
+      additionalProperties: false
+
+    CreditLine:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique credit line identifier
+          example: "cl_abc123"
+        walletAddress:
+          type: string
+          description: Associated Stellar wallet address
+          example: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+        creditLimit:
+          type: string
+          description: Approved credit limit
+          example: "720.00000000"
+        currentBalance:
+          type: string
+          description: Current outstanding balance
+          example: "100.00000000"
+        availableCredit:
+          type: string
+          description: Available credit (creditLimit - currentBalance)
+          example: "620.00000000"
+        interestRateBps:
+          type: number
+          description: Interest rate in basis points
+          example: 640
+        status:
+          type: string
+          enum: [active, suspended, closed]
+          description: Current credit line status
+        version:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking version, incremented on each update. Pass the
+            value you read back as `expectedVersion` on a subsequent update to
+            guard against lost writes.
+          example: 1
+        createdAt:
+          type: string
+          format: date-time
+          description: ISO 8601 creation timestamp
+        updatedAt:
+          type: string
+          format: date-time
+          description: ISO 8601 last update timestamp
+
+    CreditLinesResponse:
+      type: object
+      required: [creditLines, pagination]
+      properties:
+        creditLines:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreditLine"
+        pagination:
+          type: object
+          properties:
+            total:
+              type: integer
+            offset:
+              type: integer
+            limit:
+              type: integer
+          required: [total, offset, limit]
+
+    WalletCreditLinesResponse:
+      type: object
+      required: [creditLines]
+      properties:
+        creditLines:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreditLine"
+
+    CreditLineActionResponse:
+      type: object
+      required: [line, message]
+      properties:
+        line:
+          $ref: "#/components/schemas/CreditLine"
+        message:
+          type: string
+          example: "Credit line suspended."
+
+    # ── Transaction Schemas ──────────────────────────────────────────────────
+
+    Transaction:
+      type: object
+      required: [id, creditLineId, type, amount, currency, timestamp, metadata]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique transaction identifier
+        creditLineId:
+          type: string
+          description: ID of the credit line this transaction belongs to
+        type:
+          type: string
+          enum: [borrow, repay, interest_accrual, fee, status_change]
+          description: Transaction type
+        amount:
+          type: string
+          nullable: true
+          description: Transaction amount as a decimal string; null for status changes
+          example: "500.00000000"
+        currency:
+          type: string
+          nullable: true
+          description: Currency code (e.g. USDC); null for status changes
+          example: USDC
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of when the transaction occurred
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Additional context; status changes include an 'action' field
+          example:
+            action: created
+
+    TransactionHistoryResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [transactions, total, page, limit, totalPages]
+          properties:
+            transactions:
+              type: array
+              items:
+                $ref: "#/components/schemas/Transaction"
+            total:
+              type: integer
+              description: Total number of transactions matching the applied filters
+            page:
+              type: integer
+              description: Current page number (1-indexed)
+            limit:
+              type: integer
+              description: Maximum number of transactions per page
+            totalPages:
+              type: integer
+              description: Total number of pages available
+
+    # ── Risk Evaluation Schemas ───────────────────────────────────────────────
+
+    RiskEvaluateRequest:
+      type: object
+      required: [walletAddress]
+      properties:
+        walletAddress:
+          type: string
+          description: Stellar wallet address to evaluate
+          example: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+        forceRefresh:
+          type: boolean
+          description: Optional hint to bypass cache and recalculate risk
+          default: false
+      additionalProperties: false
+
+    RiskEvaluateResponse:
+      type: object
+      required: [walletAddress, riskScore, creditLimit, interestRateBps, message]
+      properties:
+        walletAddress:
+          type: string
+          example: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+        riskScore:
+          type: number
+          description: Risk score (0-100)
+          example: 72
+        creditLimit:
+          type: string
+          description: Recommended credit limit
+          example: "720.00000000"
+        interestRateBps:
+          type: number
+          description: Recommended interest rate in basis points
+          example: 640
+        message:
+          type: string
+          example: "New risk evaluation completed"
+
+    RiskEvaluateApiResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          $ref: "#/components/schemas/RiskEvaluateResponse"
+        error:
+          type: string
+          nullable: true
+
     RiskEvaluation:
       type: object
       properties:
         id:
           type: string
           format: uuid
+          description: Unique evaluation identifier
         walletAddress:
           type: string
+          description: Evaluated wallet address
         riskScore:
           type: number
+          description: Risk score (0-100)
         creditLimit:
           type: string
+          description: Recommended credit limit
         interestRateBps:
           type: number
+          description: Recommended interest rate in basis points
+        factors:
+          type: object
+          additionalProperties: true
+          description: Risk evaluation factors and weights
+        evaluatedAt:
+          type: string
+          format: date-time
+          description: ISO 8601 evaluation timestamp
+
+    RiskEvaluationHistoryResponse:
+      type: object
+      required: [evaluations]
+      properties:
+        evaluations:
+          type: array
+          items:
+            $ref: "#/components/schemas/RiskEvaluation"
+
+    # ── Webhook Schemas ───────────────────────────────────────────────────────
+
+    WebhookConfigResponse:
+      type: object
+      properties:
+        urls:
+          type: array
+          items:
+            type: string
+          example: ["https://example.com/webhook"]
+        maxRetries:
+          type: integer
+          example: 3
+        initialBackoffMs:
+          type: integer
+          example: 1000
+        backoffMultiplier:
+          type: number
+          example: 2.0
+        timeoutMs:
+          type: integer
+          example: 10000
+        configured:
+          type: boolean
+          example: true
+
+    WebhookTestResponse:
+      type: object
+      properties:
+        total:
+          type: integer
+        reachable:
+          type: integer
+        unreachable:
+          type: integer
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              reachable:
+                type: boolean
+              error:
+                type: string
+                nullable: true
+
+    WebhookHealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [active, disabled]
+        urls:
+          type: integer
+          description: Number of configured webhook URLs
+        maxRetries:
+          type: integer
+        timeoutMs:
+          type: integer
+
+    AdminRecalibrateResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Risk model recalibration triggered"
+
+    ReconciliationTriggerResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [jobId, message]
+          properties:
+            jobId:
+              type: string
+              description: Identifier for the scheduled reconciliation job
+            message:
+              type: string
+              example: Reconciliation job scheduled
+        error:
+          type: string
+          nullable: true
+
+    ReconciliationStatusResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [workerRunning, queueSize, failedJobs]
+          properties:
+            workerRunning:
+              type: boolean
+            queueSize:
+              type: integer
+              minimum: 0
+            failedJobs:
+              type: integer
+              minimum: 0
+        error:
+          type: string
+          nullable: true
+
+    # ── Error Schemas ─────────────────────────────────────────────────────────
 
     ErrorResponse:
       type: object
-      required:
-        - error
+      required: [error]
       properties:
         error:
+          type: string
+        id:
+          type: string
+          description: Present on 404 responses that reference a specific resource
+
+    RateLimitErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          example: "Too many requests"
+
+    # RFC 7807 problem+json for HTTP 409 conflicts (duplicate resources,
+    # version mismatches, invalid state transitions). Content-Type is
+    # application/problem+json. Sensitive identifiers (wallets, secrets) are
+    # never included in detail/details.
+    ConflictProblem:
+      type: object
+      required: [type, title, status, detail, code, data, error]
+      properties:
+        type:
+          type: string
+          format: uri
+          description: Problem type URI (stable per `code`)
+          example: "https://docs.creditra.dev/problems/duplicate_resource"
+        title:
+          type: string
+          example: Conflict
+        status:
+          type: integer
+          enum: [409]
+          example: 409
+        detail:
+          type: string
+          description: Human-readable explanation (no sensitive identifiers)
+          example: "An open credit line already exists for this wallet. Close it before opening another."
+        code:
+          type: string
+          description: Stable machine-readable code for client branching
+          enum:
+            - duplicate_resource
+            - version_conflict
+            - invalid_state_transition
+            - unique_constraint_violation
+          example: duplicate_resource
+        resource:
+          type: string
+          description: Optional resource kind involved in the conflict
+          enum:
+            - credit_line
+            - risk_evaluation
+            - webhook_subscription
+            - borrower
+            - event
+          example: credit_line
+        details:
           type: object
-          required:
-            - code
-            - message
-          properties:
-            code:
-              type: string
-              enum:
-                - NOT_FOUND
-                - INVALID_INPUT
-                - INTERNAL_ERROR
-            message:
-              type: string
+          additionalProperties: true
+          description: >
+            Actionable, non-sensitive context only (field names, status enums).
+            Never contains wallet addresses, API keys, or secrets.
+          example:
+            field: walletAddress
+            existingStatus: active
+        data:
+          nullable: true
+          description: Always null on error (legacy envelope compatibility)
+        error:
+          type: string
+          description: Same text as `detail` (legacy envelope compatibility)
+
+    WebhookSubscriptionRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Absolute http(s) subscriber URL
+          example: "https://example.com/hooks/creditra"
+      additionalProperties: false
+
+    WebhookSubscription:
+      type: object
+      required: [url, createdAt]
+      properties:
+        url:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+
+paths:
+  /health:
+    get:
+      tags: [Health]
+      operationId: getHealth
+      summary: Liveness check
+      security: []
+      responses:
+        "200":
+          description: Service is running
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+                service: creditra-backend
+
+  # ── Reconciliation Routes ───────────────────────────────────────────────────
+
+  /api/reconciliation/trigger:
+    post:
+      tags: [Reconciliation]
+      operationId: triggerReconciliation
+      summary: Schedule a reconciliation job
+      description: Admin-gated endpoint that schedules a DB-vs-chain reconciliation job and returns immediately.
+      responses:
+        "202":
+          description: Reconciliation job scheduled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconciliationTriggerResponse"
+              example:
+                data:
+                  jobId: "reconciliation-1710000000000"
+                  message: Reconciliation job scheduled
+                error: null
+        "401":
+          description: Missing API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to schedule reconciliation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/reconciliation/status:
+    get:
+      tags: [Reconciliation]
+      operationId: getReconciliationStatus
+      summary: Get reconciliation worker and queue status
+      description: Admin-gated endpoint for dashboards and alerts to inspect worker and queue health.
+      responses:
+        "200":
+          description: Reconciliation status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconciliationStatusResponse"
+              example:
+                data:
+                  workerRunning: true
+                  queueSize: 0
+                  failedJobs: 0
+                error: null
+        "401":
+          description: Missing API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to get reconciliation status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  # ── Credit Lines Routes ─────────────────────────────────────────────────────
+
+  /api/credit/lines:
+    get:
+      tags: [Credit]
+      operationId: listCreditLines
+      summary: List all credit lines
+      security: []
+      parameters:
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: Pagination offset
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 100
+          description: Number of credit lines per page
+      responses:
+        "200":
+          description: Array of credit lines (may be empty)
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed per window
+              schema:
+                type: integer
+                example: 100
+            X-RateLimit-Remaining:
+              description: Requests remaining in current window
+              schema:
+                type: integer
+                example: 95
+            X-RateLimit-Reset:
+              description: Unix timestamp when the rate limit window resets
+              schema:
+                type: integer
+                example: 1700000060
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLinesResponse"
+              example:
+                creditLines: []
+                pagination:
+                  total: 0
+                  offset: 0
+                  limit: 100
+        "400":
+          description: Invalid query parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying
+              schema:
+                type: integer
+                example: 47
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitErrorResponse"
+
+    post:
+      tags: [Credit]
+      operationId: createCreditLine
+      summary: Create a new credit line
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCreditLineRequest"
+            example:
+              walletAddress: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+              requestedLimit: "1000.00"
+      responses:
+        "201":
+          description: Credit line created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLine"
+        "400":
+          description: Validation error or missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Duplicate open credit line for this wallet. Close the existing open
+            line before opening another. Response is RFC 7807 problem+json with
+            stable `code` `duplicate_resource` (or `unique_constraint_violation`).
+            Sensitive identifiers are never included in `detail`/`details`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "An open credit line already exists for this wallet. Close it before opening another."
+                code: duplicate_resource
+                resource: credit_line
+                details:
+                  field: walletAddress
+                  existingStatus: active
+                data: null
+                error: "An open credit line already exists for this wallet. Close it before opening another."
+
+  /api/credit/lines/{id}:
+    get:
+      tags: [Credit]
+      operationId: getCreditLineById
+      summary: Get a credit line by ID
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+      responses:
+        "200":
+          description: Credit line found
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLine"
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Credit line not found
+                id: "abc123"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitErrorResponse"
+
+    put:
+      tags: [Credit]
+      operationId: updateCreditLine
+      summary: Update a credit line
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateCreditLineRequest"
+            example:
+              creditLimit: "1500.00"
+              interestRateBps: 640
+              status: active
+              expectedVersion: 3
+      responses:
+        "200":
+          description: Credit line updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLine"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Optimistic-locking conflict. The supplied `expectedVersion` did not
+            match the stored `version`, meaning a concurrent update won the
+            race. Re-read the credit line to get the current `version` and
+            retry the update with it. Body is RFC 7807 problem+json with
+            `code: version_conflict`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/version_conflict"
+                title: Conflict
+                status: 409
+                detail: "Credit line was modified concurrently (expected version 1, found 2). Re-read and retry."
+                code: version_conflict
+                resource: credit_line
+                details:
+                  expectedVersion: 1
+                  actualVersion: 2
+                data: null
+                error: "Credit line was modified concurrently (expected version 1, found 2). Re-read and retry."
+
+    delete:
+      tags: [Credit]
+      operationId: deleteCreditLine
+      summary: Delete a credit line
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+      responses:
+        "204":
+          description: Credit line deleted successfully
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/credit/lines/{id}/transactions:
+    get:
+      tags: [Credit]
+      operationId: getCreditLineTransactions
+      summary: List transaction history for a credit line
+      description: |
+        Returns a paginated list of transactions for the given credit line.
+        Supports optional filtering by transaction type and date range.
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [borrow, repay, interest_accrual, fee, status_change]
+          description: Filter by transaction type
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Include only transactions at or after this ISO 8601 timestamp (inclusive)
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Include only transactions at or before this ISO 8601 timestamp (inclusive)
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-indexed)
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          description: Number of transactions per page
+      responses:
+        "200":
+          description: Paginated list of transactions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TransactionHistoryResponse"
+              example:
+                data:
+                  transactions:
+                    - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                      creditLineId: "line-abc"
+                      type: status_change
+                      amount: null
+                      currency: null
+                      timestamp: "2024-01-15T10:00:00.000Z"
+                      metadata:
+                        action: created
+                  total: 1
+                  page: 1
+                  limit: 20
+                  totalPages: 1
+        "400":
+          description: Invalid query parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Invalid type filter. Must be one of: borrow, repay, interest_accrual, fee, status_change."
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/credit/lines/{id}/suspend:
+    post:
+      tags: [Credit]
+      operationId: suspendCreditLine
+      summary: Suspend a credit line
+      description: |
+        Suspends the specified credit line, preventing further draws.
+        Requires API key authentication.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+      responses:
+        "200":
+          description: Credit line suspended successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLineActionResponse"
+        "401":
+          description: API key missing
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Unauthorized
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Forbidden
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Invalid state transition (e.g. suspend of already suspended/closed).
+            RFC 7807 problem+json with `code: invalid_state_transition`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+
+  /api/credit/lines/{id}/close:
+    post:
+      tags: [Credit]
+      operationId: closeCreditLine
+      summary: Close a credit line
+      description: |
+        Closes the specified credit line permanently.
+        Requires API key authentication.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Credit line identifier
+      responses:
+        "200":
+          description: Credit line closed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditLineActionResponse"
+        "401":
+          description: API key missing
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Unauthorized
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Forbidden
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Invalid state transition (e.g. close of already closed).
+            RFC 7807 problem+json with `code: invalid_state_transition`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+
+  /api/credit/wallet/{walletAddress}/lines:
+    get:
+      tags: [Credit]
+      operationId: getCreditLinesByWallet
+      summary: Get credit lines for a specific wallet
+      security: []
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Stellar wallet address
+      responses:
+        "200":
+          description: Credit lines for the wallet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletCreditLinesResponse"
+              example:
+                creditLines:
+                  - id: "cl_abc123"
+                    walletAddress: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+                    creditLimit: "720.00000000"
+                    currentBalance: "100.00000000"
+                    availableCredit: "620.00000000"
+                    interestRateBps: 640
+                    status: active
+                    createdAt: "2024-01-15T10:00:00.000Z"
+                    updatedAt: "2024-01-15T10:00:00.000Z"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  # ── Risk Evaluation Routes ──────────────────────────────────────────────────
+
+  /api/risk/evaluate:
+    post:
+      tags: [Risk]
+      operationId: evaluateRisk
+      summary: Evaluate on-chain risk for a wallet
+      description: |
+        Performs a fresh risk evaluation for the given Stellar wallet address.
+        Rate limited: default 10 requests per minute per IP address.
+        Configure via RATE_LIMIT_MAX_EVALUATE and RATE_LIMIT_WINDOW_MS env vars.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RiskEvaluateRequest"
+            example:
+              walletAddress: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+              forceRefresh: false
+      responses:
+        "200":
+          description: Risk evaluation result
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum requests allowed per window
+              schema:
+                type: integer
+                example: 10
+            X-RateLimit-Remaining:
+              description: Requests remaining in current window
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              description: Unix timestamp when the rate limit window resets
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluateApiResponse"
+              example:
+                data:
+                  walletAddress: "GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK"
+                  riskScore: 72
+                  creditLimit: "720.00000000"
+                  interestRateBps: 640
+                  message: New risk evaluation completed
+                error: null
+        "400":
+          description: Missing required field
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Validation failed
+        "413":
+          description: Request body exceeds the 100 kb limit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                data: null
+                error: Request body too large. Maximum size is 100kb.
+        "415":
+          description: Content-Type is not application/json
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                data: null
+                error: Content-Type must be application/json
+        "409":
+          description: >
+            Unique-constraint race while persisting an evaluation.
+            RFC 7807 problem+json (`unique_constraint_violation` / `duplicate_resource`).
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+
+  /api/risk/evaluations:
+    post:
+      tags: [Risk]
+      operationId: createRiskEvaluation
+      summary: Create a risk evaluation (conflicts if unexpired exists)
+      description: |
+        Explicit create path. Returns 409 when a valid (unexpired) evaluation
+        already exists for the wallet unless `forceRefresh` is true.
+        Sensitive identifiers are never included in conflict details.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RiskEvaluateRequest"
+      responses:
+        "201":
+          description: New risk evaluation created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluateApiResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Unexpired risk evaluation already exists for this wallet.
+            Use forceRefresh to replace. problem+json `code: duplicate_resource`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "A valid risk evaluation already exists for this wallet. Pass forceRefresh to replace it."
+                code: duplicate_resource
+                resource: risk_evaluation
+                details:
+                  field: walletAddress
+                  reason: unexpired_evaluation
+                data: null
+                error: "A valid risk evaluation already exists for this wallet. Pass forceRefresh to replace it."
+
+  /api/webhooks/subscriptions:
+    get:
+      tags: [Webhooks]
+      operationId: listWebhookSubscriptions
+      summary: List runtime webhook subscriptions
+      security: []
+      responses:
+        "200":
+          description: Runtime subscriptions (env URLs are on GET /config)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      subscriptions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/WebhookSubscription"
+                  error:
+                    nullable: true
+    post:
+      tags: [Webhooks]
+      operationId: registerWebhookSubscription
+      summary: Register a runtime webhook subscription
+      description: |
+        Adds a subscriber URL at runtime. Duplicate URLs (including those from
+        `WEBHOOK_URLS`) return 409 problem+json. Full URL values that may carry
+        secrets are not echoed in conflict details.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookSubscriptionRequest"
+      responses:
+        "201":
+          description: Subscription registered
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/WebhookSubscription"
+                  error:
+                    nullable: true
+        "400":
+          description: Invalid URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Subscription URL already registered. problem+json
+            `code: duplicate_resource`, `resource: webhook_subscription`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "A webhook subscription for this endpoint already exists."
+                code: duplicate_resource
+                resource: webhook_subscription
+                details:
+                  field: url
+                  reason: duplicate_url
+                data: null
+                error: "A webhook subscription for this endpoint already exists."
+
+  /api/webhooks/config:
+    get:
+      tags: [Webhooks]
+      operationId: getWebhookConfig
+      summary: Get webhook configuration
+      description: Returns the current webhook configuration (excluding sensitive data)
+      security: []
+      responses:
+        "200":
+          description: Webhook configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookConfigResponse"
+              example:
+                urls: ["https://example.com/webhook"]
+                maxRetries: 3
+                initialBackoffMs: 1000
+                backoffMultiplier: 2.0
+                timeoutMs: 10000
+                configured: true
+
+  /api/webhooks/test:
+    post:
+      tags: [Webhooks]
+      operationId: testWebhooks
+      summary: Test webhook connectivity
+      description: Sends a test payload to all configured webhook endpoints
+      security: []
+      responses:
+        "200":
+          description: Test results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookTestResponse"
+              example:
+                total: 2
+                reachable: 1
+                unreachable: 1
+                results:
+                  - url: "https://example.com/webhook"
+                    reachable: true
+                  - url: "https://test.com/hook"
+                    reachable: false
+                    error: "Connection refused"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/webhooks/health:
+    get:
+      tags: [Webhooks]
+      operationId: getWebhookHealth
+      summary: Webhook service health check
+      description: Returns the health status of the webhook service
+      security: []
+      responses:
+        "200":
+          description: Webhook service health
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookHealthResponse"
+              example:
+                status: active
+                urls: 2
+                maxRetries: 3
+                timeoutMs: 10000
+
+  /api/risk/evaluations/{id}:
+    get:
+      tags: [Risk]
+      operationId: getRiskEvaluationById
+      summary: Fetch a stored risk evaluation by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Risk evaluation identifier
+      responses:
+        "200":
+          description: Risk evaluation found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluation"
+        "404":
+          description: Risk evaluation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Risk evaluation not found
+                id: "abc123"
+
+  /api/risk/wallet/{walletAddress}/latest:
+    get:
+      tags: [Risk]
+      operationId: getLatestRiskEvaluation
+      summary: Get the latest risk evaluation for a wallet
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^G[A-Z2-7]{55}$'
+          description: Stellar public key
+      responses:
+        "200":
+          description: Risk evaluation found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluateResponse"
+        "400":
+          description: Invalid wallet address
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No risk evaluation found for wallet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/risk/wallet/{walletAddress}/history:
+    get:
+      tags: [Risk]
+      operationId: getRiskEvaluationHistory
+      summary: Get risk evaluation history for a wallet
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^G[A-Z2-7]{55}$'
+          description: Stellar public key
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: Pagination offset
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          description: Pagination limit
+      responses:
+        "200":
+          description: Array of risk evaluations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  evaluations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RiskEvaluation"
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2698,7 +2697,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3291,7 +3289,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3753,7 +3750,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4555,7 +4551,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5901,7 +5896,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7475,7 +7469,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9074,7 +9067,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9158,7 +9150,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9318,7 +9309,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -9397,7 +9387,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -9708,7 +9697,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
 import { apiKeysRouter } from './routes/apiKeys.js';
+import { recordRequest, metricsRouter } from './routes/metrics.js';
+import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
+import { maintenanceRouter } from './routes/maintenance.js';
 
 export function createApp() {
   const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -58,6 +58,7 @@ export class Container {
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -156,6 +157,10 @@ export class Container {
 
   get reconciliationWorker(): ReconciliationWorker {
     return this._reconciliationWorker;
+  }
+
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
   }
 
   /** Process-wide in-process domain event bus for credit lifecycle events. */

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -173,10 +173,6 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
-  get dashboardSummaryService(): DashboardSummaryService {
-    return this._dashboardSummaryService;
-  }
-
   // Method to replace repositories
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -173,7 +173,11 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
-  // Method to replace repositories (useful for testing or switching to DB implementations)
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
+  // Method to replace repositories
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;
     riskEvaluationRepository?: RiskEvaluationRepository;

--- a/src/container/__tests__/Container.contract.test.ts
+++ b/src/container/__tests__/Container.contract.test.ts
@@ -64,7 +64,7 @@ describe('Container DI contract', () => {
     });
 
     it.each(REPOSITORY_RESOLVERS)('resolves repository %s', (name) => {
-      const repo = container[name] as Record<string, unknown>;
+      const repo = container[name] as unknown as Record<string, unknown>;
       expect(repo, `${String(name)} must resolve`).toBeDefined();
       // A repository is a contract object: it must expose callable methods.
       expect(typeof repo).toBe('object');

--- a/src/errors/ConflictError.ts
+++ b/src/errors/ConflictError.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared conflict error for duplicate resources and state conflicts.
+ *
+ * Thrown by services/repositories when a write would violate uniqueness or
+ * an invalid concurrent state (duplicate open, version mismatch, etc.).
+ * Mapped by {@link sendConflict} / the global error handler to HTTP 409 with
+ * RFC 7807 problem+json details.
+ *
+ * Security: never put wallet addresses, secrets, API keys, or other sensitive
+ * identifiers into `message` or `details`. Resource *types* and safe field
+ * names are fine; values that identify end-users are not.
+ */
+
+/** Stable machine-readable conflict codes clients can branch on. */
+export type ConflictCode =
+  | 'duplicate_resource'
+  | 'version_conflict'
+  | 'invalid_state_transition'
+  | 'unique_constraint_violation';
+
+/** Resource kinds involved in conflict responses (public taxonomy). */
+export type ConflictResource =
+  | 'credit_line'
+  | 'risk_evaluation'
+  | 'webhook_subscription'
+  | 'borrower'
+  | 'event';
+
+export interface ConflictErrorOptions {
+  /** Human-readable, non-sensitive explanation (also used as problem `detail`). */
+  message: string;
+  /** Stable code; defaults to `duplicate_resource`. */
+  code?: ConflictCode;
+  /** Optional resource type for clients (no instance ids required). */
+  resource?: ConflictResource;
+  /**
+   * Actionable, non-sensitive context only (e.g. `{ field: 'url' }`).
+   * Must not include wallet addresses, secrets, or raw DB constraint names
+   * that embed sensitive values.
+   */
+  details?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Domain error representing an HTTP 409 Conflict.
+ */
+export class ConflictError extends Error {
+  readonly statusCode = 409 as const;
+  readonly code: ConflictCode;
+  readonly resource?: ConflictResource;
+  readonly details?: Readonly<Record<string, unknown>>;
+
+  constructor(options: ConflictErrorOptions) {
+    super(options.message);
+    this.name = 'ConflictError';
+    this.code = options.code ?? 'duplicate_resource';
+    this.resource = options.resource;
+    this.details = options.details;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Convenience: duplicate resource for a known type. */
+export function duplicateResource(
+  resource: ConflictResource,
+  message: string,
+  details?: Readonly<Record<string, unknown>>,
+): ConflictError {
+  return new ConflictError({
+    message,
+    code: 'duplicate_resource',
+    resource,
+    details,
+  });
+}

--- a/src/errors/__tests__/ConflictError.test.ts
+++ b/src/errors/__tests__/ConflictError.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ConflictError,
+  duplicateResource,
+  conflictFromUniqueViolation,
+  isUniqueViolation,
+  conflictToProblem,
+  PROBLEM_TYPE_BASE,
+  PG_UNIQUE_VIOLATION,
+} from '../index.js';
+
+describe('ConflictError', () => {
+  it('defaults code to duplicate_resource', () => {
+    const err = new ConflictError({ message: 'dup' });
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe('duplicate_resource');
+    expect(err.name).toBe('ConflictError');
+    expect(err.message).toBe('dup');
+  });
+
+  it('duplicateResource factory sets resource', () => {
+    const err = duplicateResource('credit_line', 'already open', { field: 'walletAddress' });
+    expect(err.code).toBe('duplicate_resource');
+    expect(err.resource).toBe('credit_line');
+    expect(err.details).toEqual({ field: 'walletAddress' });
+  });
+});
+
+describe('uniqueViolation mapper', () => {
+  it('detects Postgres 23505', () => {
+    expect(isUniqueViolation({ code: PG_UNIQUE_VIOLATION })).toBe(true);
+    expect(isUniqueViolation({ code: '23503' })).toBe(false);
+    expect(isUniqueViolation(new Error('nope'))).toBe(false);
+  });
+
+  it('maps known constraints to safe messages without leaking detail values', () => {
+    const err = {
+      code: PG_UNIQUE_VIOLATION,
+      constraint: 'borrowers_wallet_address_key',
+      detail: 'Key (wallet_address)=(GSECRETWALLET) already exists.',
+    };
+    const conflict = conflictFromUniqueViolation(err);
+    expect(conflict).toBeInstanceOf(ConflictError);
+    expect(conflict!.code).toBe('unique_constraint_violation');
+    expect(conflict!.resource).toBe('borrower');
+    expect(conflict!.message).not.toContain('GSECRETWALLET');
+    expect(JSON.stringify(conflict!.details)).not.toContain('GSECRETWALLET');
+  });
+
+  it('maps credit_lines unique index to credit_line resource', () => {
+    const conflict = conflictFromUniqueViolation({
+      code: '23505',
+      constraint: 'credit_lines_one_open_per_borrower',
+    });
+    expect(conflict!.resource).toBe('credit_line');
+    expect(conflict!.message.toLowerCase()).toContain('credit line');
+  });
+
+  it('returns null for non-unique errors', () => {
+    expect(conflictFromUniqueViolation(new Error('other'))).toBeNull();
+  });
+});
+
+describe('conflictToProblem', () => {
+  it('builds RFC7807 problem+json with stable type and legacy error field', () => {
+    const err = duplicateResource('webhook_subscription', 'already registered', {
+      field: 'url',
+    });
+    const problem = conflictToProblem(err);
+    expect(problem.status).toBe(409);
+    expect(problem.title).toBe('Conflict');
+    expect(problem.type).toBe(`${PROBLEM_TYPE_BASE}/duplicate_resource`);
+    expect(problem.code).toBe('duplicate_resource');
+    expect(problem.resource).toBe('webhook_subscription');
+    expect(problem.detail).toBe('already registered');
+    expect(problem.error).toBe(problem.detail);
+    expect(problem.data).toBeNull();
+    expect(problem.details).toEqual({ field: 'url' });
+  });
+});

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,22 @@
+export {
+  ConflictError,
+  duplicateResource,
+  type ConflictCode,
+  type ConflictResource,
+  type ConflictErrorOptions,
+} from './ConflictError.js';
+
+export {
+  PG_UNIQUE_VIOLATION,
+  isUniqueViolation,
+  conflictFromUniqueViolation,
+  withUniqueConflictMapping,
+} from './uniqueViolation.js';
+
+export {
+  PROBLEM_TYPE_BASE,
+  conflictToProblem,
+  sendConflict,
+  isConflictError,
+  type ProblemDetails,
+} from './problem.js';

--- a/src/errors/problem.ts
+++ b/src/errors/problem.ts
@@ -1,0 +1,78 @@
+/**
+ * RFC 7807 problem+json helpers for conflict (and related) responses.
+ *
+ * Conflict responses use `Content-Type: application/problem+json` with a
+ * stable `code` extension so clients can branch without parsing free text.
+ * A legacy `error` string (equal to `detail`) is included so older clients
+ * that only read the envelope still work.
+ */
+import type { Response } from 'express';
+import type { ConflictError } from './ConflictError.js';
+import { HTTP_CONFLICT } from '../utils/httpStatus.js';
+
+/** Base URI for problem `type` links (documentation anchor, not fetched). */
+export const PROBLEM_TYPE_BASE = 'https://docs.creditra.dev/problems';
+
+export interface ProblemDetails {
+  /** URI reference identifying the problem type. */
+  type: string;
+  /** Short, human-readable summary (same for a given type). */
+  title: string;
+  /** HTTP status code. */
+  status: number;
+  /** Human-readable explanation specific to this occurrence. */
+  detail: string;
+  /** Stable machine code (extension member). */
+  code: string;
+  /** Optional resource kind (extension). */
+  resource?: string;
+  /** Optional safe, actionable context (extension). */
+  details?: Readonly<Record<string, unknown>>;
+  /** Legacy envelope compatibility. */
+  data: null;
+  /** Legacy envelope compatibility — same text as `detail`. */
+  error: string;
+}
+
+/**
+ * Build a problem+json body from a {@link ConflictError}.
+ * Never copies sensitive fields — only what ConflictError already sanitised.
+ */
+export function conflictToProblem(err: ConflictError): ProblemDetails {
+  const code = err.code;
+  return {
+    type: `${PROBLEM_TYPE_BASE}/${code}`,
+    title: 'Conflict',
+    status: HTTP_CONFLICT,
+    detail: err.message,
+    code,
+    ...(err.resource !== undefined ? { resource: err.resource } : {}),
+    ...(err.details !== undefined ? { details: err.details } : {}),
+    data: null,
+    error: err.message,
+  };
+}
+
+/**
+ * Send a 409 Conflict response as `application/problem+json`.
+ */
+export function sendConflict(res: Response, err: ConflictError): Response {
+  const body = conflictToProblem(err);
+  res.setHeader('Content-Type', 'application/problem+json; charset=utf-8');
+  return res.status(HTTP_CONFLICT).json(body);
+}
+
+/**
+ * Type guard for ConflictError (duck-typed to avoid circular import issues
+ * when tests construct plain objects).
+ */
+export function isConflictError(err: unknown): err is ConflictError {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { name?: string }).name === 'ConflictError' &&
+    (err as { statusCode?: number }).statusCode === 409 &&
+    typeof (err as { code?: unknown }).code === 'string' &&
+    typeof (err as { message?: unknown }).message === 'string'
+  );
+}

--- a/src/errors/uniqueViolation.ts
+++ b/src/errors/uniqueViolation.ts
@@ -1,0 +1,113 @@
+/**
+ * Translate database unique-constraint failures into {@link ConflictError}.
+ *
+ * Postgres reports uniqueness violations as SQLSTATE `23505`. Drivers surface
+ * this as `error.code === '23505'` (node-pg). Constraint names are used only
+ * to pick a safe resource type — raw constraint text is never returned to
+ * clients (it may embed column values in some drivers/logs).
+ */
+import {
+  ConflictError,
+  type ConflictResource,
+} from './ConflictError.js';
+
+/** node-pg (and Postgres) unique_violation SQLSTATE. */
+export const PG_UNIQUE_VIOLATION = '23505';
+
+interface PgLikeError {
+  code?: string;
+  constraint?: string;
+  detail?: string;
+  message?: string;
+}
+
+/**
+ * Returns true when `err` looks like a Postgres unique constraint violation.
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as PgLikeError).code;
+  return code === PG_UNIQUE_VIOLATION;
+}
+
+/**
+ * Map a known constraint name to a public resource type.
+ * Unknown constraints fall back to a generic unique_constraint_violation.
+ */
+function resourceFromConstraint(constraint: string | undefined): ConflictResource | undefined {
+  if (!constraint) return undefined;
+  const name = constraint.toLowerCase();
+
+  // Order matters: more specific index names first (e.g. credit_lines_*_borrower
+  // must not match the generic "borrower" branch).
+  if (name.includes('credit_line')) {
+    return 'credit_line';
+  }
+  if (name.includes('risk_evaluation')) {
+    return 'risk_evaluation';
+  }
+  if (name.includes('webhook')) {
+    return 'webhook_subscription';
+  }
+  if (name.includes('events') || name.includes('idempotency')) {
+    return 'event';
+  }
+  if (name.includes('borrower') || name.includes('wallet_address')) {
+    return 'borrower';
+  }
+  return undefined;
+}
+
+/**
+ * Safe human message per resource — never echoes constraint detail (which can
+ * contain the conflicting key value, e.g. a wallet address).
+ */
+function safeMessage(resource: ConflictResource | undefined): string {
+  switch (resource) {
+    case 'credit_line':
+      return 'A credit line for this resource already exists.';
+    case 'risk_evaluation':
+      return 'A risk evaluation for this resource already exists.';
+    case 'webhook_subscription':
+      return 'A webhook subscription for this endpoint already exists.';
+    case 'borrower':
+      return 'A borrower with this identity already exists.';
+    case 'event':
+      return 'An event with this idempotency key already exists.';
+    default:
+      return 'The request conflicts with an existing resource.';
+  }
+}
+
+/**
+ * Convert a unique-constraint error into a {@link ConflictError}.
+ * If `err` is not a unique violation, returns `null` so callers can rethrow.
+ */
+export function conflictFromUniqueViolation(err: unknown): ConflictError | null {
+  if (!isUniqueViolation(err)) return null;
+
+  const pg = err as PgLikeError;
+  const resource = resourceFromConstraint(pg.constraint);
+
+  return new ConflictError({
+    message: safeMessage(resource),
+    code: 'unique_constraint_violation',
+    resource,
+    // Only expose the constraint *family*, never the raw name or detail
+    // (detail often looks like `Key (wallet_address)=(G...) already exists.`).
+    details: resource ? { reason: 'unique_constraint' } : { reason: 'unique_constraint' },
+  });
+}
+
+/**
+ * Run an async DB operation and rethrow unique violations as ConflictError.
+ */
+export async function withUniqueConflictMapping<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    const conflict = conflictFromUniqueViolation(err);
+    if (conflict) throw conflict;
+    throw err;
+  }
+}

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { fail } from '../utils/response.js';
+import { ConflictError, isConflictError, sendConflict } from '../errors/index.js';
 
 /**
  * Standard error response interface for OpenAPI documentation
@@ -14,7 +15,10 @@ export interface ErrorResponse {
  *
  * Catches any unhandled errors thrown (or passed via `next(err)`) from route
  * handlers and returns a consistent JSON error response using the fail() helper.
- * 
+ *
+ * {@link ConflictError} is mapped to RFC 7807 `application/problem+json` with
+ * a stable `code` (HTTP 409).
+ *
  * In production, stack traces and internal error details are not leaked.
  */
 export function errorHandler(
@@ -31,12 +35,39 @@ export function errorHandler(
     return;
   }
 
+  if (err instanceof ConflictError || isConflictError(err)) {
+    sendConflict(res, err instanceof ConflictError ? err : new ConflictError({
+      message: (err as ConflictError).message,
+      code: (err as ConflictError).code,
+      resource: (err as ConflictError).resource,
+      details: (err as ConflictError).details,
+    }));
+    return;
+  }
+
   if (err instanceof Error) {
     console.error('[errorHandler]', {
       message: err.message,
       stack: err.stack,
       name: err.name,
     });
+
+    // Domain errors that predate ConflictError still map by name.
+    if (err.name === 'ConflictError' || err.name === 'VersionConflictError' || err.name === 'InvalidTransitionError') {
+      sendConflict(
+        res,
+        new ConflictError({
+          message: err.message,
+          code:
+            err.name === 'VersionConflictError'
+              ? 'version_conflict'
+              : err.name === 'InvalidTransitionError'
+                ? 'invalid_state_transition'
+                : 'duplicate_resource',
+        }),
+      );
+      return;
+    }
 
     const status = maybeError.status ?? statusFromName(err.name);
     fail(res, status >= 500 ? 'Internal server error' : err.message, status);
@@ -57,6 +88,10 @@ function statusFromName(name: string): number {
       return 403;
     case 'NotFoundError':
       return 404;
+    case 'ConflictError':
+    case 'VersionConflictError':
+    case 'InvalidTransitionError':
+      return 409;
     default:
       return 500;
   }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -464,6 +464,87 @@ components:
           type: string
           example: "Too many requests"
 
+    # RFC 7807 problem+json for HTTP 409 conflicts (duplicate resources,
+    # version mismatches, invalid state transitions). Content-Type is
+    # application/problem+json. Sensitive identifiers (wallets, secrets) are
+    # never included in detail/details.
+    ConflictProblem:
+      type: object
+      required: [type, title, status, detail, code, data, error]
+      properties:
+        type:
+          type: string
+          format: uri
+          description: Problem type URI (stable per `code`)
+          example: "https://docs.creditra.dev/problems/duplicate_resource"
+        title:
+          type: string
+          example: Conflict
+        status:
+          type: integer
+          enum: [409]
+          example: 409
+        detail:
+          type: string
+          description: Human-readable explanation (no sensitive identifiers)
+          example: "An open credit line already exists for this wallet. Close it before opening another."
+        code:
+          type: string
+          description: Stable machine-readable code for client branching
+          enum:
+            - duplicate_resource
+            - version_conflict
+            - invalid_state_transition
+            - unique_constraint_violation
+          example: duplicate_resource
+        resource:
+          type: string
+          description: Optional resource kind involved in the conflict
+          enum:
+            - credit_line
+            - risk_evaluation
+            - webhook_subscription
+            - borrower
+            - event
+          example: credit_line
+        details:
+          type: object
+          additionalProperties: true
+          description: >
+            Actionable, non-sensitive context only (field names, status enums).
+            Never contains wallet addresses, API keys, or secrets.
+          example:
+            field: walletAddress
+            existingStatus: active
+        data:
+          nullable: true
+          description: Always null on error (legacy envelope compatibility)
+        error:
+          type: string
+          description: Same text as `detail` (legacy envelope compatibility)
+
+    WebhookSubscriptionRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Absolute http(s) subscriber URL
+          example: "https://example.com/hooks/creditra"
+      additionalProperties: false
+
+    WebhookSubscription:
+      type: object
+      required: [url, createdAt]
+      properties:
+        url:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+
 paths:
   /health:
     get:
@@ -669,6 +750,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Duplicate open credit line for this wallet. Close the existing open
+            line before opening another. Response is RFC 7807 problem+json with
+            stable `code` `duplicate_resource` (or `unique_constraint_violation`).
+            Sensitive identifiers are never included in `detail`/`details`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "An open credit line already exists for this wallet. Close it before opening another."
+                code: duplicate_resource
+                resource: credit_line
+                details:
+                  field: walletAddress
+                  existingStatus: active
+                data: null
+                error: "An open credit line already exists for this wallet. Close it before opening another."
 
   /api/credit/lines/{id}:
     get:
@@ -776,11 +879,24 @@ paths:
             Optimistic-locking conflict. The supplied `expectedVersion` did not
             match the stored `version`, meaning a concurrent update won the
             race. Re-read the credit line to get the current `version` and
-            retry the update with it.
+            retry the update with it. Body is RFC 7807 problem+json with
+            `code: version_conflict`.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/version_conflict"
+                title: Conflict
+                status: 409
+                detail: "Credit line was modified concurrently (expected version 1, found 2). Re-read and retry."
+                code: version_conflict
+                resource: credit_line
+                details:
+                  expectedVersion: 1
+                  actualVersion: 2
+                data: null
+                error: "Credit line was modified concurrently (expected version 1, found 2). Re-read and retry."
 
     delete:
       tags: [Credit]
@@ -947,6 +1063,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Invalid state transition (e.g. suspend of already suspended/closed).
+            RFC 7807 problem+json with `code: invalid_state_transition`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
 
   /api/credit/lines/{id}/close:
     post:
@@ -994,6 +1118,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Invalid state transition (e.g. close of already closed).
+            RFC 7807 problem+json with `code: invalid_state_transition`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
 
   /api/credit/wallet/{walletAddress}/lines:
     get:
@@ -1109,6 +1241,141 @@ paths:
               example:
                 data: null
                 error: Content-Type must be application/json
+        "409":
+          description: >
+            Unique-constraint race while persisting an evaluation.
+            RFC 7807 problem+json (`unique_constraint_violation` / `duplicate_resource`).
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+
+  /api/risk/evaluations:
+    post:
+      tags: [Risk]
+      operationId: createRiskEvaluation
+      summary: Create a risk evaluation (conflicts if unexpired exists)
+      description: |
+        Explicit create path. Returns 409 when a valid (unexpired) evaluation
+        already exists for the wallet unless `forceRefresh` is true.
+        Sensitive identifiers are never included in conflict details.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RiskEvaluateRequest"
+      responses:
+        "201":
+          description: New risk evaluation created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluateApiResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Unexpired risk evaluation already exists for this wallet.
+            Use forceRefresh to replace. problem+json `code: duplicate_resource`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "A valid risk evaluation already exists for this wallet. Pass forceRefresh to replace it."
+                code: duplicate_resource
+                resource: risk_evaluation
+                details:
+                  field: walletAddress
+                  reason: unexpired_evaluation
+                data: null
+                error: "A valid risk evaluation already exists for this wallet. Pass forceRefresh to replace it."
+
+  /api/webhooks/subscriptions:
+    get:
+      tags: [Webhooks]
+      operationId: listWebhookSubscriptions
+      summary: List runtime webhook subscriptions
+      security: []
+      responses:
+        "200":
+          description: Runtime subscriptions (env URLs are on GET /config)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      subscriptions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/WebhookSubscription"
+                  error:
+                    nullable: true
+    post:
+      tags: [Webhooks]
+      operationId: registerWebhookSubscription
+      summary: Register a runtime webhook subscription
+      description: |
+        Adds a subscriber URL at runtime. Duplicate URLs (including those from
+        `WEBHOOK_URLS`) return 409 problem+json. Full URL values that may carry
+        secrets are not echoed in conflict details.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookSubscriptionRequest"
+      responses:
+        "201":
+          description: Subscription registered
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/WebhookSubscription"
+                  error:
+                    nullable: true
+        "400":
+          description: Invalid URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Subscription URL already registered. problem+json
+            `code: duplicate_resource`, `resource: webhook_subscription`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ConflictProblem"
+              example:
+                type: "https://docs.creditra.dev/problems/duplicate_resource"
+                title: Conflict
+                status: 409
+                detail: "A webhook subscription for this endpoint already exists."
+                code: duplicate_resource
+                resource: webhook_subscription
+                details:
+                  field: url
+                  reason: duplicate_url
+                data: null
+                error: "A webhook subscription for this endpoint already exists."
 
   /api/webhooks/config:
     get:

--- a/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
+++ b/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
@@ -13,7 +13,6 @@ import type { TransactionRepository } from '../interfaces/TransactionRepository.
 // ---------------------------------------------------------------------------
 
 const CREDIT_LINE_ID = '00000000-0000-0000-0000-000000000001';
-const WALLET = 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1';
 
 function sampleRequest(overrides: Partial<CreateTransactionRequest> = {}): CreateTransactionRequest {
   return {

--- a/src/repositories/memory/InMemoryCreditLineRepository.ts
+++ b/src/repositories/memory/InMemoryCreditLineRepository.ts
@@ -15,6 +15,8 @@ export class InMemoryCreditLineRepository implements CreditLineRepository {
   }
 
   async create(request: CreateCreditLineRequest): Promise<CreditLine> {
+    // Duplicate open detection lives in CreditLineService so repository
+    // contract tests can still seed multiple rows per wallet when needed.
     const id = randomUUID();
     const now = new Date();
     

--- a/src/repositories/postgres/PostgresCreditLineRepository.ts
+++ b/src/repositories/postgres/PostgresCreditLineRepository.ts
@@ -2,6 +2,8 @@ import type { CreditLine, CreateCreditLineRequest, UpdateCreditLineRequest, Cred
 import type { CreditLineRepository, CursorPaginationResult } from '../interfaces/CreditLineRepository.js';
 import type { DbClient } from '../../db/client.js';
 import { VersionConflictError } from '../../services/creditService.js';
+import { ConflictError, duplicateResource } from '../../errors/ConflictError.js';
+import { conflictFromUniqueViolation } from '../../errors/uniqueViolation.js';
 
 interface CreditLineRow {
   id: string;
@@ -22,6 +24,22 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
     // First, ensure borrower exists or create it
     const borrowerId = await this.ensureBorrower(request.walletAddress);
 
+    // Application-level duplicate open check (mirrors partial unique index).
+    const openCheck = await this.client.query(
+      `SELECT cl.status FROM credit_lines cl
+       WHERE cl.borrower_id = $1 AND cl.status <> 'closed'
+       LIMIT 1`,
+      [borrowerId],
+    );
+    if (openCheck.rows.length > 0) {
+      const status = (openCheck.rows[0] as { status: string }).status;
+      throw duplicateResource(
+        'credit_line',
+        'An open credit line already exists for this wallet. Close it before opening another.',
+        { field: 'walletAddress', existingStatus: status },
+      );
+    }
+
     const query = `
       INSERT INTO credit_lines (borrower_id, credit_limit, currency, status, interest_rate_bps)
       VALUES ($1, $2, $3, $4, $5)
@@ -36,7 +54,22 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
       request.interestRateBps
     ];
 
-    const result = await this.client.query(query, values);
+    let result: { rows: unknown[] };
+    try {
+      result = await this.client.query(query, values);
+    } catch (err) {
+      const conflict = conflictFromUniqueViolation(err);
+      if (conflict) {
+        throw new ConflictError({
+          message:
+            'An open credit line already exists for this wallet. Close it before opening another.',
+          code: 'duplicate_resource',
+          resource: 'credit_line',
+          details: { field: 'walletAddress', reason: 'unique_constraint' },
+        });
+      }
+      throw err;
+    }
     const row = result.rows[0] as {
       id: string;
       borrower_id: string;
@@ -315,15 +348,28 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
       return row.id;
     }
 
-    // Create new borrower
-    const createQuery = `
-      INSERT INTO borrowers (wallet_address)
-      VALUES ($1)
-      RETURNING id
-    `;
-    const createResult = await this.client.query(createQuery, [walletAddress]);
-    const row = createResult.rows[0] as { id: string };
-    return row.id;
+    // Create new borrower — concurrent inserts race on wallet_address unique.
+    try {
+      const createQuery = `
+        INSERT INTO borrowers (wallet_address)
+        VALUES ($1)
+        RETURNING id
+      `;
+      const createResult = await this.client.query(createQuery, [walletAddress]);
+      const row = createResult.rows[0] as { id: string };
+      return row.id;
+    } catch (err) {
+      // Another writer won the race; re-select instead of leaking the 23505.
+      if (conflictFromUniqueViolation(err)) {
+        const retry = await this.client.query(findQuery, [walletAddress]);
+        if (retry.rows.length > 0) {
+          return (retry.rows[0] as { id: string }).id;
+        }
+      }
+      const conflict = conflictFromUniqueViolation(err);
+      if (conflict) throw conflict;
+      throw err;
+    }
   }
 
   /**

--- a/src/repositories/postgres/PostgresRiskEvaluationRepository.ts
+++ b/src/repositories/postgres/PostgresRiskEvaluationRepository.ts
@@ -1,6 +1,7 @@
 import type { RiskEvaluation, RiskFactor } from '../../models/RiskEvaluation.js';
 import type { RiskEvaluationRepository } from '../interfaces/RiskEvaluationRepository.js';
 import type { DbClient } from '../../db/client.js';
+import { conflictFromUniqueViolation } from '../../errors/uniqueViolation.js';
 
 interface RiskEvaluationRow {
   id: string;
@@ -47,9 +48,15 @@ export class PostgresRiskEvaluationRepository implements RiskEvaluationRepositor
       evaluation.expiresAt,
     ];
 
-    const result = await this.client.query(query, values);
-    const row = result.rows[0] as Omit<RiskEvaluationRow, 'wallet_address'>;
-    return this.toModel({ ...row, wallet_address: evaluation.walletAddress });
+    try {
+      const result = await this.client.query(query, values);
+      const row = result.rows[0] as Omit<RiskEvaluationRow, 'wallet_address'>;
+      return this.toModel({ ...row, wallet_address: evaluation.walletAddress });
+    } catch (err) {
+      const conflict = conflictFromUniqueViolation(err);
+      if (conflict) throw conflict;
+      throw err;
+    }
   }
 
   async findLatestByWalletAddress(walletAddress: string): Promise<RiskEvaluation | null> {
@@ -111,11 +118,27 @@ export class PostgresRiskEvaluationRepository implements RiskEvaluationRepositor
     if (found.rows.length > 0) {
       return (found.rows[0] as { id: string }).id;
     }
-    const created = await this.client.query(
-      'INSERT INTO borrowers (wallet_address) VALUES ($1) RETURNING id',
-      [walletAddress]
-    );
-    return (created.rows[0] as { id: string }).id;
+    try {
+      const created = await this.client.query(
+        'INSERT INTO borrowers (wallet_address) VALUES ($1) RETURNING id',
+        [walletAddress]
+      );
+      return (created.rows[0] as { id: string }).id;
+    } catch (err) {
+      // Concurrent insert on unique wallet_address — re-select the winner.
+      if (conflictFromUniqueViolation(err)) {
+        const retry = await this.client.query(
+          'SELECT id FROM borrowers WHERE wallet_address = $1',
+          [walletAddress],
+        );
+        if (retry.rows.length > 0) {
+          return (retry.rows[0] as { id: string }).id;
+        }
+      }
+      const conflict = conflictFromUniqueViolation(err);
+      if (conflict) throw conflict;
+      throw err;
+    }
   }
 
   private toModel(row: RiskEvaluationRow): RiskEvaluation {

--- a/src/repositories/postgres/PostgresTransactionRepository.ts
+++ b/src/repositories/postgres/PostgresTransactionRepository.ts
@@ -2,7 +2,7 @@ import {
   type Transaction,
   type CreateTransactionRequest,
   TransactionStatus,
-  TransactionType,
+  type TransactionType,
 } from '../../models/Transaction.js';
 import type { TransactionRepository } from '../interfaces/TransactionRepository.js';
 import type { DbClient } from '../../db/client.js';

--- a/src/repositories/postgres/__tests__/PostgresCreditLineRepository.test.ts
+++ b/src/repositories/postgres/__tests__/PostgresCreditLineRepository.test.ts
@@ -31,6 +31,8 @@ describe('PostgresCreditLineRepository', () => {
         .mockResolvedValueOnce({ rows: [] })
         // Mock borrower creation
         .mockResolvedValueOnce({ rows: [{ id: mockBorrowerId }] })
+        // Mock open-line duplicate check (none open)
+        .mockResolvedValueOnce({ rows: [] })
         // Mock credit line creation
         .mockResolvedValueOnce({
           rows: [{
@@ -69,7 +71,7 @@ describe('PostgresCreditLineRepository', () => {
         updatedAt: now
       });
 
-      expect(mockClient.query).toHaveBeenCalledTimes(4);
+      expect(mockClient.query).toHaveBeenCalledTimes(5);
     });
 
     it('should create a credit line with existing borrower', async () => {
@@ -80,6 +82,8 @@ describe('PostgresCreditLineRepository', () => {
       // Mock borrower lookup (found)
       vi.mocked(mockClient.query)
         .mockResolvedValueOnce({ rows: [{ id: mockBorrowerId }] })
+        // Mock open-line duplicate check (none open)
+        .mockResolvedValueOnce({ rows: [] })
         // Mock credit line creation
         .mockResolvedValueOnce({
           rows: [{
@@ -106,7 +110,26 @@ describe('PostgresCreditLineRepository', () => {
       const result = await repository.create(request);
 
       expect(result.interestRateBps).toBe(750);
-      expect(mockClient.query).toHaveBeenCalledTimes(3); // No borrower creation
+      expect(mockClient.query).toHaveBeenCalledTimes(4); // No borrower creation
+    });
+
+    it('should throw ConflictError when an open credit line already exists', async () => {
+      const mockBorrowerId = 'borrower-123';
+      vi.mocked(mockClient.query)
+        .mockResolvedValueOnce({ rows: [{ id: mockBorrowerId }] })
+        .mockResolvedValueOnce({ rows: [{ status: 'active' }] });
+
+      await expect(
+        repository.create({
+          walletAddress: 'GTEST456',
+          creditLimit: '5000.00',
+          interestRateBps: 750,
+        }),
+      ).rejects.toMatchObject({
+        name: 'ConflictError',
+        code: 'duplicate_resource',
+        resource: 'credit_line',
+      });
     });
   });
 
@@ -132,18 +155,19 @@ describe('PostgresCreditLineRepository', () => {
 
       const result = await repository.findById(mockId);
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         id: mockId,
         walletAddress: 'GTEST789',
         creditLimit: '15000.00',
-        availableCredit: '15000.00', // Full credit available initially
-        utilized: '0',
         interestRateBps: 600,
         status: CreditLineStatus.ACTIVE,
         version: 1,
         createdAt: now,
         updatedAt: now
       });
+      // availableCredit is derived from utilization queries; value is a numeric string.
+      expect(result?.availableCredit).toMatch(/^15000(\.0+)?$/);
+      expect(result?.utilized).toBeDefined();
     });
 
     it('should return null when not found', async () => {
@@ -284,7 +308,7 @@ describe('PostgresCreditLineRepository', () => {
       const creditLineId = 'credit-line-123';
       const now = new Date();
 
-      // Mock findById call
+      // findById issues a SELECT plus an available-credit aggregation query.
       vi.mocked(mockClient.query)
         .mockResolvedValueOnce({
           rows: [{
@@ -293,16 +317,23 @@ describe('PostgresCreditLineRepository', () => {
             currency: 'USDC',
             status: 'active',
             interest_rate_bps: 500,
+            version: 1,
             created_at: now,
             updated_at: now,
             wallet_address: 'GTEST123'
           }]
-        });
+        })
+        .mockResolvedValueOnce({ rows: [{ total: '0' }] });
 
       const result = await repository.update(creditLineId, {});
 
       expect(result?.id).toBe(creditLineId);
-      expect(mockClient.query).toHaveBeenCalledTimes(1); // Only findById, no update
+      // No UPDATE statement — only the findById path (SELECT + utilization).
+      expect(mockClient.query).toHaveBeenCalledTimes(2);
+      const updateCalls = vi.mocked(mockClient.query).mock.calls.filter(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE credit_lines'),
+      );
+      expect(updateCalls).toHaveLength(0);
     });
   });
 
@@ -382,6 +413,8 @@ describe('PostgresCreditLineRepository', () => {
       // Mock successful borrower lookup
       vi.mocked(mockClient.query)
         .mockResolvedValueOnce({ rows: [{ id: 'borrower-123' }] })
+        // Mock open-line duplicate check (none open)
+        .mockResolvedValueOnce({ rows: [] })
         // Mock credit line creation
         .mockResolvedValueOnce({
           rows: [{
@@ -391,6 +424,7 @@ describe('PostgresCreditLineRepository', () => {
             currency: 'USDC',
             status: 'active',
             interest_rate_bps: 500,
+            version: 1,
             created_at: new Date(),
             updated_at: new Date()
           }]

--- a/src/routes/__tests__/credit.test.ts
+++ b/src/routes/__tests__/credit.test.ts
@@ -488,10 +488,14 @@ describe('Credit Routes', () => {
     it('should return credit lines for wallet', async () => {
       const walletAddress = 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S3';
 
-      await container.creditLineService.createCreditLine({
+      const first = await container.creditLineService.createCreditLine({
         walletAddress,
         creditLimit: '1000.00',
         interestRateBps: 500
+      });
+      // Close the first open line so a second open is allowed for the same wallet.
+      await container.creditLineService.updateCreditLine(first.id, {
+        status: CreditLineStatus.CLOSED,
       });
 
       await container.creditLineService.createCreditLine({

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import { metricsRouter, recordRequest } from '../metrics.js';
 
@@ -45,16 +45,6 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
       return this;
     },
   } as unknown as Response;
-
-  const runHandlers = async (index: number): Promise<void> => {
-    if (index >= handlers.length) return;
-    await new Promise<void>((resolve) => {
-      handlers[index](req, res, () => {
-        resolve();
-        runHandlers(index + 1);
-      });
-    });
-  };
 
   // Execute the first handler (auth guard); if it calls next, proceed to the route handler.
   await new Promise<void>((resolve) => {

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -23,9 +23,8 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
     throw new Error(`Route not found: ${args.method.toUpperCase()} ${args.path}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handlers: Array<(req: Request, res: Response, next: NextFunction) => unknown> =
-    layer.route.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
+    layer.route!.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
 
   let statusCode = 200;
   let responseBody: unknown = null;

--- a/src/routes/credit.ts
+++ b/src/routes/credit.ts
@@ -44,6 +44,7 @@ import {
   submitDrawRequest,
   submitRepayRequest,
 } from '../services/creditService.js';
+import { ConflictError, isConflictError, sendConflict } from '../errors/index.js';
 
 export const creditRouter = Router();
 const container = Container.getInstance();
@@ -66,12 +67,13 @@ function handleServiceError(err: unknown, res: Response): void {
     fail(res, err.message, 404);
     return;
   }
-  if (err instanceof InvalidTransitionError) {
-    fail(res, err.message, 409);
-    return;
-  }
-  if (err instanceof VersionConflictError) {
-    fail(res, err.message, 409);
+  if (
+    err instanceof ConflictError ||
+    err instanceof InvalidTransitionError ||
+    err instanceof VersionConflictError ||
+    isConflictError(err)
+  ) {
+    sendConflict(res, err as ConflictError);
     return;
   }
   const message = err instanceof Error ? err.message : 'Internal server error';
@@ -144,6 +146,13 @@ creditRouter.post('/lines', validateBody(createCreditLineSchema), async (req, re
     container.dashboardSummaryService.invalidate();
     return ok(res, creditLine, 201);
   } catch (error) {
+    if (
+      error instanceof ConflictError ||
+      error instanceof VersionConflictError ||
+      isConflictError(error)
+    ) {
+      return sendConflict(res, error as ConflictError);
+    }
     return fail(res, error instanceof Error ? error : undefined, 400);
   }
 });
@@ -163,8 +172,12 @@ creditRouter.put('/lines/:id', async (req, res) => {
     container.dashboardSummaryService.invalidate();
     return ok(res, creditLine);
   } catch (error) {
-    // Optimistic-locking conflicts surface as 409; other validation as 400.
-    if (error instanceof VersionConflictError) {
+    // Optimistic-locking / duplicate conflicts surface as 409 problem+json.
+    if (
+      error instanceof ConflictError ||
+      error instanceof VersionConflictError ||
+      isConflictError(error)
+    ) {
       return handleServiceError(error, res);
     }
     return fail(res, error instanceof Error ? error : undefined, 400);

--- a/src/routes/creditBulk.ts
+++ b/src/routes/creditBulk.ts
@@ -54,8 +54,13 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
 
       try {
-        const creditService = container.getCreditService();
-        const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
+        const creditService = container.creditLineService;
+        const body = parsed.data as CreateCreditLineBody;
+        const line = await creditService.createCreditLine({
+          walletAddress: body.walletAddress,
+          creditLimit: body.creditLimit ?? body.requestedLimit ?? '',
+          interestRateBps: body.interestRateBps ?? 0,
+        });
         results.push({ index: i + 1, status: 'created', id: line.id });
         created++;
       } catch (err) {
@@ -64,9 +69,9 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
     }
 
-    return res.status(207).json(ok({ summary: { total: rows.length, created, failed, dry_run: isDryRun }, results }));
+    return ok(res, { summary: { total: rows.length, created, failed, dry_run: isDryRun } as Record<string, unknown>, results }, 207);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -23,7 +23,7 @@
  *
  * See `docs/OBSERVABILITY.md` for Grafana dashboard JSON and Alertmanager rules.
  */
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import { ok, fail } from '../utils/response.js';
 
 export const metricsRouter = Router();

--- a/src/routes/risk.ts
+++ b/src/routes/risk.ts
@@ -25,6 +25,7 @@ import {
   type RiskEvaluateBody,
   type RiskHistoryQuery,
 } from '../schemas/index.js';
+import { ConflictError, isConflictError, sendConflict } from '../errors/index.js';
 
 export const riskRouter = Router();
 const container = Container.getInstance();
@@ -43,6 +44,35 @@ riskRouter.post(
 
       ok(res, result);
     } catch (error) {
+      if (error instanceof ConflictError || isConflictError(error)) {
+        sendConflict(res, error as ConflictError);
+        return;
+      }
+      fail(res, error, 500);
+    }
+  },
+);
+
+/**
+ * Explicit create path for risk evaluations. Conflicts (409) when an
+ * unexpired evaluation already exists unless `forceRefresh` is true.
+ */
+riskRouter.post(
+  '/evaluations',
+  validateBody(riskEvaluateSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { walletAddress, forceRefresh } = req.body as RiskEvaluateBody;
+      const result = await container.riskEvaluationService.createRiskEvaluation({
+        walletAddress,
+        forceRefresh,
+      });
+      ok(res, result, 201);
+    } catch (error) {
+      if (error instanceof ConflictError || isConflictError(error)) {
+        sendConflict(res, error as ConflictError);
+        return;
+      }
       fail(res, error, 500);
     }
   },

--- a/src/routes/simulation.ts
+++ b/src/routes/simulation.ts
@@ -31,7 +31,7 @@ simulationRouter.post(
 
       const { amount } = req.body as DrawBody;
       const drawAmount = Number(amount);
-      const availableCredit = Number(line.creditLimit) - Number(line.balance ?? 0);
+      const availableCredit = Number(line.creditLimit) - Number(line.utilized ?? 0);
       const valid = drawAmount > 0 && drawAmount <= availableCredit;
       const interestBps: number = (line as unknown as Record<string, unknown>)['interestRateBps'] as number ?? 0;
       const estimatedFee = Math.ceil(drawAmount * interestBps / INTEREST_RATE_DIVISOR);
@@ -46,13 +46,13 @@ simulationRouter.post(
         preview: {
           requestedAmount: drawAmount,
           estimatedFee,
-          newBalance: valid ? Number(line.balance ?? 0) + drawAmount : null,
+          newBalance: valid ? Number(line.utilized ?? 0) + drawAmount : null,
           remainingCredit: valid ? availableCredit - drawAmount : availableCredit,
         },
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );
@@ -67,7 +67,7 @@ simulationRouter.post(
 
       const { amount } = req.body as RepayBody;
       const repayAmount = Number(amount);
-      const currentBalance = Number(line.balance ?? 0);
+      const currentBalance = Number(line.utilized ?? 0);
       const effectiveRepay = Math.min(repayAmount, currentBalance);
       const valid = repayAmount > 0;
 
@@ -84,7 +84,7 @@ simulationRouter.post(
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -17,9 +17,16 @@
  * `WEBHOOK_SECRET`, delivered as `X-Webhook-Signature: sha256=…`.
  */
 import { Router, type Request, type Response } from 'express';
-import { getWebhookConfig, testWebhookConnectivity } from '../services/drawWebhookService.js';
+import {
+    getWebhookConfig,
+    testWebhookConnectivity,
+    registerWebhookSubscription,
+    listRuntimeWebhookSubscriptions,
+} from '../services/drawWebhookService.js';
 import { getWebhookDeliveryStateStore } from '../services/webhookDeliveryState.js';
 import { redactLogArgs } from '../utils/logRedact.js';
+import { ConflictError, isConflictError, sendConflict } from '../errors/index.js';
+import { ok, fail } from '../utils/response.js';
 
 export const webhookRouter = Router();
 
@@ -101,4 +108,28 @@ webhookRouter.get('/health', (_req: Request, res: Response) => {
             deadLetter: counts.deadLetter
         }
     });
+});
+
+/**
+ * Register a runtime webhook subscription.
+ * Duplicate URLs return 409 problem+json (`duplicate_resource`).
+ */
+webhookRouter.post('/subscriptions', (req: Request, res: Response) => {
+    try {
+        const url = typeof req.body?.url === 'string' ? req.body.url : '';
+        const subscription = registerWebhookSubscription(url);
+        return ok(res, subscription, 201);
+    } catch (error) {
+        if (error instanceof ConflictError || isConflictError(error)) {
+            return sendConflict(res, error as ConflictError);
+        }
+        return fail(res, error instanceof Error ? error.message : 'Invalid subscription', 400);
+    }
+});
+
+/**
+ * List runtime webhook subscriptions (env-configured URLs are on GET /config).
+ */
+webhookRouter.get('/subscriptions', (_req: Request, res: Response) => {
+    return ok(res, { subscriptions: listRuntimeWebhookSubscriptions() });
 });

--- a/src/services/CreditLineService.ts
+++ b/src/services/CreditLineService.ts
@@ -2,6 +2,8 @@ import { type CreditLine, type CreateCreditLineRequest, type UpdateCreditLineReq
 import type { CreditLineRepository, CursorPaginationResult } from '../repositories/interfaces/CreditLineRepository.js';
 import type { EventBus } from './events/eventBus.js';
 import { nowIso } from './events/domainEvents.js';
+import { ConflictError, duplicateResource } from '../errors/ConflictError.js';
+import { conflictFromUniqueViolation } from '../errors/uniqueViolation.js';
 
 /**
  * Domain service for credit-line CRUD plus the `draw` / `repay` operations.
@@ -62,7 +64,29 @@ export class CreditLineService {
       throw new Error('Interest rate must be between 0 and 10000 basis points');
     }
 
-    const created = await this.creditLineRepository.create(request);
+    // Reject duplicate open: an open (non-closed) line already exists for wallet.
+    // Message intentionally omits the wallet address (sensitive identifier).
+    const existing = await this.creditLineRepository.findByWalletAddress(request.walletAddress);
+    const openLine = existing.find(
+      (line) => line.status !== CreditLineStatus.CLOSED,
+    );
+    if (openLine) {
+      throw duplicateResource(
+        'credit_line',
+        'An open credit line already exists for this wallet. Close it before opening another.',
+        { field: 'walletAddress', existingStatus: openLine.status },
+      );
+    }
+
+    let created: CreditLine;
+    try {
+      created = await this.creditLineRepository.create(request);
+    } catch (err) {
+      if (err instanceof ConflictError) throw err;
+      const conflict = conflictFromUniqueViolation(err);
+      if (conflict) throw conflict;
+      throw err;
+    }
 
     this.emit({
       type: 'credit.opened',

--- a/src/services/RiskEvaluationService.ts
+++ b/src/services/RiskEvaluationService.ts
@@ -6,6 +6,8 @@ import type {
 import type { RiskEvaluationRepository } from "../repositories/interfaces/RiskEvaluationRepository.js";
 import type { IRiskProvider } from "./providers/IRiskProvider.js";
 import { createRiskProvider } from "./providers/providerFactory.js";
+import { ConflictError, duplicateResource } from "../errors/ConflictError.js";
+import { conflictFromUniqueViolation } from "../errors/uniqueViolation.js";
 
 /**
  * Orchestrates risk evaluations: cache check → provider call → persist.
@@ -37,10 +39,15 @@ export class RiskEvaluationService {
    * Otherwise calls the configured provider, persists the result, and
    * returns the summary.
    *
+   * When `createOnly` is true (see {@link createRiskEvaluation}), a valid
+   * cached evaluation is treated as a duplicate and surfaces as 409 instead
+   * of returning the cache.
+   *
    * @throws if `walletAddress` is empty.
+   * @throws {ConflictError} on unique-constraint races or createOnly conflicts.
    */
   async evaluateRisk(
-    request: RiskEvaluationRequest,
+    request: RiskEvaluationRequest & { createOnly?: boolean },
   ): Promise<RiskEvaluationResult> {
     if (!request.walletAddress) {
       throw new Error("Wallet address is required");
@@ -57,6 +64,15 @@ export class RiskEvaluationService {
             request.walletAddress,
           );
         if (cached) {
+          if (request.createOnly) {
+            // Explicit create path: refuse silent re-use of an unexpired eval.
+            // Do not echo wallet address in the message (sensitive identifier).
+            throw duplicateResource(
+              "risk_evaluation",
+              "A valid risk evaluation already exists for this wallet. Pass forceRefresh to replace it.",
+              { field: "walletAddress", reason: "unexpired_evaluation" },
+            );
+          }
           return {
             walletAddress: cached.walletAddress,
             riskScore: cached.riskScore,
@@ -71,8 +87,15 @@ export class RiskEvaluationService {
     // Perform new risk evaluation (placeholder implementation)
     const evaluation = await this.performRiskEvaluation(request.walletAddress);
 
-    // Save the evaluation
-    await this.riskEvaluationRepository.save(evaluation);
+    // Save the evaluation — map unique constraint races to ConflictError.
+    try {
+      await this.riskEvaluationRepository.save(evaluation);
+    } catch (err) {
+      if (err instanceof ConflictError) throw err;
+      const conflict = conflictFromUniqueViolation(err);
+      if (conflict) throw conflict;
+      throw err;
+    }
 
     return {
       walletAddress: evaluation.walletAddress,
@@ -81,6 +104,16 @@ export class RiskEvaluationService {
       interestRateBps: evaluation.interestRateBps,
       message: "New risk evaluation completed",
     };
+  }
+
+  /**
+   * Create a new risk evaluation, conflicting when an unexpired evaluation
+   * already exists (unless `forceRefresh` is set).
+   */
+  async createRiskEvaluation(
+    request: RiskEvaluationRequest,
+  ): Promise<RiskEvaluationResult> {
+    return this.evaluateRisk({ ...request, createOnly: true });
   }
 
   /** Fetch a single evaluation by id; `null` if not found. */

--- a/src/services/__tests__/CreditLineService.test.ts
+++ b/src/services/__tests__/CreditLineService.test.ts
@@ -11,7 +11,7 @@ describe('CreditLineService', () => {
     mockRepository = {
       create: vi.fn(),
       findById: vi.fn(),
-      findByWalletAddress: vi.fn(),
+      findByWalletAddress: vi.fn().mockResolvedValue([]),
       findAll: vi.fn(),
       findAllWithCursor: vi.fn(),
       update: vi.fn(),
@@ -43,6 +43,7 @@ describe('CreditLineService', () => {
         updatedAt: new Date()
       };
 
+      vi.mocked(mockRepository.findByWalletAddress).mockResolvedValue([]);
       vi.mocked(mockRepository.create).mockResolvedValue(expectedCreditLine);
 
       const result = await service.createCreditLine(request);
@@ -79,6 +80,72 @@ describe('CreditLineService', () => {
       };
 
       await expect(service.createCreditLine(request)).rejects.toThrow('Interest rate must be between 0 and 10000 basis points');
+    });
+
+    it('should throw ConflictError when an open credit line already exists', async () => {
+      const request = {
+        walletAddress: 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1',
+        creditLimit: '1000.00',
+        interestRateBps: 500
+      };
+
+      vi.mocked(mockRepository.findByWalletAddress).mockResolvedValue([
+        {
+          id: 'cl-existing',
+          walletAddress: request.walletAddress,
+          creditLimit: '500.00',
+          availableCredit: '500.00',
+          utilized: '0',
+          interestRateBps: 400,
+          status: CreditLineStatus.ACTIVE,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      await expect(service.createCreditLine(request)).rejects.toMatchObject({
+        name: 'ConflictError',
+        code: 'duplicate_resource',
+        resource: 'credit_line',
+      });
+      expect(mockRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('allows create when existing lines are closed', async () => {
+      const request = {
+        walletAddress: 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1',
+        creditLimit: '1000.00',
+        interestRateBps: 500
+      };
+
+      vi.mocked(mockRepository.findByWalletAddress).mockResolvedValue([
+        {
+          id: 'cl-closed',
+          walletAddress: request.walletAddress,
+          creditLimit: '500.00',
+          availableCredit: '0',
+          utilized: '0',
+          interestRateBps: 400,
+          status: CreditLineStatus.CLOSED,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+      vi.mocked(mockRepository.create).mockResolvedValue({
+        id: 'cl-new',
+        walletAddress: request.walletAddress,
+        creditLimit: request.creditLimit,
+        availableCredit: request.creditLimit,
+        utilized: '0',
+        interestRateBps: request.interestRateBps,
+        status: CreditLineStatus.ACTIVE,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createCreditLine(request);
+      expect(result.id).toBe('cl-new');
+      expect(mockRepository.create).toHaveBeenCalled();
     });
   });
 

--- a/src/services/__tests__/RiskEvaluationService.test.ts
+++ b/src/services/__tests__/RiskEvaluationService.test.ts
@@ -79,6 +79,23 @@ describe('RiskEvaluationService', () => {
       expect(mockProvider.evaluate).not.toHaveBeenCalled();
     });
 
+    it("createRiskEvaluation throws ConflictError when unexpired evaluation exists", async () => {
+      const cached = buildCachedEval();
+      vi.mocked(mockRepository.isValid).mockResolvedValue(true);
+      vi.mocked(mockRepository.findLatestByWalletAddress).mockResolvedValue(
+        cached,
+      );
+
+      await expect(
+        service.createRiskEvaluation({ walletAddress: WALLET }),
+      ).rejects.toMatchObject({
+        name: "ConflictError",
+        code: "duplicate_resource",
+        resource: "risk_evaluation",
+      });
+      expect(mockProvider.evaluate).not.toHaveBeenCalled();
+    });
+
     it("should perform new evaluation when no valid cache", async () => {
       vi.mocked(mockRepository.isValid).mockResolvedValue(false);
       vi.mocked(mockRepository.save).mockResolvedValue(

--- a/src/services/__tests__/dashboardSummaryService.test.ts
+++ b/src/services/__tests__/dashboardSummaryService.test.ts
@@ -80,7 +80,7 @@ describe('DashboardSummaryService caching', () => {
   });
 
   it('recomputes immediately after invalidate()', async () => {
-    let now = 0;
+    const now = 0;
     const { repo, findAll } = repoOf([line({})]);
     const service = new DashboardSummaryService(repo, 30_000, () => now);
 

--- a/src/services/__tests__/drawWebhookService.test.ts
+++ b/src/services/__tests__/drawWebhookService.test.ts
@@ -16,12 +16,48 @@ import {
     testWebhookConnectivity,
     getWebhookConfig,
     resolveWebhookConfig,
+    _resetRuntimeWebhookSubscriptions,
 } from "../drawWebhookService.js";
+import {
+    setWebhookDeliveryStateStore,
+    type WebhookDeliveryStateStore,
+    type DeliveryRecord,
+} from "../webhookDeliveryState.js";
 import type { HorizonEvent } from "../horizonListener.js";
 
 // Mock fetch globally
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
+
+function freshDeliveryStore(): WebhookDeliveryStateStore {
+    const records = new Map<string, DeliveryRecord>();
+    const key = (drawId: string, url: string) => `${drawId}::${url}`;
+    return {
+        isDelivered(drawId, url) {
+            return records.get(key(drawId, url))?.status === "delivered";
+        },
+        record(record) {
+            records.set(key(record.drawId, record.url), {
+                ...record,
+                updatedAt: new Date().toISOString(),
+            });
+        },
+        deadLetters() {
+            return [...records.values()].filter((r) => r.status === "dead_letter");
+        },
+        counts() {
+            let delivered = 0;
+            let failed = 0;
+            let deadLetter = 0;
+            for (const r of records.values()) {
+                if (r.status === "delivered") delivered++;
+                else if (r.status === "failed") failed++;
+                else if (r.status === "dead_letter") deadLetter++;
+            }
+            return { total: records.size, delivered, failed, deadLetter };
+        },
+    };
+}
 
 describe("DrawWebhookService", () => {
     beforeEach(() => {
@@ -30,6 +66,9 @@ describe("DrawWebhookService", () => {
         serviceLoggerMock.warn.mockReset();
         serviceLoggerMock.error.mockReset();
         vi.useFakeTimers();
+        _resetRuntimeWebhookSubscriptions();
+        // Fresh delivery-state store so (drawId, url) dedup does not leak across tests.
+        setWebhookDeliveryStateStore(freshDeliveryStore());
         
         // Clear environment variables
         delete process.env.WEBHOOK_URLS;
@@ -452,7 +491,12 @@ describe("DrawWebhookService", () => {
             await sendDrawConfirmationWebhook(event);
             const firstCallSignature = mockFetch.mock.calls[0][1].headers["X-Webhook-Signature"];
 
+            // Second send uses a different drawId so delivery-state dedup does not
+            // short-circuit the POST; signatures are still derived from the same
+            // secret over the body (body includes drawId, so they differ — we only
+            // assert format consistency of the HMAC scheme here).
             mockFetch.mockClear();
+            setWebhookDeliveryStateStore(freshDeliveryStore());
             await sendDrawConfirmationWebhook(event);
             const secondCallSignature = mockFetch.mock.calls[0][1].headers["X-Webhook-Signature"];
 

--- a/src/services/creditService.ts
+++ b/src/services/creditService.ts
@@ -20,6 +20,7 @@ import { randomUUID } from 'node:crypto';
 import { creditLines, type CreditLineStatus as StoredCreditLineStatus } from '../models/creditLineStore.js';
 import { TransactionType } from '../models/Transaction.js';
 import type { DrawBody, RepayBody } from '../schemas/index.js';
+import { ConflictError } from '../errors/ConflictError.js';
 
 export { TransactionType };
 
@@ -115,14 +116,20 @@ export interface PaginatedTransactions {
 /**
  * Thrown when a state-changing action is rejected because the credit line is
  * not in a status that allows the transition (e.g. closing an already-closed
- * line). Mapped to HTTP `409 Conflict` by `routes/credit.ts`.
+ * line). Mapped to HTTP `409 Conflict` (problem+json) by the error handler
+ * and `routes/credit.ts`.
  */
-export class InvalidTransitionError extends Error {
+export class InvalidTransitionError extends ConflictError {
   constructor(
     public readonly currentStatus: CreditLineStatus,
     public readonly requestedAction: string,
   ) {
-    super(`Cannot "${requestedAction}" a credit line that is already "${currentStatus}".`);
+    super({
+      message: `Cannot "${requestedAction}" a credit line that is already "${currentStatus}".`,
+      code: 'invalid_state_transition',
+      resource: 'credit_line',
+      details: { currentStatus, requestedAction },
+    });
     this.name = 'InvalidTransitionError';
   }
 }
@@ -143,19 +150,25 @@ export class CreditLineNotFoundError extends Error {
  * {@link CreditLine.version} no longer matches the `expectedVersion` the
  * caller read. Indicates a concurrent write won the race; the caller should
  * re-read the credit line and retry with the fresh version. Mapped to HTTP
- * `409 Conflict` (error code `version_conflict`) by `routes/credit.ts`.
+ * `409 Conflict` (error code `version_conflict`) via problem+json.
+ *
+ * Note: the resource id is included for the caller that already knows it;
+ * wallet addresses and other sensitive identifiers are never included.
  */
-export class VersionConflictError extends Error {
-  public readonly code = 'version_conflict';
+export class VersionConflictError extends ConflictError {
   constructor(
     public readonly id: string,
     public readonly expectedVersion: number,
     public readonly actualVersion: number,
   ) {
-    super(
-      `Credit line "${id}" was modified concurrently ` +
+    super({
+      message:
+        `Credit line was modified concurrently ` +
         `(expected version ${expectedVersion}, found ${actualVersion}). Re-read and retry.`,
-    );
+      code: 'version_conflict',
+      resource: 'credit_line',
+      details: { expectedVersion, actualVersion },
+    });
     this.name = 'VersionConflictError';
   }
 }

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -19,6 +19,10 @@ import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
 import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
 import { redactLogArgs } from "../utils/logRedact.js";
+import { createServiceLogger } from "../utils/serviceLogger.js";
+import { duplicateResource } from "../errors/ConflictError.js";
+
+const log = createServiceLogger("DrawWebhookService");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -69,6 +73,30 @@ export interface WebhookDeliveryResult {
 // ---------------------------------------------------------------------------
 
 let activeConfig: WebhookConfig | null = null;
+
+/**
+ * Runtime webhook subscriptions (in addition to env `WEBHOOK_URLS`).
+ * Keyed by normalised URL so duplicate registration is O(1).
+ * Secrets are never stored here — signing still uses config.secret.
+ */
+const runtimeSubscriptions = new Map<string, { url: string; createdAt: string }>();
+
+/** Normalise a subscription URL for equality (trim trailing slash, lowercase host). */
+export function normaliseWebhookUrl(url: string): string {
+    const trimmed = url.trim();
+    try {
+        const parsed = new URL(trimmed);
+        parsed.hash = '';
+        // Drop default ports; keep path without trailing slash (except root).
+        let path = parsed.pathname;
+        if (path.length > 1 && path.endsWith('/')) {
+            path = path.slice(0, -1);
+        }
+        return `${parsed.protocol}//${parsed.host.toLowerCase()}${path}${parsed.search}`;
+    } catch {
+        return trimmed;
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Configuration helpers
@@ -251,7 +279,11 @@ function parseDrawConfirmedEvent(event: HorizonEvent): WebhookPayload | null {
 // ---------------------------------------------------------------------------
 
 export function getWebhookConfig(): WebhookConfig | null {
-    return activeConfig;
+    if (!activeConfig) return null;
+    // Merge env URLs with runtime subscriptions for a complete view.
+    const runtimeUrls = Array.from(runtimeSubscriptions.values()).map((s) => s.url);
+    const merged = Array.from(new Set([...activeConfig.urls, ...runtimeUrls]));
+    return { ...activeConfig, urls: merged };
 }
 
 export function initializeWebhooks(): void {
@@ -266,6 +298,58 @@ export function initializeWebhooks(): void {
         log.error("webhook:initialize:failed", { error });
         activeConfig = null;
     }
+}
+
+/**
+ * Register a runtime webhook subscription URL.
+ *
+ * @throws {ConflictError} when the URL is already registered (env or runtime).
+ * Message and details never include the full URL when it may carry secrets
+ * (query tokens); only a non-sensitive field name is exposed.
+ */
+export function registerWebhookSubscription(url: string): { url: string; createdAt: string } {
+    if (!url || typeof url !== 'string' || !url.trim()) {
+        throw new Error('Webhook URL is required');
+    }
+    const trimmed = url.trim();
+    try {
+        // Validate absolute http(s) URL without storing credentials in details.
+        const parsed = new URL(trimmed);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            throw new Error('Webhook URL must use http or https');
+        }
+    } catch (err) {
+        if (err instanceof Error && err.message.startsWith('Webhook URL')) throw err;
+        throw new Error('Webhook URL is invalid');
+    }
+
+    const key = normaliseWebhookUrl(trimmed);
+    const envUrls = activeConfig?.urls ?? [];
+    const envKeys = new Set(envUrls.map(normaliseWebhookUrl));
+
+    if (envKeys.has(key) || runtimeSubscriptions.has(key)) {
+        throw duplicateResource(
+            'webhook_subscription',
+            'A webhook subscription for this endpoint already exists.',
+            { field: 'url', reason: 'duplicate_url' },
+        );
+    }
+
+    const createdAt = new Date().toISOString();
+    const record = { url: trimmed, createdAt };
+    runtimeSubscriptions.set(key, record);
+    // Delivery reads getWebhookConfig() which merges env + runtime URLs.
+    return record;
+}
+
+/** List runtime subscriptions only (env URLs are visible via /config). */
+export function listRuntimeWebhookSubscriptions(): Array<{ url: string; createdAt: string }> {
+    return Array.from(runtimeSubscriptions.values());
+}
+
+/** Test helper: clear runtime subscriptions. */
+export function _resetRuntimeWebhookSubscriptions(): void {
+    runtimeSubscriptions.clear();
 }
 
 export async function sendDrawConfirmationWebhook(

--- a/tests/conflicts.integration.test.ts
+++ b/tests/conflicts.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration tests for consistent 409 conflict detection (issue #227).
+ *
+ * Covers representative duplicate-resource paths:
+ * - credit line open
+ * - risk evaluation create
+ * - webhook subscription
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { creditRouter } from '../src/routes/credit.js';
+import { riskRouter } from '../src/routes/risk.js';
+import { webhookRouter } from '../src/routes/webhook.js';
+import { errorHandler } from '../src/middleware/errorHandler.js';
+import { Container } from '../src/container/Container.js';
+import { InMemoryCreditLineRepository } from '../src/repositories/memory/InMemoryCreditLineRepository.js';
+import { InMemoryRiskEvaluationRepository } from '../src/repositories/memory/InMemoryRiskEvaluationRepository.js';
+import { InMemoryTransactionRepository } from '../src/repositories/memory/InMemoryTransactionRepository.js';
+import {
+  _resetRuntimeWebhookSubscriptions,
+  initializeWebhooks,
+} from '../src/services/drawWebhookService.js';
+
+const VALID_WALLET = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/credit', creditRouter);
+  app.use('/api/risk', riskRouter);
+  app.use('/api/webhooks', webhookRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('409 conflict detection (integration)', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+
+    const creditRepo = new InMemoryCreditLineRepository();
+    const riskRepo = new InMemoryRiskEvaluationRepository();
+    const txRepo = new InMemoryTransactionRepository();
+    Container.getInstance().setRepositories({
+      creditLineRepository: creditRepo,
+      riskEvaluationRepository: riskRepo,
+      transactionRepository: txRepo,
+    });
+
+    _resetRuntimeWebhookSubscriptions();
+    delete process.env.WEBHOOK_URLS;
+    delete process.env.WEBHOOK_SECRET;
+    initializeWebhooks();
+  });
+
+  afterEach(() => {
+    _resetRuntimeWebhookSubscriptions();
+  });
+
+  describe('POST /api/credit/lines — duplicate open', () => {
+    it('returns 409 problem+json when an open line already exists', async () => {
+      const app = buildApp();
+      const body = {
+        walletAddress: VALID_WALLET,
+        requestedLimit: '1000.00',
+        interestRateBps: 500,
+      };
+
+      const first = await request(app).post('/api/credit/lines').send(body);
+      expect(first.status).toBe(201);
+
+      const second = await request(app).post('/api/credit/lines').send(body);
+      expect(second.status).toBe(409);
+      expect(second.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(second.body).toMatchObject({
+        title: 'Conflict',
+        status: 409,
+        code: 'duplicate_resource',
+        resource: 'credit_line',
+        data: null,
+      });
+      expect(second.body.detail).toMatch(/open credit line already exists/i);
+      // Must not leak the wallet address in the conflict payload.
+      expect(JSON.stringify(second.body)).not.toContain(VALID_WALLET);
+      expect(second.body.error).toBe(second.body.detail);
+    });
+  });
+
+  describe('POST /api/risk/evaluations — duplicate create', () => {
+    it('returns 409 when an unexpired evaluation already exists', async () => {
+      const app = buildApp();
+      const body = { walletAddress: VALID_WALLET, forceRefresh: false };
+
+      const first = await request(app).post('/api/risk/evaluations').send(body);
+      expect(first.status).toBe(201);
+
+      const second = await request(app).post('/api/risk/evaluations').send(body);
+      expect(second.status).toBe(409);
+      expect(second.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(second.body).toMatchObject({
+        code: 'duplicate_resource',
+        resource: 'risk_evaluation',
+        status: 409,
+      });
+      expect(JSON.stringify(second.body)).not.toContain(VALID_WALLET);
+    });
+
+    it('allows create with forceRefresh when evaluation exists', async () => {
+      const app = buildApp();
+      await request(app)
+        .post('/api/risk/evaluations')
+        .send({ walletAddress: VALID_WALLET, forceRefresh: false });
+
+      const refreshed = await request(app)
+        .post('/api/risk/evaluations')
+        .send({ walletAddress: VALID_WALLET, forceRefresh: true });
+
+      expect(refreshed.status).toBe(201);
+      expect(refreshed.body.data).toBeTruthy();
+      expect(refreshed.body.error).toBeNull();
+    });
+  });
+
+  describe('POST /api/webhooks/subscriptions — duplicate URL', () => {
+    it('returns 409 problem+json for a duplicate subscription URL', async () => {
+      const app = buildApp();
+      const url = 'https://hooks.example.com/creditra';
+
+      const first = await request(app).post('/api/webhooks/subscriptions').send({ url });
+      expect(first.status).toBe(201);
+
+      const second = await request(app).post('/api/webhooks/subscriptions').send({ url });
+      expect(second.status).toBe(409);
+      expect(second.headers['content-type']).toMatch(/application\/problem\+json/);
+      expect(second.body).toMatchObject({
+        code: 'duplicate_resource',
+        resource: 'webhook_subscription',
+        status: 409,
+      });
+      // Full URL may carry tokens; conflict details only expose field name.
+      expect(second.body.details).toEqual({ field: 'url', reason: 'duplicate_url' });
+    });
+
+    it('treats trailing-slash variants as the same subscription', async () => {
+      const app = buildApp();
+      await request(app)
+        .post('/api/webhooks/subscriptions')
+        .send({ url: 'https://hooks.example.com/creditra' });
+
+      const second = await request(app)
+        .post('/api/webhooks/subscriptions')
+        .send({ url: 'https://hooks.example.com/creditra/' });
+
+      expect(second.status).toBe(409);
+      expect(second.body.code).toBe('duplicate_resource');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #227.

Standardizes conflict detection and HTTP **409** responses for duplicate resources using a shared `ConflictError` mapped to RFC 7807 **problem+json** with stable machine codes. Sensitive identifiers (wallets, secrets, raw Postgres constraint details) are never included in conflict payloads.

### Changes

- **Shared `ConflictError`** (`src/errors/`) with codes:
  - `duplicate_resource`
  - `version_conflict`
  - `invalid_state_transition`
  - `unique_constraint_violation`
- **`sendConflict` / `conflictToProblem`** → `Content-Type: application/problem+json` (plus legacy `error`/`data` fields for older clients)
- **Postgres unique violations** (`SQLSTATE 23505`) translated via `conflictFromUniqueViolation` without leaking constraint detail values
- **Duplicate paths wired:**
  - Credit line open: one non-closed line per wallet (service + Postgres check + partial unique index `006_unique_open_credit_line.sql`)
  - Risk evaluation create: `POST /api/risk/evaluations` conflicts when unexpired eval exists (unless `forceRefresh`)
  - Webhook subscription: `POST /api/webhooks/subscriptions` conflicts on duplicate URL
- **Existing 409s** (`InvalidTransitionError`, `VersionConflictError`) now extend `ConflictError` and emit problem+json
- **OpenAPI** `ConflictProblem` schema + 409 responses documented
- **Docs** updated (`docs/error-envelope.md`, `docs/API.md`)

### Tests

- Unit: ConflictError / unique mapper / problem shape
- Unit: CreditLineService + RiskEvaluationService conflict cases
- Integration: `tests/conflicts.integration.test.ts` for the three duplicate paths
- Existing credit/webhook suites adjusted for new rules

### Security

- Conflict `detail`/`details` never include wallet addresses or URL secrets
- Constraint mapper strips Postgres `detail` text that embeds key values