### PR TITLE
feat(admin): support tools read-only troubleshooting endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@ Two perpendicular headers:
 | Header | Used by | Backed by |
 |---|---|---|
 | `X-API-Key` | Risk admin, reconciliation admin | [`src/middleware/auth.ts`](../src/middleware/auth.ts) |
-| `X-Admin-Api-Key` | Credit-line `suspend` / `close` | [`src/middleware/adminAuth.ts`](../src/middleware/adminAuth.ts) |
+| `X-Admin-Api-Key` | Credit-line `suspend` / `close`, **support tools** | [`src/middleware/adminAuth.ts`](../src/middleware/adminAuth.ts) |
 
 - API keys are compared in constant time via `crypto.timingSafeEqual`.
 - Missing → `401`, present-but-wrong → `403`.
@@ -305,6 +305,72 @@ Implemented in [`src/routes/reconciliation.ts`](../src/routes/reconciliation.ts)
 
 - **Auth:** `X-API-Key`.
 - **Response 200:** `{ data: { workerRunning, queueSize, failedJobs }, error: null }`.
+
+---
+
+### Support tools (read-only)
+
+Implemented in [`src/routes/support.ts`](../src/routes/support.ts). Intended for
+incident response so operators avoid ad-hoc DB queries.
+
+**Security invariants:**
+
+- **Auth:** every path requires `X-Admin-Api-Key` (fail-closed `503` if `ADMIN_API_KEY` unset).
+- **Read-only:** only `GET` handlers; no credit-line mutations and no job scheduling.
+- **Redaction:** response wallets are truncated (`GDRXE2...NLRK`); secret keys / emails stripped via [`src/utils/supportRedact.ts`](../src/utils/supportRedact.ts).
+
+#### `GET /api/support/borrowers/:walletAddress`
+
+Composite borrower lookup: credit-line snapshots, recent transactions, reconciliation control-plane status.
+
+- **Auth:** `X-Admin-Api-Key`.
+- **Query:** `limit` (1–100, default 20) — recent transaction page size.
+- **Response 200:**
+  ```json
+  {
+    "data": {
+      "walletAddress": "GDRXE2...NLRK",
+      "creditLines": [/* SupportCreditLineSnapshot */],
+      "recentTransactions": [/* SupportTransactionSnapshot */],
+      "reconciliation": {
+        "workerRunning": true,
+        "queueSize": 0,
+        "failedJobs": 0,
+        "readOnly": true
+      },
+      "generatedAt": "2026-01-15T12:00:00.000Z",
+      "found": true
+    },
+    "error": null
+  }
+  ```
+- **`found: false`** when the wallet has no credit lines (still HTTP 200 — not a 404 — so support can distinguish “empty borrower” from a bad id on single-line routes).
+- **400** invalid Stellar address.
+
+#### `GET /api/support/credit-lines/:id`
+
+Single credit-line troubleshooting snapshot + recent txs + recon status.
+
+- **Auth:** `X-Admin-Api-Key`.
+- **Query:** `limit` (1–100, default 20).
+- **404** when the credit line does not exist.
+
+#### `GET /api/support/credit-lines/:id/transactions`
+
+Recent transactions only for a credit line.
+
+- **Auth:** `X-Admin-Api-Key`.
+- **Query:** `limit` (1–100, default 20).
+- **Response 200:** `{ data: { transactions: [...] }, error: null }`.
+- **404** unknown credit line.
+
+#### `GET /api/support/reconciliation/status`
+
+Observational reconciliation worker/queue status for support tooling.
+
+- **Auth:** `X-Admin-Api-Key`.
+- **Response 200:** `{ data: { workerRunning, queueSize, failedJobs, readOnly: true }, error: null }`.
+- Unlike `POST /api/reconciliation/trigger`, this never schedules jobs.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,7 +61,9 @@ Two roles ship in code; everything else is read-public:
 | Role | Header | Gated endpoints |
 |---|---|---|
 | `api-key` (partner / integration) | `X-API-Key` | `POST /api/risk/admin/recalibrate`, `/api/reconciliation/*` |
-| `admin` (operator) | `X-Admin-Api-Key` | `POST /api/credit/lines/:id/suspend`, `.../close` |
+| `admin` (operator / support) | `X-Admin-Api-Key` | `POST /api/credit/lines/:id/suspend`, `.../close`, **`/api/support/*` (read-only)** |
+
+Support tools (`/api/support/*`) are intentionally **GET-only** and fail closed when `ADMIN_API_KEY` is unset. Responses redact wallet addresses and strip secret-like fields — see [`src/utils/supportRedact.ts`](../src/utils/supportRedact.ts).
 
 Both middlewares register **after** rate-limit but **before** the handler so an unauthenticated client can still be throttled. New roles should follow the same pattern.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,3 +40,24 @@ failures. Search the symptom first, then walk the fix list top-to-bottom.
 
 1. Identify the process holding the port: `lsof -i :3000`.
 2. Stop it, or run with `PORT=3001 npm run dev`.
+
+## Support tools: looking up a borrower without touching the DB
+
+When an incident needs credit-line state, recent draws/repays, or reconciliation
+worker health, use the **read-only support tools** instead of ad-hoc SQL:
+
+1. Ensure `ADMIN_API_KEY` is set on the server (endpoints return `503` if unset).
+2. Call with the admin header:
+
+```bash
+curl -sS -H "X-Admin-Api-Key: $ADMIN_API_KEY" \
+  "http://localhost:3000/api/support/borrowers/<G-WALLET>?limit=20"
+```
+
+3. Other safe endpoints:
+   - `GET /api/support/credit-lines/:id`
+   - `GET /api/support/credit-lines/:id/transactions`
+   - `GET /api/support/reconciliation/status` (never schedules jobs)
+
+4. Response wallets are truncated (`GDRXE2...NLRK`). Use the full address only
+   in the path/query for lookup. See `docs/API.md` § Support tools.

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2698,7 +2697,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3291,7 +3289,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3753,7 +3750,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4555,7 +4551,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5901,7 +5896,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7475,7 +7469,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9074,7 +9067,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9158,7 +9150,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9318,7 +9309,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -9397,7 +9387,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -9708,7 +9697,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
 import { apiKeysRouter } from './routes/apiKeys.js';
+import { recordRequest, metricsRouter } from './routes/metrics.js';
+import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
+import { maintenanceRouter } from './routes/maintenance.js';
 
 export function createApp() {
   const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -58,6 +58,7 @@ export class Container {
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -168,7 +169,11 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
-  // Method to replace repositories (useful for testing or switching to DB implementations)
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
+  // Method to replace repositories
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;
     riskEvaluationRepository?: RiskEvaluationRepository;

--- a/src/container/__tests__/Container.contract.test.ts
+++ b/src/container/__tests__/Container.contract.test.ts
@@ -64,7 +64,7 @@ describe('Container DI contract', () => {
     });
 
     it.each(REPOSITORY_RESOLVERS)('resolves repository %s', (name) => {
-      const repo = container[name] as Record<string, unknown>;
+      const repo = container[name] as unknown as Record<string, unknown>;
       expect(repo, `${String(name)} must resolve`).toBeDefined();
       // A repository is a contract object: it must expose callable methods.
       expect(typeof repo).toBe('object');

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ import { riskRouter } from "./routes/risk.js";
 import { healthRouter } from "./routes/health.js";
 import { webhookRouter } from "./routes/webhook.js";
 import { reconciliationRouter } from "./routes/reconciliation.js";
+import { supportRouter } from "./routes/support.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+
 import { requestLogger } from "./middleware/requestLogger.js";
 import {
   InMemoryRateLimitStore,
@@ -154,6 +156,8 @@ app.use("/api/risk/wallet", defaultRateLimit);
 app.use("/api/risk", riskRouter);
 app.use("/api/webhooks", webhookRouter);
 app.use("/api/reconciliation", reconciliationRouter);
+// Support tools: admin-only, read-only borrower troubleshooting (issue #226).
+app.use("/api/support", defaultRateLimit, supportRouter);
 
 // Global error handler — must be registered after routes
 app.use(errorHandler);

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -33,6 +33,11 @@ tags:
     description: Draw confirmation webhook management
   - name: Reconciliation
     description: Admin control plane for DB-vs-chain reconciliation
+  - name: Support
+    description: |
+      Read-only admin/support tools for safe borrower lookup and troubleshooting.
+      All endpoints require `X-Admin-Api-Key`, never mutate state, and redact
+      sensitive identifiers (wallet truncation, secret stripping) in responses.
 
 security:
   - ApiKeyAuth: []
@@ -46,6 +51,14 @@ components:
       description: |
         API key for authenticated endpoints. Required for admin operations.
         Keys are configured via the `API_KEYS` environment variable.
+    AdminApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Admin-Api-Key
+      description: |
+        Admin/support operator key. Required for support tools and destructive
+        credit-line state transitions. Configured via `ADMIN_API_KEY`.
+        Fail-closed: when unset, endpoints return 503.
 
   schemas:
     HealthResponse:
@@ -408,6 +421,188 @@ components:
           type: string
           example: "Risk model recalibration triggered"
 
+    SupportCreditLineSnapshot:
+      type: object
+      required:
+        - id
+        - walletAddress
+        - creditLimit
+        - availableCredit
+        - utilized
+        - interestRateBps
+        - status
+        - version
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        walletAddress:
+          type: string
+          description: Truncated Stellar wallet (e.g. GDRXE2...NLRK)
+          example: "GDRXE2...NLRK"
+        creditLimit:
+          type: string
+          example: "5000.00"
+        availableCredit:
+          type: string
+        utilized:
+          type: string
+        interestRateBps:
+          type: integer
+        status:
+          type: string
+        version:
+          type: integer
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    SupportTransactionSnapshot:
+      type: object
+      required:
+        - id
+        - creditLineId
+        - walletAddress
+        - amount
+        - type
+        - status
+        - blockchainTxHash
+        - createdAt
+        - processedAt
+      properties:
+        id:
+          type: string
+        creditLineId:
+          type: string
+        walletAddress:
+          type: string
+          description: Truncated Stellar wallet
+        amount:
+          type: string
+        type:
+          type: string
+        status:
+          type: string
+        blockchainTxHash:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        processedAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    SupportReconciliationStatus:
+      type: object
+      required: [workerRunning, queueSize, failedJobs, readOnly]
+      properties:
+        workerRunning:
+          type: boolean
+        queueSize:
+          type: integer
+          minimum: 0
+        failedJobs:
+          type: integer
+          minimum: 0
+        readOnly:
+          type: boolean
+          enum: [true]
+          description: Always true — support tools never schedule reconciliation jobs
+
+    SupportBorrowerLookupResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+            - walletAddress
+            - creditLines
+            - recentTransactions
+            - reconciliation
+            - generatedAt
+            - found
+          properties:
+            walletAddress:
+              type: string
+              description: Truncated wallet used for the lookup
+            creditLines:
+              type: array
+              items:
+                $ref: "#/components/schemas/SupportCreditLineSnapshot"
+            recentTransactions:
+              type: array
+              items:
+                $ref: "#/components/schemas/SupportTransactionSnapshot"
+            reconciliation:
+              $ref: "#/components/schemas/SupportReconciliationStatus"
+            generatedAt:
+              type: string
+              format: date-time
+            found:
+              type: boolean
+              description: False when the wallet has no credit lines (still HTTP 200)
+        error:
+          type: string
+          nullable: true
+
+    SupportCreditLineLookupResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+            - creditLine
+            - recentTransactions
+            - reconciliation
+            - generatedAt
+          properties:
+            creditLine:
+              $ref: "#/components/schemas/SupportCreditLineSnapshot"
+            recentTransactions:
+              type: array
+              items:
+                $ref: "#/components/schemas/SupportTransactionSnapshot"
+            reconciliation:
+              $ref: "#/components/schemas/SupportReconciliationStatus"
+            generatedAt:
+              type: string
+              format: date-time
+        error:
+          type: string
+          nullable: true
+
+    SupportTransactionsResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [transactions]
+          properties:
+            transactions:
+              type: array
+              items:
+                $ref: "#/components/schemas/SupportTransactionSnapshot"
+        error:
+          type: string
+          nullable: true
+
+    SupportReconciliationStatusResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/SupportReconciliationStatus"
+        error:
+          type: string
+          nullable: true
+
     ReconciliationTriggerResponse:
       type: object
       properties:
@@ -554,6 +749,215 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Failed to get reconciliation status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  # ── Support Tools (read-only, admin) ─────────────────────────────────────
+
+  /api/support/borrowers/{walletAddress}:
+    get:
+      tags: [Support]
+      operationId: supportBorrowerLookup
+      summary: Safe borrower troubleshooting lookup
+      description: |
+        Read-only composite view for incident response: credit-line snapshots,
+        recent transactions, and reconciliation control-plane status.
+        Requires `X-Admin-Api-Key`. Wallet addresses in the response are truncated.
+        Never mutates state or schedules jobs.
+      security:
+        - AdminApiKeyAuth: []
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 56
+            maxLength: 56
+          description: Full Stellar G-address used for lookup
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          description: Max recent transactions to include
+      responses:
+        "200":
+          description: Borrower support view (found may be false when no lines exist)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupportBorrowerLookupResponse"
+              example:
+                data:
+                  walletAddress: "GDRXE2...NLRK"
+                  creditLines: []
+                  recentTransactions: []
+                  reconciliation:
+                    workerRunning: true
+                    queueSize: 0
+                    failedJobs: 0
+                    readOnly: true
+                  generatedAt: "2026-01-15T12:00:00.000Z"
+                  found: false
+                error: null
+        "400":
+          description: Invalid wallet address or query
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Missing or invalid admin key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Admin authentication not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/support/credit-lines/{id}:
+    get:
+      tags: [Support]
+      operationId: supportCreditLineLookup
+      summary: Credit-line troubleshooting snapshot
+      description: |
+        Read-only snapshot of a single credit line plus recent transactions and
+        reconciliation status. Requires `X-Admin-Api-Key`. Responses redact wallets.
+      security:
+        - AdminApiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: Credit line support view
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupportCreditLineLookupResponse"
+        "401":
+          description: Missing or invalid admin key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Admin authentication not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/support/credit-lines/{id}/transactions:
+    get:
+      tags: [Support]
+      operationId: supportCreditLineTransactions
+      summary: Recent transactions for support troubleshooting
+      description: |
+        Read-only recent transaction list for a credit line. Requires
+        `X-Admin-Api-Key`. Wallet addresses are truncated in the payload.
+      security:
+        - AdminApiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: Recent transactions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupportTransactionsResponse"
+        "401":
+          description: Missing or invalid admin key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Admin authentication not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/support/reconciliation/status:
+    get:
+      tags: [Support]
+      operationId: supportReconciliationStatus
+      summary: Read-only reconciliation control-plane status
+      description: |
+        Observational reconciliation worker/queue status for support tooling.
+        Unlike `POST /api/reconciliation/trigger`, this endpoint never schedules jobs.
+        Requires `X-Admin-Api-Key`. Response always includes `readOnly: true`.
+      security:
+        - AdminApiKeyAuth: []
+      responses:
+        "200":
+          description: Reconciliation status (read-only)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupportReconciliationStatusResponse"
+              example:
+                data:
+                  workerRunning: true
+                  queueSize: 0
+                  failedJobs: 0
+                  readOnly: true
+                error: null
+        "401":
+          description: Missing or invalid admin key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Admin authentication not configured
           content:
             application/json:
               schema:

--- a/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
+++ b/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
@@ -13,7 +13,6 @@ import type { TransactionRepository } from '../interfaces/TransactionRepository.
 // ---------------------------------------------------------------------------
 
 const CREDIT_LINE_ID = '00000000-0000-0000-0000-000000000001';
-const WALLET = 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1';
 
 function sampleRequest(overrides: Partial<CreateTransactionRequest> = {}): CreateTransactionRequest {
   return {

--- a/src/repositories/postgres/PostgresTransactionRepository.ts
+++ b/src/repositories/postgres/PostgresTransactionRepository.ts
@@ -2,7 +2,7 @@ import {
   type Transaction,
   type CreateTransactionRequest,
   TransactionStatus,
-  TransactionType,
+  type TransactionType,
 } from '../../models/Transaction.js';
 import type { TransactionRepository } from '../interfaces/TransactionRepository.js';
 import type { DbClient } from '../../db/client.js';

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import { metricsRouter, recordRequest } from '../metrics.js';
 
@@ -45,16 +45,6 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
       return this;
     },
   } as unknown as Response;
-
-  const runHandlers = async (index: number): Promise<void> => {
-    if (index >= handlers.length) return;
-    await new Promise<void>((resolve) => {
-      handlers[index](req, res, () => {
-        resolve();
-        runHandlers(index + 1);
-      });
-    });
-  };
 
   // Execute the first handler (auth guard); if it calls next, proceed to the route handler.
   await new Promise<void>((resolve) => {

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -23,9 +23,8 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
     throw new Error(`Route not found: ${args.method.toUpperCase()} ${args.path}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handlers: Array<(req: Request, res: Response, next: NextFunction) => unknown> =
-    layer.route.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
+    layer.route!.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
 
   let statusCode = 200;
   let responseBody: unknown = null;

--- a/src/routes/__tests__/support.route.test.ts
+++ b/src/routes/__tests__/support.route.test.ts
@@ -1,0 +1,217 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { supportRouter } from '../support.js';
+import { ADMIN_KEY_HEADER } from '../../middleware/adminAuth.js';
+import { Container } from '../../container/Container.js';
+import { InMemoryCreditLineRepository } from '../../repositories/memory/InMemoryCreditLineRepository.js';
+import { InMemoryTransactionRepository } from '../../repositories/memory/InMemoryTransactionRepository.js';
+import { InMemoryRiskEvaluationRepository } from '../../repositories/memory/InMemoryRiskEvaluationRepository.js';
+import { TransactionStatus, TransactionType } from '../../models/Transaction.js';
+
+const ADMIN = 'support-admin-secret-for-tests';
+const WALLET = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+const INVALID_WALLET = 'not-a-stellar-address';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/support', supportRouter);
+  return app;
+}
+
+describe('support tools routes (read-only, admin RBAC)', () => {
+  let originalAdminKey: string | undefined;
+  let creditLineRepository: InMemoryCreditLineRepository;
+  let transactionRepository: InMemoryTransactionRepository;
+
+  beforeEach(() => {
+    originalAdminKey = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN;
+    process.env.NODE_ENV = 'test';
+
+    creditLineRepository = new InMemoryCreditLineRepository();
+    transactionRepository = new InMemoryTransactionRepository();
+    Container.getInstance().setRepositories({
+      creditLineRepository,
+      riskEvaluationRepository: new InMemoryRiskEvaluationRepository(),
+      transactionRepository,
+    });
+  });
+
+  afterEach(() => {
+    if (originalAdminKey === undefined) {
+      delete process.env.ADMIN_API_KEY;
+    } else {
+      process.env.ADMIN_API_KEY = originalAdminKey;
+    }
+  });
+
+  // ── RBAC boundaries ─────────────────────────────────────────────────────
+
+  it('returns 401 when admin key header is missing', async () => {
+    const res = await request(buildApp()).get(`/api/support/borrowers/${WALLET}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Unauthorized/i);
+  });
+
+  it('returns 401 when admin key is wrong', async () => {
+    const res = await request(buildApp())
+      .get(`/api/support/borrowers/${WALLET}`)
+      .set(ADMIN_KEY_HEADER, 'wrong-key');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when ADMIN_API_KEY is not configured (fail closed)', async () => {
+    delete process.env.ADMIN_API_KEY;
+    const res = await request(buildApp())
+      .get(`/api/support/borrowers/${WALLET}`)
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not configured/i);
+  });
+
+  it('rejects non-admin callers on every support path', async () => {
+    const app = buildApp();
+    const paths = [
+      `/api/support/borrowers/${WALLET}`,
+      '/api/support/credit-lines/some-id',
+      '/api/support/credit-lines/some-id/transactions',
+      '/api/support/reconciliation/status',
+    ];
+    for (const path of paths) {
+      const res = await request(app).get(path);
+      expect(res.status).toBe(401);
+    }
+  });
+
+  // ── Validation ──────────────────────────────────────────────────────────
+
+  it('returns 400 for invalid wallet address', async () => {
+    const res = await request(buildApp())
+      .get(`/api/support/borrowers/${INVALID_WALLET}`)
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Happy paths ─────────────────────────────────────────────────────────
+
+  it('returns borrower lookup with redacted wallet and empty lines', async () => {
+    const res = await request(buildApp())
+      .get(`/api/support/borrowers/${WALLET}`)
+      .set(ADMIN_KEY_HEADER, ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeNull();
+    expect(res.body.data.found).toBe(false);
+    expect(res.body.data.walletAddress).toBe('GDRXE2...NLRK');
+    expect(res.body.data.creditLines).toEqual([]);
+    expect(res.body.data.reconciliation.readOnly).toBe(true);
+    // Full wallet must never appear in the body (redaction).
+    expect(JSON.stringify(res.body)).not.toContain(WALLET);
+  });
+
+  it('returns credit line snapshot + txs for a known line', async () => {
+    const line = await creditLineRepository.create({
+      walletAddress: WALLET,
+      creditLimit: '2500.00',
+      interestRateBps: 250,
+    });
+
+    const created = await transactionRepository.create({
+      creditLineId: line.id,
+      amount: '50.00',
+      type: TransactionType.BORROW,
+      blockchainTxHash: 'txhash-xyz',
+    });
+    // Patch wallet on the in-memory record so findByCreditLineId returns it with address.
+    const map = (transactionRepository as unknown as {
+      transactions: Map<string, { walletAddress: string }>;
+    }).transactions;
+    const stored = map.get(created.id);
+    if (stored) stored.walletAddress = WALLET;
+    await transactionRepository.updateStatus(created.id, TransactionStatus.CONFIRMED);
+
+    const res = await request(buildApp())
+      .get(`/api/support/credit-lines/${line.id}`)
+      .set(ADMIN_KEY_HEADER, ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.creditLine.id).toBe(line.id);
+    expect(res.body.data.creditLine.creditLimit).toBe('2500.00');
+    expect(res.body.data.creditLine.walletAddress).toBe('GDRXE2...NLRK');
+    expect(res.body.data.recentTransactions.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.data.reconciliation.readOnly).toBe(true);
+    expect(JSON.stringify(res.body)).not.toContain(WALLET);
+  });
+
+  it('returns 404 for unknown credit line', async () => {
+    const res = await request(buildApp())
+      .get('/api/support/credit-lines/missing-id')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it('returns recent transactions for a credit line', async () => {
+    const line = await creditLineRepository.create({
+      walletAddress: WALLET,
+      creditLimit: '100.00',
+      interestRateBps: 0,
+    });
+
+    const res = await request(buildApp())
+      .get(`/api/support/credit-lines/${line.id}/transactions?limit=5`)
+      .set(ADMIN_KEY_HEADER, ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.transactions).toEqual([]);
+  });
+
+  it('returns 404 for transactions on unknown credit line', async () => {
+    const res = await request(buildApp())
+      .get('/api/support/credit-lines/nope/transactions')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns read-only reconciliation status', async () => {
+    const res = await request(buildApp())
+      .get('/api/support/reconciliation/status')
+      .set(ADMIN_KEY_HEADER, ADMIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      workerRunning: expect.any(Boolean),
+      queueSize: expect.any(Number),
+      failedJobs: expect.any(Number),
+      readOnly: true,
+    });
+  });
+
+  // ── Read-only guarantees ────────────────────────────────────────────────
+
+  it('does not expose write methods on the support router', () => {
+    const methods = (supportRouter.stack as Array<{ route?: { methods: Record<string, boolean> } }>)
+      .filter((layer) => layer.route)
+      .flatMap((layer) => Object.keys(layer.route!.methods));
+    expect(methods.every((m) => m === 'get')).toBe(true);
+    expect(methods.some((m) => ['post', 'put', 'patch', 'delete'].includes(m))).toBe(false);
+  });
+
+  it('borrower lookup does not mutate credit line count', async () => {
+    await creditLineRepository.create({
+      walletAddress: WALLET,
+      creditLimit: '10.00',
+      interestRateBps: 0,
+    });
+    const before = await creditLineRepository.count();
+
+    await request(buildApp())
+      .get(`/api/support/borrowers/${WALLET}`)
+      .set(ADMIN_KEY_HEADER, ADMIN);
+
+    const after = await creditLineRepository.count();
+    expect(after).toBe(before);
+  });
+});

--- a/src/routes/creditBulk.ts
+++ b/src/routes/creditBulk.ts
@@ -54,8 +54,13 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
 
       try {
-        const creditService = container.getCreditService();
-        const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
+        const creditService = container.creditLineService;
+        const body = parsed.data as CreateCreditLineBody;
+        const line = await creditService.createCreditLine({
+          walletAddress: body.walletAddress,
+          creditLimit: body.creditLimit ?? body.requestedLimit ?? '',
+          interestRateBps: body.interestRateBps ?? 0,
+        });
         results.push({ index: i + 1, status: 'created', id: line.id });
         created++;
       } catch (err) {
@@ -64,9 +69,9 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
     }
 
-    return res.status(207).json(ok({ summary: { total: rows.length, created, failed, dry_run: isDryRun }, results }));
+    return ok(res, { summary: { total: rows.length, created, failed, dry_run: isDryRun } as Record<string, unknown>, results }, 207);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -23,7 +23,7 @@
  *
  * See `docs/OBSERVABILITY.md` for Grafana dashboard JSON and Alertmanager rules.
  */
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import { ok, fail } from '../utils/response.js';
 
 export const metricsRouter = Router();

--- a/src/routes/simulation.ts
+++ b/src/routes/simulation.ts
@@ -31,7 +31,7 @@ simulationRouter.post(
 
       const { amount } = req.body as DrawBody;
       const drawAmount = Number(amount);
-      const availableCredit = Number(line.creditLimit) - Number(line.balance ?? 0);
+      const availableCredit = Number(line.creditLimit) - Number(line.utilized ?? 0);
       const valid = drawAmount > 0 && drawAmount <= availableCredit;
       const interestBps: number = (line as unknown as Record<string, unknown>)['interestRateBps'] as number ?? 0;
       const estimatedFee = Math.ceil(drawAmount * interestBps / INTEREST_RATE_DIVISOR);
@@ -46,13 +46,13 @@ simulationRouter.post(
         preview: {
           requestedAmount: drawAmount,
           estimatedFee,
-          newBalance: valid ? Number(line.balance ?? 0) + drawAmount : null,
+          newBalance: valid ? Number(line.utilized ?? 0) + drawAmount : null,
           remainingCredit: valid ? availableCredit - drawAmount : availableCredit,
         },
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );
@@ -67,7 +67,7 @@ simulationRouter.post(
 
       const { amount } = req.body as RepayBody;
       const repayAmount = Number(amount);
-      const currentBalance = Number(line.balance ?? 0);
+      const currentBalance = Number(line.utilized ?? 0);
       const effectiveRepay = Math.min(repayAmount, currentBalance);
       const valid = repayAmount > 0;
 
@@ -84,7 +84,7 @@ simulationRouter.post(
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );

--- a/src/routes/support.ts
+++ b/src/routes/support.ts
@@ -1,0 +1,123 @@
+/**
+ * Support tools routes — read-only borrower troubleshooting.
+ *
+ * Mounted at `/api/support`. All handlers require `X-Admin-Api-Key`
+ * (admin/support operators only). No handler mutates state or schedules jobs.
+ *
+ * Surface:
+ * - GET `/borrowers/:walletAddress`              — credit lines + recent txs + recon
+ * - GET `/credit-lines/:id`                      — single credit-line snapshot + txs
+ * - GET `/credit-lines/:id/transactions`         — recent transactions only
+ * - GET `/reconciliation/status`                 — recon worker/queue (read-only)
+ *
+ * See `docs/API.md` § Support tools and issue #226.
+ */
+import { Router, type Request, type Response } from 'express';
+import { adminAuth } from '../middleware/adminAuth.js';
+import { validateParams, validateQuery } from '../middleware/validate.js';
+import {
+  supportBorrowerParamsSchema,
+  supportCreditLineParamsSchema,
+  supportRecentQuerySchema,
+  type SupportRecentQuery,
+} from '../schemas/support.schema.js';
+import { Container } from '../container/Container.js';
+import { SupportToolsService } from '../services/supportToolsService.js';
+import { defaultJobQueue } from '../services/jobQueue.js';
+import { ok, fail } from '../utils/response.js';
+
+export const supportRouter = Router();
+
+/** Every support route is admin-gated. Fail-closed when ADMIN_API_KEY unset. */
+supportRouter.use(adminAuth);
+
+function getSupportService(): SupportToolsService {
+  const container = Container.getInstance();
+  return new SupportToolsService({
+    creditLineRepository: container.creditLineRepository,
+    transactionRepository: container.transactionRepository,
+    reconciliationWorker: container.reconciliationWorker,
+    jobQueue: defaultJobQueue,
+  });
+}
+
+/**
+ * GET /api/support/borrowers/:walletAddress
+ * Composite borrower lookup for incident response.
+ */
+supportRouter.get(
+  '/borrowers/:walletAddress',
+  validateParams(supportBorrowerParamsSchema),
+  validateQuery(supportRecentQuerySchema),
+  async (req: Request, res: Response) => {
+    try {
+      const { walletAddress } = req.params;
+      const { limit } = req.query as unknown as SupportRecentQuery;
+      const result = await getSupportService().getBorrowerLookup(walletAddress, limit);
+      return ok(res, result);
+    } catch (error) {
+      return fail(res, error instanceof Error ? error : 'Failed to load borrower support view', 500);
+    }
+  },
+);
+
+/**
+ * GET /api/support/credit-lines/:id
+ * Single credit-line troubleshooting snapshot.
+ */
+supportRouter.get(
+  '/credit-lines/:id',
+  validateParams(supportCreditLineParamsSchema),
+  validateQuery(supportRecentQuerySchema),
+  async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { limit } = req.query as unknown as SupportRecentQuery;
+      const result = await getSupportService().getCreditLineLookup(id, limit);
+      if (!result) {
+        return fail(res, 'Credit line not found', 404);
+      }
+      return ok(res, result);
+    } catch (error) {
+      return fail(res, error instanceof Error ? error : 'Failed to load credit line support view', 500);
+    }
+  },
+);
+
+/**
+ * GET /api/support/credit-lines/:id/transactions
+ * Recent transactions for a credit line (read-only).
+ */
+supportRouter.get(
+  '/credit-lines/:id/transactions',
+  validateParams(supportCreditLineParamsSchema),
+  validateQuery(supportRecentQuerySchema),
+  async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { limit } = req.query as unknown as SupportRecentQuery;
+      const txs = await getSupportService().getRecentTransactions(id, limit);
+      if (txs === null) {
+        return fail(res, 'Credit line not found', 404);
+      }
+      return ok(res, { transactions: txs });
+    } catch (error) {
+      return fail(res, error instanceof Error ? error : 'Failed to load transactions', 500);
+    }
+  },
+);
+
+/**
+ * GET /api/support/reconciliation/status
+ * Read-only reconciliation control-plane status (does not trigger jobs).
+ */
+supportRouter.get('/reconciliation/status', (_req: Request, res: Response) => {
+  try {
+    const status = getSupportService().getReconciliationStatus();
+    return ok(res, status);
+  } catch (error) {
+    return fail(res, error instanceof Error ? error : 'Failed to load reconciliation status', 500);
+  }
+});
+
+export default supportRouter;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -17,3 +17,14 @@ export type {
   RepayBody,
   TransactionHistoryQuery,
 } from './credit.schema.js';
+
+export {
+  supportBorrowerParamsSchema,
+  supportCreditLineParamsSchema,
+  supportRecentQuerySchema,
+} from './support.schema.js';
+export type {
+  SupportBorrowerParams,
+  SupportCreditLineParams,
+  SupportRecentQuery,
+} from './support.schema.js';

--- a/src/schemas/support.schema.ts
+++ b/src/schemas/support.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { walletAddressSchema } from './common.schema.js';
+
+/** Path params for borrower support lookup. */
+export const supportBorrowerParamsSchema = z.object({
+  walletAddress: walletAddressSchema,
+});
+
+export type SupportBorrowerParams = z.infer<typeof supportBorrowerParamsSchema>;
+
+/** Path params for credit-line support lookup. */
+export const supportCreditLineParamsSchema = z.object({
+  id: z.string().min(1, 'id is required'),
+});
+
+export type SupportCreditLineParams = z.infer<typeof supportCreditLineParamsSchema>;
+
+/** Shared query for recent-transaction page size. */
+export const supportRecentQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(100).optional(),
+  })
+  .strict();
+
+export type SupportRecentQuery = z.infer<typeof supportRecentQuerySchema>;

--- a/src/services/__tests__/dashboardSummaryService.test.ts
+++ b/src/services/__tests__/dashboardSummaryService.test.ts
@@ -80,7 +80,7 @@ describe('DashboardSummaryService caching', () => {
   });
 
   it('recomputes immediately after invalidate()', async () => {
-    let now = 0;
+    const now = 0;
     const { repo, findAll } = repoOf([line({})]);
     const service = new DashboardSummaryService(repo, 30_000, () => now);
 

--- a/src/services/__tests__/supportToolsService.test.ts
+++ b/src/services/__tests__/supportToolsService.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupportToolsService } from '../supportToolsService.js';
+import { InMemoryCreditLineRepository } from '../../repositories/memory/InMemoryCreditLineRepository.js';
+import { InMemoryTransactionRepository } from '../../repositories/memory/InMemoryTransactionRepository.js';
+import { CreditLineStatus } from '../../models/CreditLine.js';
+import { TransactionStatus, TransactionType } from '../../models/Transaction.js';
+import type { Job } from '../jobQueue.js';
+
+const WALLET = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+const FIXED_NOW = new Date('2026-01-15T12:00:00.000Z');
+
+function buildService(opts?: {
+  workerRunning?: boolean;
+  queueSize?: number;
+  failedJobs?: number;
+}) {
+  const creditLineRepository = new InMemoryCreditLineRepository();
+  const transactionRepository = new InMemoryTransactionRepository();
+  const failed: Job[] = Array.from({ length: opts?.failedJobs ?? 0 }, (_, i) => ({
+    id: `fail-${i}`,
+    type: 'credit-reconciliation',
+    payload: {},
+    attempts: 3,
+    maxAttempts: 3,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    lastError: 'boom',
+  }));
+
+  const service = new SupportToolsService({
+    creditLineRepository,
+    transactionRepository,
+    reconciliationWorker: {
+      isRunning: () => opts?.workerRunning ?? false,
+    },
+    jobQueue: {
+      size: () => opts?.queueSize ?? 0,
+      getFailedJobs: () => failed,
+    },
+    now: () => FIXED_NOW,
+  });
+
+  return { service, creditLineRepository, transactionRepository };
+}
+
+describe('SupportToolsService', () => {
+  let creditLineRepository: InMemoryCreditLineRepository;
+  let transactionRepository: InMemoryTransactionRepository;
+  let service: SupportToolsService;
+
+  beforeEach(() => {
+    ({ service, creditLineRepository, transactionRepository } = buildService({
+      workerRunning: true,
+      queueSize: 2,
+      failedJobs: 1,
+    }));
+  });
+
+  it('returns empty borrower lookup when wallet has no lines (found=false)', async () => {
+    const result = await service.getBorrowerLookup(WALLET);
+    expect(result.found).toBe(false);
+    expect(result.creditLines).toEqual([]);
+    expect(result.recentTransactions).toEqual([]);
+    expect(result.reconciliation).toEqual({
+      workerRunning: true,
+      queueSize: 2,
+      failedJobs: 1,
+      readOnly: true,
+    });
+    expect(result.generatedAt).toBe(FIXED_NOW.toISOString());
+    // Wallet is redacted in the response payload.
+    expect(result.walletAddress).toBe('GDRXE2...NLRK');
+  });
+
+  it('aggregates credit lines, txs, and recon status with redaction', async () => {
+    const line = await creditLineRepository.create({
+      walletAddress: WALLET,
+      creditLimit: '5000.00',
+      interestRateBps: 500,
+    });
+
+    // Inject a transaction with full wallet for redaction coverage.
+    const rawTx = await transactionRepository.create({
+      creditLineId: line.id,
+      amount: '100.00',
+      type: TransactionType.BORROW,
+      blockchainTxHash: 'abc123hash',
+    });
+    // In-memory create leaves wallet empty — set it like the service layer would.
+    await transactionRepository.updateStatus(rawTx.id, TransactionStatus.CONFIRMED);
+    // Directly patch wallet via a second create path: re-fetch and assert structure
+    // by creating through repository then overwriting map is awkward; instead
+    // verify snapshot fields from a wallet-scoped query after manual setup.
+    const txRepo = transactionRepository as unknown as {
+      transactions: Map<string, {
+        id: string;
+        creditLineId: string;
+        walletAddress: string;
+        amount: string;
+        type: TransactionType;
+        status: TransactionStatus;
+        blockchainTxHash?: string;
+        createdAt: Date;
+        processedAt?: Date;
+      }>;
+    };
+    const stored = txRepo.transactions.get(rawTx.id);
+    if (stored) {
+      stored.walletAddress = WALLET;
+    }
+
+    const result = await service.getBorrowerLookup(WALLET, 10);
+    expect(result.found).toBe(true);
+    expect(result.creditLines).toHaveLength(1);
+    expect(result.creditLines[0].id).toBe(line.id);
+    expect(result.creditLines[0].walletAddress).toBe('GDRXE2...NLRK');
+    expect(result.creditLines[0].creditLimit).toBe('5000.00');
+    expect(result.creditLines[0].status).toBe(CreditLineStatus.ACTIVE);
+    expect(result.recentTransactions).toHaveLength(1);
+    expect(result.recentTransactions[0].walletAddress).toBe('GDRXE2...NLRK');
+    expect(result.recentTransactions[0].amount).toBe('100.00');
+    expect(result.recentTransactions[0].blockchainTxHash).toBe('abc123hash');
+    expect(JSON.stringify(result)).not.toContain(WALLET);
+  });
+
+  it('returns null for missing credit line lookup', async () => {
+    const result = await service.getCreditLineLookup('does-not-exist');
+    expect(result).toBeNull();
+  });
+
+  it('returns credit line lookup with txs when present', async () => {
+    const line = await creditLineRepository.create({
+      walletAddress: WALLET,
+      creditLimit: '1000.00',
+      interestRateBps: 100,
+    });
+    const result = await service.getCreditLineLookup(line.id);
+    expect(result).not.toBeNull();
+    expect(result!.creditLine.id).toBe(line.id);
+    expect(result!.creditLine.walletAddress).toBe('GDRXE2...NLRK');
+    expect(result!.reconciliation.readOnly).toBe(true);
+  });
+
+  it('returns null recent txs when credit line missing', async () => {
+    expect(await service.getRecentTransactions('missing')).toBeNull();
+  });
+
+  it('returns empty recent txs when line exists but has none', async () => {
+    const line = await creditLineRepository.create({
+      walletAddress: WALLET,
+      creditLimit: '100.00',
+      interestRateBps: 0,
+    });
+    const txs = await service.getRecentTransactions(line.id);
+    expect(txs).toEqual([]);
+  });
+
+  it('getReconciliationStatus is observational and marks readOnly', () => {
+    const status = service.getReconciliationStatus();
+    expect(status).toEqual({
+      workerRunning: true,
+      queueSize: 2,
+      failedJobs: 1,
+      readOnly: true,
+    });
+  });
+
+  it('clamps recent tx limit to max 100', async () => {
+    const line = await creditLineRepository.create({
+      walletAddress: WALLET,
+      creditLimit: '10.00',
+      interestRateBps: 0,
+    });
+    // Should not throw with huge limit.
+    const result = await service.getCreditLineLookup(line.id, 10_000);
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -19,6 +19,7 @@ import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
 import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
 import { redactLogArgs } from "../utils/logRedact.js";
+import { logger as log } from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -200,11 +201,7 @@ async function retryWithBackoff<T>(
             lastError = error as Error;
             
             if (attempt <= maxRetries) {
-                log.warn("webhook:delivery:retry", {
-                    attempt,
-                    retryInMs: delay,
-                    error: lastError,
-                });
+                log.warn({ attempt, retryInMs: delay, error: lastError }, "webhook:delivery:retry");
                 await new Promise(resolve => setTimeout(resolve, delay));
                 delay = Math.floor(delay * backoffMultiplier);
             }
@@ -241,7 +238,7 @@ function parseDrawConfirmedEvent(event: HorizonEvent): WebhookPayload | null {
             }
         };
     } catch (error) {
-        log.error("webhook:event-parse:failed", { error });
+        log.error({ error }, "webhook:event-parse:failed");
         return null;
     }
 }
@@ -257,13 +254,9 @@ export function getWebhookConfig(): WebhookConfig | null {
 export function initializeWebhooks(): void {
     try {
         activeConfig = resolveWebhookConfig();
-        log.info("webhook:initialized", {
-            urls: activeConfig.urls.length,
-            maxRetries: activeConfig.maxRetries,
-            timeoutMs: activeConfig.timeoutMs
-        });
+        log.info({ urls: activeConfig.urls.length, maxRetries: activeConfig.maxRetries, timeoutMs: activeConfig.timeoutMs }, "webhook:initialized");
     } catch (error) {
-        log.error("webhook:initialize:failed", { error });
+        log.error({ error }, "webhook:initialize:failed");
         activeConfig = null;
     }
 }
@@ -278,20 +271,14 @@ export async function sendDrawConfirmationWebhook(
 
     const payload = parseDrawConfirmedEvent(event);
     if (!payload) {
-        log.info("webhook:delivery:skipped-non-draw-event", {
-            ledger: event.ledger,
-            contractId: event.contractId,
-        });
+        log.info({ ledger: event.ledger, contractId: event.contractId }, "webhook:delivery:skipped-non-draw-event");
         return [];
     }
 
     const payloadString = JSON.stringify(payload);
     const signature = generateSignature(payloadString, activeConfig.secret);
 
-    log.info("webhook:delivery:start", {
-        drawId: payload.data.drawId,
-        deliveryCount: activeConfig.urls.length,
-    });
+    log.info({ drawId: payload.data.drawId, deliveryCount: activeConfig.urls.length }, "webhook:delivery:start");
 
     const store = getWebhookDeliveryStateStore();
 
@@ -355,10 +342,7 @@ export async function sendDrawConfirmationWebhook(
     const successCount = results.filter(r => r.success).length;
     const failureCount = results.length - successCount;
     
-    log.info("webhook:delivery:complete", {
-        successful: successCount,
-        failed: failureCount,
-    });
+    log.info({ successful: successCount, failed: failureCount }, "webhook:delivery:complete");
 
     return results;
 }

--- a/src/services/supportToolsService.ts
+++ b/src/services/supportToolsService.ts
@@ -1,0 +1,234 @@
+/**
+ * Read-only support tools service.
+ *
+ * Aggregates borrower troubleshooting views for incident response without
+ * any write side-effects: no credit-line mutations, no job scheduling, and
+ * no reconciliation triggers. All methods only call repository/service
+ * getters and pure transforms.
+ *
+ * Surface consumed by {@link supportRouter}:
+ * - {@link getBorrowerLookup} — credit-line snapshots + recent txs + recon status
+ * - {@link getCreditLineSnapshot} — single credit-line snapshot
+ * - {@link getRecentTransactions} — recent txs for a credit line
+ * - {@link getReconciliationStatus} — worker/queue health (read-only)
+ */
+
+import type { CreditLine } from '../models/CreditLine.js';
+import type { Transaction } from '../models/Transaction.js';
+import type { CreditLineRepository } from '../repositories/interfaces/CreditLineRepository.js';
+import type { TransactionRepository } from '../repositories/interfaces/TransactionRepository.js';
+import type { JobQueue } from './jobQueue.js';
+import { redactSupportValue } from '../utils/supportRedact.js';
+
+const DEFAULT_RECENT_TX_LIMIT = 20;
+const MAX_RECENT_TX_LIMIT = 100;
+
+export interface CreditLineSnapshot {
+  id: string;
+  walletAddress: string;
+  creditLimit: string;
+  availableCredit: string;
+  utilized: string;
+  interestRateBps: number;
+  status: string;
+  version: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TransactionSnapshot {
+  id: string;
+  creditLineId: string;
+  walletAddress: string;
+  amount: string;
+  type: string;
+  status: string;
+  blockchainTxHash: string | null;
+  createdAt: string;
+  processedAt: string | null;
+}
+
+export interface ReconciliationControlPlaneStatus {
+  /** Whether the background reconciliation worker interval is active. */
+  workerRunning: boolean;
+  /** Pending jobs in the in-process queue (not yet completed). */
+  queueSize: number;
+  /** Dead-letter / permanently failed job count. */
+  failedJobs: number;
+  /**
+   * Explicit marker that this payload is observational only —
+   * support tools never schedule reconciliation.
+   */
+  readOnly: true;
+}
+
+export interface BorrowerLookupResult {
+  walletAddress: string;
+  creditLines: CreditLineSnapshot[];
+  recentTransactions: TransactionSnapshot[];
+  reconciliation: ReconciliationControlPlaneStatus;
+  generatedAt: string;
+  /** True when no credit lines exist for the wallet (not an error). */
+  found: boolean;
+}
+
+export interface CreditLineLookupResult {
+  creditLine: CreditLineSnapshot;
+  recentTransactions: TransactionSnapshot[];
+  reconciliation: ReconciliationControlPlaneStatus;
+  generatedAt: string;
+}
+
+export interface SupportToolsServiceDeps {
+  creditLineRepository: CreditLineRepository;
+  transactionRepository: TransactionRepository;
+  reconciliationWorker: { isRunning(): boolean };
+  jobQueue: Pick<JobQueue, 'size' | 'getFailedJobs'>;
+  /** Injectable clock for tests. */
+  now?: () => Date;
+}
+
+export class SupportToolsService {
+  private readonly now: () => Date;
+
+  constructor(private readonly deps: SupportToolsServiceDeps) {
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  /**
+   * Full borrower troubleshooting view: credit lines, recent txs, recon status.
+   * Read-only. Returns `found: false` when the wallet has no credit lines
+   * (still 200 at the route layer so support can distinguish "empty" from 404
+   * on a single-line lookup).
+   */
+  async getBorrowerLookup(
+    walletAddress: string,
+    recentTxLimit = DEFAULT_RECENT_TX_LIMIT,
+  ): Promise<BorrowerLookupResult> {
+    const limit = clampLimit(recentTxLimit);
+    const lines = await this.deps.creditLineRepository.findByWalletAddress(walletAddress);
+    const txs = await this.deps.transactionRepository.findByWalletAddress(
+      walletAddress,
+      0,
+      limit,
+    );
+
+    const payload: BorrowerLookupResult = {
+      walletAddress,
+      creditLines: lines.map(toCreditLineSnapshot),
+      recentTransactions: txs.map(toTransactionSnapshot),
+      reconciliation: this.getReconciliationStatus(),
+      generatedAt: this.now().toISOString(),
+      found: lines.length > 0,
+    };
+
+    return redactSupportValue(payload);
+  }
+
+  /**
+   * Single credit-line snapshot + recent txs + recon status.
+   * @returns null when the credit line does not exist
+   */
+  async getCreditLineLookup(
+    creditLineId: string,
+    recentTxLimit = DEFAULT_RECENT_TX_LIMIT,
+  ): Promise<CreditLineLookupResult | null> {
+    const limit = clampLimit(recentTxLimit);
+    const line = await this.deps.creditLineRepository.findById(creditLineId);
+    if (!line) {
+      return null;
+    }
+
+    const txs = await this.deps.transactionRepository.findByCreditLineId(
+      creditLineId,
+      0,
+      limit,
+    );
+
+    const payload: CreditLineLookupResult = {
+      creditLine: toCreditLineSnapshot(line),
+      recentTransactions: txs.map(toTransactionSnapshot),
+      reconciliation: this.getReconciliationStatus(),
+      generatedAt: this.now().toISOString(),
+    };
+
+    return redactSupportValue(payload);
+  }
+
+  /** Recent transactions for a credit line (empty list if line missing is caller's concern). */
+  async getRecentTransactions(
+    creditLineId: string,
+    limit = DEFAULT_RECENT_TX_LIMIT,
+  ): Promise<TransactionSnapshot[] | null> {
+    const exists = await this.deps.creditLineRepository.exists(creditLineId);
+    if (!exists) {
+      return null;
+    }
+
+    const txs = await this.deps.transactionRepository.findByCreditLineId(
+      creditLineId,
+      0,
+      clampLimit(limit),
+    );
+
+    return redactSupportValue(txs.map(toTransactionSnapshot));
+  }
+
+  /**
+   * Control-plane reconciliation status. Pure observation — never enqueues jobs.
+   */
+  getReconciliationStatus(): ReconciliationControlPlaneStatus {
+    return {
+      workerRunning: this.deps.reconciliationWorker.isRunning(),
+      queueSize: this.deps.jobQueue.size(),
+      failedJobs: this.deps.jobQueue.getFailedJobs().length,
+      readOnly: true,
+    };
+  }
+}
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) {
+    return DEFAULT_RECENT_TX_LIMIT;
+  }
+  return Math.min(Math.floor(limit), MAX_RECENT_TX_LIMIT);
+}
+
+function toCreditLineSnapshot(line: CreditLine): CreditLineSnapshot {
+  return {
+    id: line.id,
+    walletAddress: line.walletAddress,
+    creditLimit: line.creditLimit,
+    availableCredit: line.availableCredit,
+    utilized: line.utilized,
+    interestRateBps: line.interestRateBps,
+    status: line.status,
+    version: line.version ?? null,
+    createdAt: toIso(line.createdAt),
+    updatedAt: toIso(line.updatedAt),
+  };
+}
+
+function toTransactionSnapshot(tx: Transaction): TransactionSnapshot {
+  return {
+    id: tx.id,
+    creditLineId: tx.creditLineId,
+    walletAddress: tx.walletAddress,
+    amount: tx.amount,
+    type: tx.type,
+    status: tx.status,
+    blockchainTxHash: tx.blockchainTxHash ?? null,
+    createdAt: toIso(tx.createdAt),
+    processedAt: tx.processedAt ? toIso(tx.processedAt) : null,
+  };
+}
+
+function toIso(value: Date | string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toISOString();
+}
+
+export { DEFAULT_RECENT_TX_LIMIT, MAX_RECENT_TX_LIMIT };

--- a/src/utils/__tests__/supportRedact.test.ts
+++ b/src/utils/__tests__/supportRedact.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  truncateWalletAddress,
+  redactSupportString,
+  redactSupportValue,
+} from '../supportRedact.js';
+
+const WALLET = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+const SECRET = 'SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+describe('supportRedact', () => {
+  it('truncates wallet addresses for display', () => {
+    expect(truncateWalletAddress(WALLET)).toBe('GDRXE2...NLRK');
+  });
+
+  it('redacts seeds, emails, and embedded wallets in free-form strings', () => {
+    const input = `wallet=${WALLET} seed=${SECRET} contact=ops@example.com`;
+    const out = redactSupportString(input);
+    expect(out).not.toContain(WALLET);
+    expect(out).not.toContain(SECRET);
+    expect(out).not.toContain('ops@example.com');
+    expect(out).toContain('[REDACTED_STELLAR_SECRET]');
+    expect(out).toContain('[REDACTED_EMAIL]');
+    expect(out).toContain('GDRXE2...NLRK');
+  });
+
+  it('deep-redacts walletAddress fields and sensitive keys', () => {
+    const payload = {
+      walletAddress: WALLET,
+      creditLimit: '1000.00',
+      secret: 'should-never-leak',
+      nested: {
+        borrowerWallet: WALLET,
+        api_key: 'ck_secret',
+      },
+      recentTransactions: [
+        { walletAddress: WALLET, amount: '10.00', type: 'borrow' },
+      ],
+    };
+
+    const redacted = redactSupportValue(payload);
+    expect(redacted.walletAddress).toBe('GDRXE2...NLRK');
+    expect(redacted.creditLimit).toBe('1000.00');
+    expect(redacted.secret).toBe('[REDACTED]');
+    expect(redacted.nested.borrowerWallet).toBe('GDRXE2...NLRK');
+    expect(redacted.nested.api_key).toBe('[REDACTED]');
+    expect(redacted.recentTransactions[0].walletAddress).toBe('GDRXE2...NLRK');
+    expect(redacted.recentTransactions[0].amount).toBe('10.00');
+    expect(JSON.stringify(redacted)).not.toContain(WALLET);
+    expect(JSON.stringify(redacted)).not.toContain('should-never-leak');
+  });
+});

--- a/src/utils/supportRedact.ts
+++ b/src/utils/supportRedact.ts
@@ -1,0 +1,97 @@
+/**
+ * Response-level redaction for support/troubleshooting payloads.
+ *
+ * Support endpoints intentionally return operational state for incident
+ * response, but must not leak secrets or full PII in downstream logs,
+ * screenshots, or ticket systems. Wallet addresses are truncated; Stellar
+ * secret seeds and emails are fully redacted.
+ *
+ * This is separate from {@link redactLogValue} (log pipeline) so API
+ * responses can keep structured troubleshooting fields while still masking
+ * sensitive identifiers.
+ */
+
+const STELLAR_ADDRESS_REGEX = /\bG[A-Z2-7]{55}\b/g;
+const STELLAR_SECRET_SEED_REGEX = /\bS[A-Z2-7]{55}\b/g;
+const STELLAR_MUXED_ACCOUNT_REGEX = /\bM[A-Z2-7]{68}\b/g;
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
+const SENSITIVE_KEY_PATTERN =
+  /^(password|secret|seed|private[_-]?key|api[_-]?key|token|authorization)$/i;
+
+/** Truncate a Stellar public key for safe display (keeps prefix/suffix for correlation). */
+export function truncateWalletAddress(address: string): string {
+  if (address.length < 12) {
+    return '[REDACTED_WALLET]';
+  }
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+/** Redact free-form strings that may embed addresses, seeds, or emails. */
+export function redactSupportString(value: string): string {
+  return value
+    .replace(STELLAR_SECRET_SEED_REGEX, '[REDACTED_STELLAR_SECRET]')
+    .replace(STELLAR_MUXED_ACCOUNT_REGEX, '[REDACTED_MUXED_ACCOUNT]')
+    .replace(EMAIL_REGEX, '[REDACTED_EMAIL]')
+    .replace(STELLAR_ADDRESS_REGEX, (match) => truncateWalletAddress(match));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (Object.prototype.toString.call(value) !== '[object Object]') {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Deep-redact a support payload. Known sensitive object keys are replaced
+ * wholesale; string values are scrubbed for embedded secrets/addresses.
+ */
+export function redactSupportValue<T>(value: T): T {
+  return redactInternal(value, new WeakSet<object>()) as T;
+}
+
+function redactInternal(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === 'string') {
+    return redactSupportString(value);
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactInternal(entry, seen));
+  }
+
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        out[key] = '[REDACTED]';
+        continue;
+      }
+      // Wallet fields are common and get consistent truncation even when
+      // already full-length addresses.
+      if (
+        (key === 'walletAddress' || key === 'borrowerWallet') &&
+        typeof nested === 'string'
+      ) {
+        out[key] = truncateWalletAddress(nested);
+        continue;
+      }
+      out[key] = redactInternal(nested, seen);
+    }
+    return out;
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary

Implements read-only **support tools** for safe borrower lookup and incident response, so operators do not need ad-hoc DB access.

### Endpoints (all `GET`, all require `X-Admin-Api-Key`)

| Path | Purpose |
|------|---------|
| `/api/support/borrowers/:walletAddress` | Credit-line snapshots + recent txs + recon status |
| `/api/support/credit-lines/:id` | Single credit-line troubleshooting view |
| `/api/support/credit-lines/:id/transactions` | Recent transactions only |
| `/api/support/reconciliation/status` | Worker/queue status (`readOnly: true`, never schedules jobs) |

### Security

- **RBAC:** `adminAuth` on every support route; `503` when `ADMIN_API_KEY` unset (fail closed)
- **Read-only:** GET handlers only; no credit-line mutations and no job enqueue
- **Redaction:** wallets truncated (`Gxxxx…yyyy`), secrets/emails stripped via `supportRedact`

### Tests & docs

- Route tests: RBAC boundaries, validation, redaction, no-write surface, no mutation side effects
- Service + redact unit tests
- OpenAPI (`src/openapi.yaml`), `docs/API.md`, `docs/SECURITY.md`, `docs/troubleshooting.md`

Closes #226