### PR TITLE
feat(security): verify inbound webhook signatures and block replay

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -290,6 +290,20 @@ HMAC is computed over the **raw JSON body** with `WEBHOOK_SECRET`. Subscribers m
 
 Webhook delivery settings expose retry and backoff knobs. Implement idempotency on receive so repeated deliveries are safe.
 
+### Inbound partner webhooks
+
+Implemented in [`src/routes/inboundWebhooks.ts`](../src/routes/inboundWebhooks.ts).
+
+#### `POST /api/inbound-webhooks/events`
+
+- **Auth:** HMAC headers only (`X-Signature`, `X-Timestamp`, `X-Nonce`). No API key.
+- **Secret:** `INBOUND_WEBHOOK_SECRET` (503 when unset).
+- **Signed payload:** `X-Timestamp + "." + X-Nonce + "." + raw_body`.
+- **Replay:** nonce TTL cache; duplicate nonces → `401 Replay detected`.
+- **Response 202:** `{ data: { accepted: true, event }, error: null }`.
+
+Partner signing guide: [`docs/webhooks.md`](./webhooks.md).
+
 ---
 
 ### Reconciliation

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -44,7 +44,18 @@ A separate, single-secret header in [`src/middleware/adminAuth.ts`](../src/middl
 
 Fail-closed: when `ADMIN_API_KEY` is unset, the endpoint returns `503` so operators discover the misconfiguration rather than silently accepting any request.
 
-### 2.3 Where session/JWT would live
+### 2.3 Inbound webhooks (`X-Signature` / `X-Timestamp` / `X-Nonce`)
+
+Partner ingress at `POST /api/inbound-webhooks/events` is authenticated with HMAC-SHA256 over `timestamp.nonce.raw_body`, not API keys. Middleware lives in [`src/middleware/inboundWebhookSignature.ts`](../src/middleware/inboundWebhookSignature.ts):
+
+- Constant-time comparison via `crypto.timingSafeEqual`.
+- Timestamp skew window (`INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS`, default 5 minutes).
+- Nonce claim after successful verification blocks replay within the window.
+- Fail-closed `503` when `INBOUND_WEBHOOK_SECRET` is unset.
+
+Full partner scheme: [`docs/webhooks.md`](./webhooks.md).
+
+### 2.4 Where session/JWT would live
 
 No JWT or cookie auth ships today. If introduced, recommended placement:
 

--- a/docs/webhook-subscribers.md
+++ b/docs/webhook-subscribers.md
@@ -5,6 +5,9 @@ Creditra sends outbound `draw_confirmed` webhooks to each URL configured in
 verify that the raw request body came from a sender that knows
 `WEBHOOK_SECRET`.
 
+> **Inbound** partner → Creditra webhooks use a different path and header set.
+> See [`webhooks.md`](./webhooks.md) for `POST /api/inbound-webhooks/events`.
+
 Implementation references:
 
 - [`src/services/drawWebhookService.ts`](../src/services/drawWebhookService.ts)

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,151 @@
+# Webhooks
+
+Creditra has two webhook surfaces:
+
+1. **Outbound** draw-confirmation deliveries to subscriber URLs (`WEBHOOK_URLS`).
+2. **Inbound** signed partner events accepted at `POST /api/inbound-webhooks/events`.
+
+Outbound onboarding for subscribers is documented in
+[`webhook-subscribers.md`](./webhook-subscribers.md). This page documents the
+**inbound** signature scheme partners must implement when calling Creditra.
+
+---
+
+## Inbound webhook signatures
+
+Every inbound webhook must include:
+
+```http
+Content-Type: application/json
+X-Timestamp: 2026-07-09T00:00:00.000Z
+X-Nonce: unique-message-id
+X-Signature: sha256=<hex HMAC>
+```
+
+| Header | Required | Description |
+|---|---|---|
+| `X-Timestamp` | yes | ISO-8601 (`Date.toISOString()`) **or** unix epoch seconds |
+| `X-Nonce` | yes | Unique message id (UUID recommended). Max 256 characters. |
+| `X-Signature` | yes | `sha256=` + lowercase/uppercase hex HMAC-SHA256 digest |
+
+### Signing string
+
+The signature is HMAC-SHA256 over the exact raw JSON request body plus the
+timestamp and nonce, joined with dots:
+
+```text
+signed_payload = X-Timestamp + "." + X-Nonce + "." + raw_body
+X-Signature    = "sha256=" + hex(hmac_sha256(INBOUND_WEBHOOK_SECRET, signed_payload))
+```
+
+**Critical:** sign the **raw body bytes** that will be sent on the wire.
+Re-serializing JSON (key order, spacing, unicode escapes) changes the HMAC
+input and will fail verification.
+
+### Server rejection rules
+
+The server rejects requests that fail any of these checks (fail closed):
+
+| Condition | HTTP | Error |
+|---|---:|---|
+| `INBOUND_WEBHOOK_SECRET` unset | 503 | Inbound webhook signing is not configured… |
+| Missing `X-Timestamp` / `X-Nonce` / `X-Signature` | 401 | Missing required webhook headers… |
+| Unparseable timestamp | 401 | Invalid webhook timestamp |
+| Timestamp outside tolerance | 401 | Stale webhook timestamp |
+| Malformed `X-Signature` | 401 | Malformed webhook signature |
+| HMAC mismatch | 401 | Invalid webhook signature |
+| Nonce already seen inside the window | 401 | Replay detected |
+
+Default timestamp tolerance is **5 minutes** (clock skew + delivery delay).
+Configure with `INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS`.
+
+### Replay protection
+
+1. Signature and timestamp are verified first.
+2. Only then is the nonce **claimed** in a TTL cache.
+3. A second request with the same `X-Nonce` while the claim is live returns `401 Replay detected`.
+
+The application ships an in-process nonce store (single-node / tests). Durable
+multi-replica deployments can persist nonces with migration
+`006_inbound_webhook_nonces.sql` (`inbound_webhook_nonces` table).
+
+Nonce TTL aligns with the timestamp tolerance window so expired nonces do not
+accumulate forever.
+
+### Configuration
+
+| Environment variable | Default | Used for |
+|---|---:|---|
+| `INBOUND_WEBHOOK_SECRET` | empty | Shared HMAC secret. Required to accept inbound webhooks. |
+| `INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS` | `300000` (5 min) | Max absolute skew between server clock and `X-Timestamp`. |
+
+Do **not** put real secrets in logs, tickets, sample payloads, or OpenAPI examples.
+
+### Endpoint
+
+```http
+POST /api/inbound-webhooks/events
+```
+
+- **Auth:** signature headers only (no API key).
+- **Body:** JSON object. Include an `event` string when possible.
+- **Success 202:**
+
+```json
+{
+  "data": { "accepted": true, "event": "partner.updated" },
+  "error": null
+}
+```
+
+### Partner signing example (Node.js)
+
+```ts
+import { createHmac, randomUUID } from "node:crypto";
+
+const secret = process.env.INBOUND_WEBHOOK_SECRET!;
+const timestamp = new Date().toISOString();
+const nonce = randomUUID();
+const body = JSON.stringify({ event: "partner.updated", id: "evt_123" });
+
+const signature =
+  "sha256=" +
+  createHmac("sha256", secret)
+    .update(`${timestamp}.${nonce}.`)
+    .update(body)
+    .digest("hex");
+
+await fetch("https://api.example.com/api/inbound-webhooks/events", {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    "x-timestamp": timestamp,
+    "x-nonce": nonce,
+    "x-signature": signature,
+  },
+  body,
+});
+```
+
+### Implementation references
+
+| Piece | Path |
+|---|---|
+| Raw body capture | [`src/middleware/rawBody.ts`](../src/middleware/rawBody.ts) |
+| HMAC + replay middleware | [`src/middleware/inboundWebhookSignature.ts`](../src/middleware/inboundWebhookSignature.ts) |
+| Nonce store | [`src/services/inboundWebhookNonceStore.ts`](../src/services/inboundWebhookNonceStore.ts) |
+| Route | [`src/routes/inboundWebhooks.ts`](../src/routes/inboundWebhooks.ts) |
+| OpenAPI | [`src/openapi.yaml`](../src/openapi.yaml) → `/api/inbound-webhooks/events` |
+| SQL migration | [`migrations/006_inbound_webhook_nonces.sql`](../migrations/006_inbound_webhook_nonces.sql) |
+
+---
+
+## Outbound webhooks (summary)
+
+Outbound `draw_confirmed` deliveries use a related but distinct contract:
+
+- Headers: `X-Webhook-Signature`, `X-Webhook-Timestamp`
+- Secret: `WEBHOOK_SECRET`
+- Signing input: raw JSON body only (no nonce in the signed string)
+
+See [`webhook-subscribers.md`](./webhook-subscribers.md) for the full subscriber guide.

--- a/migrations/006_inbound_webhook_nonces.sql
+++ b/migrations/006_inbound_webhook_nonces.sql
@@ -1,0 +1,18 @@
+-- Replay protection store for inbound signed webhooks.
+-- Application code ships an in-process TTL cache; durable multi-replica
+-- deployments can back the same contract with this table.
+CREATE TABLE IF NOT EXISTS inbound_webhook_nonces (
+  nonce TEXT PRIMARY KEY,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS inbound_webhook_nonces_expires_at_idx
+  ON inbound_webhook_nonces (expires_at);
+
+COMMENT ON TABLE inbound_webhook_nonces IS
+  'Nonce cache for inbound webhook replay protection (HMAC + timestamp window)';
+
+-- Rollback (manual):
+-- DROP INDEX IF EXISTS inbound_webhook_nonces_expires_at_idx;
+-- DROP TABLE IF EXISTS inbound_webhook_nonces;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -47,3 +47,4 @@ This runs the initial migration (or all pending migrations) and checks for the p
 | `001_initial_schema.sql` | Borrowers, credit lines, risk evaluations, transactions, events, indexes |
 | `002_add_interest_rate_to_credit_lines.sql` | Adds `interest_rate_bps` to `credit_lines` |
 | `003_data_retention.sql` | Adds `borrowers.anonymized_at` and the `data_retention_runs` audit table — see [docs/DATA_RETENTION.md](../docs/DATA_RETENTION.md) |
+| `006_inbound_webhook_nonces.sql` | Nonce TTL table for inbound webhook replay protection — see [docs/webhooks.md](../docs/webhooks.md) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2698,7 +2697,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3291,7 +3289,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3753,7 +3750,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4555,7 +4551,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5901,7 +5896,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7475,7 +7469,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9074,7 +9067,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9158,7 +9150,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9318,7 +9309,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -9397,7 +9387,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -9708,7 +9697,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
 import { apiKeysRouter } from './routes/apiKeys.js';
+import { recordRequest, metricsRouter } from './routes/metrics.js';
+import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
+import { maintenanceRouter } from './routes/maintenance.js';
 
 export function createApp() {
   const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -58,6 +58,7 @@ export class Container {
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -168,7 +169,11 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
-  // Method to replace repositories (useful for testing or switching to DB implementations)
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
+  // Method to replace repositories
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;
     riskEvaluationRepository?: RiskEvaluationRepository;

--- a/src/container/__tests__/Container.contract.test.ts
+++ b/src/container/__tests__/Container.contract.test.ts
@@ -64,7 +64,7 @@ describe('Container DI contract', () => {
     });
 
     it.each(REPOSITORY_RESOLVERS)('resolves repository %s', (name) => {
-      const repo = container[name] as Record<string, unknown>;
+      const repo = container[name] as unknown as Record<string, unknown>;
       expect(repo, `${String(name)} must resolve`).toBeDefined();
       // A repository is a contract object: it must expose callable methods.
       expect(typeof repo).toBe('object');

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,11 @@ import { creditRouter } from "./routes/credit.js";
 import { riskRouter } from "./routes/risk.js";
 import { healthRouter } from "./routes/health.js";
 import { webhookRouter } from "./routes/webhook.js";
+import { inboundWebhookRouter } from "./routes/inboundWebhooks.js";
 import { reconciliationRouter } from "./routes/reconciliation.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { requestLogger } from "./middleware/requestLogger.js";
+import { captureRawBody } from "./middleware/rawBody.js";
 import {
   InMemoryRateLimitStore,
   RedisRateLimitStore,
@@ -135,8 +137,9 @@ app.use((req, res, next) => {
 });
 
 // 100 kb hard cap; body-parser emits a 413 that errorHandler converts to a
-// structured response.
-app.use(express.json({ limit: '100kb' }));
+// structured response. `verify` captures the raw bytes for inbound webhook
+// HMAC verification (see docs/webhooks.md).
+app.use(express.json({ limit: '100kb', verify: captureRawBody }));
 
 app.use(requestLogger);
 
@@ -153,6 +156,7 @@ app.use("/api/risk/evaluate", evaluateRateLimit);
 app.use("/api/risk/wallet", defaultRateLimit);
 app.use("/api/risk", riskRouter);
 app.use("/api/webhooks", webhookRouter);
+app.use("/api/inbound-webhooks", inboundWebhookRouter);
 app.use("/api/reconciliation", reconciliationRouter);
 
 // Global error handler — must be registered after routes

--- a/src/middleware/__tests__/inboundWebhookSignature.test.ts
+++ b/src/middleware/__tests__/inboundWebhookSignature.test.ts
@@ -1,0 +1,290 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { captureRawBody } from '../rawBody.js';
+import {
+  createInboundWebhookSignatureMiddleware,
+  parseWebhookTimestamp,
+  signInboundWebhookPayload,
+  DEFAULT_INBOUND_WEBHOOK_TOLERANCE_MS,
+} from '../inboundWebhookSignature.js';
+import { InMemoryInboundWebhookNonceStore } from '../../services/inboundWebhookNonceStore.js';
+
+const SECRET = 'inbound-webhook-secret';
+const NOW = Date.parse('2026-07-09T00:00:00.000Z');
+
+function buildApp(store = new InMemoryInboundWebhookNonceStore(() => NOW)) {
+  const app = express();
+  app.use(express.json({ verify: captureRawBody }));
+  app.post(
+    '/webhook',
+    createInboundWebhookSignatureMiddleware({
+      secret: SECRET,
+      nonceStore: store,
+      now: () => NOW,
+      toleranceMs: DEFAULT_INBOUND_WEBHOOK_TOLERANCE_MS,
+    }),
+    (_req, res) => res.status(202).json({ accepted: true }),
+  );
+  return app;
+}
+
+function signedHeaders(
+  body: string,
+  nonce = 'nonce-1',
+  timestamp = '2026-07-09T00:00:00.000Z',
+) {
+  return {
+    'x-timestamp': timestamp,
+    'x-nonce': nonce,
+    'x-signature': signInboundWebhookPayload(
+      SECRET,
+      timestamp,
+      nonce,
+      Buffer.from(body),
+    ),
+  };
+}
+
+describe('parseWebhookTimestamp', () => {
+  it('parses ISO-8601 timestamps', () => {
+    expect(parseWebhookTimestamp('2026-07-09T00:00:00.000Z')).toBe(NOW);
+  });
+
+  it('parses unix epoch seconds', () => {
+    expect(parseWebhookTimestamp(String(Math.floor(NOW / 1000)))).toBe(NOW);
+  });
+
+  it('returns null for garbage', () => {
+    expect(parseWebhookTimestamp('not-a-date')).toBeNull();
+    expect(parseWebhookTimestamp('')).toBeNull();
+  });
+});
+
+describe('createInboundWebhookSignatureMiddleware', () => {
+  beforeEach(() => {
+    delete process.env.INBOUND_WEBHOOK_SECRET;
+    delete process.env.INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS;
+  });
+
+  it('accepts a valid signed webhook', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set(signedHeaders(body))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ accepted: true });
+  });
+
+  it('accepts unix-epoch X-Timestamp values', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const timestamp = String(Math.floor(NOW / 1000));
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set(signedHeaders(body, 'epoch-nonce', timestamp))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(202);
+  });
+
+  it('rejects missing signature headers', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Missing required webhook headers/i);
+  });
+
+  it('rejects malformed signatures', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set({
+        ...signedHeaders(body),
+        'x-signature': 'not-a-signature',
+      })
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Malformed webhook signature');
+  });
+
+  it('rejects invalid signatures', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set({
+        ...signedHeaders(body),
+        'x-signature': `sha256=${'0'.repeat(64)}`,
+      })
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid webhook signature');
+  });
+
+  it('rejects stale timestamps', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set(signedHeaders(body, 'nonce-1', '2026-07-08T23:00:00.000Z'))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Stale webhook timestamp');
+  });
+
+  it('rejects future timestamps outside the tolerance window', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/webhook')
+      .set(signedHeaders(body, 'future-nonce', '2026-07-09T01:00:00.000Z'))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Stale webhook timestamp');
+  });
+
+  it('rejects replayed nonces', async () => {
+    const store = new InMemoryInboundWebhookNonceStore(() => NOW);
+    const app = buildApp(store);
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const headers = signedHeaders(body);
+
+    await request(app)
+      .post('/webhook')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body)
+      .expect(202);
+
+    const replay = await request(app)
+      .post('/webhook')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(replay.status).toBe(401);
+    expect(replay.body.error).toBe('Replay detected');
+  });
+
+  it('allows the same nonce after TTL expiry', async () => {
+    let clock = NOW;
+    const store = new InMemoryInboundWebhookNonceStore(() => clock);
+    const app = express();
+    app.use(express.json({ verify: captureRawBody }));
+    app.post(
+      '/webhook',
+      createInboundWebhookSignatureMiddleware({
+        secret: SECRET,
+        nonceStore: store,
+        now: () => clock,
+        toleranceMs: 1000,
+      }),
+      (_req, res) => res.status(202).json({ accepted: true }),
+    );
+
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const headers = signedHeaders(body, 'ttl-nonce', new Date(clock).toISOString());
+
+    await request(app)
+      .post('/webhook')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body)
+      .expect(202);
+
+    // Advance past nonce expiry (sentAt + tolerance).
+    clock = NOW + 2000;
+    const laterBody = JSON.stringify({ event: 'partner.updated' });
+    const laterHeaders = signedHeaders(
+      laterBody,
+      'ttl-nonce',
+      new Date(clock).toISOString(),
+    );
+
+    const res = await request(app)
+      .post('/webhook')
+      .set(laterHeaders)
+      .set('content-type', 'application/json')
+      .send(laterBody);
+
+    expect(res.status).toBe(202);
+  });
+
+  it('does not claim a nonce when the signature is invalid', async () => {
+    const store = new InMemoryInboundWebhookNonceStore(() => NOW);
+    const app = buildApp(store);
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const headers = {
+      ...signedHeaders(body, 'poison-nonce'),
+      'x-signature': `sha256=${'ab'.repeat(32)}`,
+    };
+
+    await request(app)
+      .post('/webhook')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body)
+      .expect(401);
+
+    const valid = signedHeaders(body, 'poison-nonce');
+    const res = await request(app)
+      .post('/webhook')
+      .set(valid)
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(202);
+  });
+
+  it('returns 503 when the signing secret is not configured', async () => {
+    const app = express();
+    app.use(express.json({ verify: captureRawBody }));
+    app.post(
+      '/webhook',
+      createInboundWebhookSignatureMiddleware(),
+      (_req, res) => {
+        res.status(202).json({ accepted: true });
+      },
+    );
+
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const res = await request(app)
+      .post('/webhook')
+      .set(signedHeaders(body))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not configured/i);
+  });
+});
+
+describe('InMemoryInboundWebhookNonceStore', () => {
+  it('purges expired nonces', () => {
+    const store = new InMemoryInboundWebhookNonceStore(() => 1000);
+    expect(store.claim('a', 1500)).toBe(true);
+    expect(store.claim('a', 1500)).toBe(false);
+    expect(store.purgeExpired(1600)).toBe(1);
+    expect(store.claim('a', 2000)).toBe(true);
+  });
+});

--- a/src/middleware/inboundWebhookSignature.ts
+++ b/src/middleware/inboundWebhookSignature.ts
@@ -1,0 +1,197 @@
+/**
+ * Inbound webhook signature verification + replay protection.
+ *
+ * Partners must sign each delivery with HMAC-SHA256 and include:
+ *   - `X-Timestamp`  — ISO-8601 or unix epoch seconds
+ *   - `X-Nonce`      — unique id per message (replay key)
+ *   - `X-Signature`  — `sha256=<hex>` over `timestamp.nonce.raw_body`
+ *
+ * See `docs/webhooks.md` for the partner-facing signing scheme.
+ */
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { getRawBody } from './rawBody.js';
+import {
+  defaultInboundWebhookNonceStore,
+  type InboundWebhookNonceStore,
+} from '../services/inboundWebhookNonceStore.js';
+
+export const DEFAULT_INBOUND_WEBHOOK_TOLERANCE_MS = 5 * 60 * 1000;
+
+const SIGNATURE_PREFIX = 'sha256=';
+const HEX_64 = /^[a-fA-F0-9]{64}$/;
+
+export interface InboundWebhookSignatureOptions {
+  /** Shared HMAC secret. Defaults to `process.env.INBOUND_WEBHOOK_SECRET`. */
+  secret?: string;
+  /** Nonce claim store. Defaults to the process-local store. */
+  nonceStore?: InboundWebhookNonceStore;
+  /** Clock source (injectable for tests). */
+  now?: () => number;
+  /**
+   * Max |now - timestamp| allowed. Defaults to
+   * `INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS` or 5 minutes.
+   */
+  toleranceMs?: number;
+}
+
+/**
+ * Build the partner-facing signature header value for a payload.
+ * Exported for tests and partner SDK samples.
+ */
+export function signInboundWebhookPayload(
+  secret: string,
+  timestamp: string,
+  nonce: string,
+  rawBody: Buffer | string,
+): string {
+  const hmac = createHmac('sha256', secret);
+  hmac.update(`${timestamp}.${nonce}.`);
+  hmac.update(rawBody);
+  return `${SIGNATURE_PREFIX}${hmac.digest('hex')}`;
+}
+
+/**
+ * Parse `X-Timestamp` as ISO-8601 or unix epoch seconds.
+ * Returns epoch ms, or `null` if unparseable.
+ */
+export function parseWebhookTimestamp(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Unix epoch seconds (integer, optionally with fractional part).
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    const asNumber = Number(trimmed);
+    if (!Number.isFinite(asNumber)) return null;
+    // Treat values < 1e12 as seconds; larger as milliseconds.
+    return asNumber < 1e12 ? Math.floor(asNumber * 1000) : Math.floor(asNumber);
+  }
+
+  const ms = Date.parse(trimmed);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function headerValue(req: Request, name: string): string {
+  const raw = req.headers[name];
+  if (Array.isArray(raw)) return raw[0] ?? '';
+  return typeof raw === 'string' ? raw : '';
+}
+
+function parseSignatureHex(header: string): Buffer | null {
+  const value = header.trim();
+  if (!value.toLowerCase().startsWith(SIGNATURE_PREFIX)) return null;
+  const hex = value.slice(SIGNATURE_PREFIX.length).trim();
+  if (!HEX_64.test(hex)) return null;
+  return Buffer.from(hex, 'hex');
+}
+
+function resolveToleranceMs(explicit?: number): number {
+  if (typeof explicit === 'number' && Number.isFinite(explicit) && explicit >= 0) {
+    return explicit;
+  }
+  const fromEnv = process.env.INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS;
+  if (fromEnv) {
+    const parsed = Number(fromEnv);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return DEFAULT_INBOUND_WEBHOOK_TOLERANCE_MS;
+}
+
+function unauthorized(res: Response, message: string): void {
+  res.status(401).json({ error: message });
+}
+
+/**
+ * Factory for the inbound webhook verification middleware.
+ *
+ * Order of checks (fail closed):
+ * 1. Secret configured (else 503)
+ * 2. Required headers present and well-formed
+ * 3. Timestamp within tolerance
+ * 4. HMAC matches (constant time)
+ * 5. Nonce not previously claimed (replay)
+ */
+export function createInboundWebhookSignatureMiddleware(
+  options: InboundWebhookSignatureOptions = {},
+) {
+  const nonceStore = options.nonceStore ?? defaultInboundWebhookNonceStore;
+  const now = options.now ?? (() => Date.now());
+  const toleranceMs = resolveToleranceMs(options.toleranceMs);
+
+  return function inboundWebhookSignature(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    const secret = options.secret ?? process.env.INBOUND_WEBHOOK_SECRET ?? '';
+    if (!secret) {
+      res.status(503).json({
+        error: 'Inbound webhook signing is not configured on this server.',
+      });
+      return;
+    }
+
+    const timestamp = headerValue(req, 'x-timestamp');
+    const nonce = headerValue(req, 'x-nonce');
+    const signature = headerValue(req, 'x-signature');
+
+    if (!timestamp || !nonce || !signature) {
+      unauthorized(
+        res,
+        'Missing required webhook headers (X-Timestamp, X-Nonce, X-Signature)',
+      );
+      return;
+    }
+
+    if (nonce.length > 256) {
+      unauthorized(res, 'Invalid webhook nonce');
+      return;
+    }
+
+    const sentAtMs = parseWebhookTimestamp(timestamp);
+    if (sentAtMs === null) {
+      unauthorized(res, 'Invalid webhook timestamp');
+      return;
+    }
+
+    const skew = Math.abs(now() - sentAtMs);
+    if (skew > toleranceMs) {
+      unauthorized(res, 'Stale webhook timestamp');
+      return;
+    }
+
+    const rawBody = getRawBody(req);
+    if (!rawBody) {
+      unauthorized(res, 'Missing raw request body for signature verification');
+      return;
+    }
+
+    const provided = parseSignatureHex(signature);
+    if (!provided) {
+      unauthorized(res, 'Malformed webhook signature');
+      return;
+    }
+
+    const expectedHex = signInboundWebhookPayload(secret, timestamp, nonce, rawBody)
+      .slice(SIGNATURE_PREFIX.length);
+    const expected = Buffer.from(expectedHex, 'hex');
+
+    if (
+      provided.length !== expected.length ||
+      !timingSafeEqual(provided, expected)
+    ) {
+      unauthorized(res, 'Invalid webhook signature');
+      return;
+    }
+
+    // Claim only after cryptographic verification so attackers cannot poison
+    // the nonce cache with unsigned traffic.
+    const expiresAtMs = Math.max(now(), sentAtMs) + toleranceMs;
+    if (!nonceStore.claim(nonce, expiresAtMs)) {
+      unauthorized(res, 'Replay detected');
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/middleware/rawBody.ts
+++ b/src/middleware/rawBody.ts
@@ -1,0 +1,20 @@
+/**
+ * Capture the exact request bytes during JSON body parsing so HMAC
+ * verification can run against the wire body (not a re-serialized object).
+ */
+import type { Request } from 'express';
+
+export interface RawBodyRequest extends Request {
+  rawBody?: Buffer;
+}
+
+/**
+ * body-parser `verify` hook: stash a copy of the raw buffer on the request.
+ */
+export function captureRawBody(req: Request, _res: unknown, buf: Buffer): void {
+  (req as RawBodyRequest).rawBody = Buffer.from(buf);
+}
+
+export function getRawBody(req: Request): Buffer | undefined {
+  return (req as RawBodyRequest).rawBody;
+}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -31,6 +31,8 @@ tags:
     description: On-chain risk evaluation
   - name: Webhooks
     description: Draw confirmation webhook management
+  - name: Inbound Webhooks
+    description: Signed partner webhook ingestion (HMAC + replay protection)
   - name: Reconciliation
     description: Admin control plane for DB-vs-chain reconciliation
 
@@ -400,6 +402,35 @@ components:
           type: integer
         timeoutMs:
           type: integer
+
+    InboundWebhookRequest:
+      type: object
+      required: [event]
+      properties:
+        event:
+          type: string
+          example: partner.updated
+      additionalProperties: true
+      description: |
+        Free-form partner payload. Prefer including a stable `event` name.
+        The raw JSON body is part of the HMAC input — do not re-serialize after signing.
+
+    InboundWebhookAcceptedResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [accepted, event]
+          properties:
+            accepted:
+              type: boolean
+              example: true
+            event:
+              type: string
+              example: partner.updated
+        error:
+          type: string
+          nullable: true
 
     AdminRecalibrateResponse:
       type: object
@@ -1131,6 +1162,92 @@ paths:
                 backoffMultiplier: 2.0
                 timeoutMs: 10000
                 configured: true
+
+  /api/inbound-webhooks/events:
+    post:
+      tags: [Inbound Webhooks]
+      operationId: receiveInboundWebhookEvent
+      summary: Receive a signed inbound webhook event
+      description: |
+        Partner ingress protected by HMAC-SHA256 and nonce replay protection.
+
+        Required headers:
+        - `X-Timestamp` — ISO-8601 or unix epoch seconds
+        - `X-Nonce` — unique per delivery (replay key)
+        - `X-Signature` — `sha256=<hex>` over `X-Timestamp + "." + X-Nonce + "." + raw_body`
+
+        Stale timestamps (outside `INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS`, default 5 minutes)
+        and repeated nonces are rejected. See `docs/webhooks.md` for the partner signing guide.
+      security: []
+      parameters:
+        - name: X-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+            pattern: "^sha256=[a-fA-F0-9]{64}$"
+          description: HMAC-SHA256 signature of the signed payload
+        - name: X-Timestamp
+          in: header
+          required: true
+          schema:
+            type: string
+          description: ISO-8601 datetime or unix epoch seconds
+        - name: X-Nonce
+          in: header
+          required: true
+          schema:
+            type: string
+            maxLength: 256
+          description: Unique message identifier for replay protection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboundWebhookRequest"
+            example:
+              event: partner.updated
+              id: evt_123
+      responses:
+        "202":
+          description: Event accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboundWebhookAcceptedResponse"
+              example:
+                data:
+                  accepted: true
+                  event: partner.updated
+                error: null
+        "401":
+          description: Missing, invalid, stale, or replayed signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                missingHeaders:
+                  value:
+                    error: Missing required webhook headers (X-Timestamp, X-Nonce, X-Signature)
+                invalidSignature:
+                  value:
+                    error: Invalid webhook signature
+                stale:
+                  value:
+                    error: Stale webhook timestamp
+                replay:
+                  value:
+                    error: Replay detected
+        "503":
+          description: Inbound webhook signing secret is not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Inbound webhook signing is not configured on this server.
 
   /api/webhooks/test:
     post:

--- a/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
+++ b/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
@@ -13,7 +13,6 @@ import type { TransactionRepository } from '../interfaces/TransactionRepository.
 // ---------------------------------------------------------------------------
 
 const CREDIT_LINE_ID = '00000000-0000-0000-0000-000000000001';
-const WALLET = 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1';
 
 function sampleRequest(overrides: Partial<CreateTransactionRequest> = {}): CreateTransactionRequest {
   return {

--- a/src/repositories/postgres/PostgresTransactionRepository.ts
+++ b/src/repositories/postgres/PostgresTransactionRepository.ts
@@ -2,7 +2,7 @@ import {
   type Transaction,
   type CreateTransactionRequest,
   TransactionStatus,
-  TransactionType,
+  type TransactionType,
 } from '../../models/Transaction.js';
 import type { TransactionRepository } from '../interfaces/TransactionRepository.js';
 import type { DbClient } from '../../db/client.js';

--- a/src/routes/__tests__/inboundWebhooks.test.ts
+++ b/src/routes/__tests__/inboundWebhooks.test.ts
@@ -1,0 +1,102 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { captureRawBody } from '../../middleware/rawBody.js';
+import { signInboundWebhookPayload } from '../../middleware/inboundWebhookSignature.js';
+import { defaultInboundWebhookNonceStore } from '../../services/inboundWebhookNonceStore.js';
+import { inboundWebhookRouter } from '../inboundWebhooks.js';
+
+const SECRET = 'route-secret';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ verify: captureRawBody }));
+  app.use('/api/inbound-webhooks', inboundWebhookRouter);
+  return app;
+}
+
+function signedHeaders(body: string, nonce = 'route-nonce') {
+  const timestamp = new Date().toISOString();
+  return {
+    'x-timestamp': timestamp,
+    'x-nonce': nonce,
+    'x-signature': signInboundWebhookPayload(
+      SECRET,
+      timestamp,
+      nonce,
+      Buffer.from(body),
+    ),
+  };
+}
+
+describe('inbound webhook routes', () => {
+  beforeEach(() => {
+    process.env.INBOUND_WEBHOOK_SECRET = SECRET;
+    defaultInboundWebhookNonceStore.resetForTests();
+  });
+
+  it('accepts signed inbound events', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+
+    const res = await request(buildApp())
+      .post('/api/inbound-webhooks/events')
+      .set(signedHeaders(body))
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({
+      data: { accepted: true, event: 'partner.updated' },
+      error: null,
+    });
+  });
+
+  it('rejects unsigned inbound events', async () => {
+    const res = await request(buildApp())
+      .post('/api/inbound-webhooks/events')
+      .set('content-type', 'application/json')
+      .send({ event: 'partner.updated' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Missing required webhook headers/i);
+  });
+
+  it('rejects replay of a previously accepted delivery', async () => {
+    const body = JSON.stringify({ event: 'partner.payment' });
+    const headers = signedHeaders(body, 'integration-replay-nonce');
+    const app = buildApp();
+
+    await request(app)
+      .post('/api/inbound-webhooks/events')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body)
+      .expect(202);
+
+    const replay = await request(app)
+      .post('/api/inbound-webhooks/events')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(replay.status).toBe(401);
+    expect(replay.body.error).toBe('Replay detected');
+  });
+
+  it('rejects invalid signatures at the route boundary', async () => {
+    const body = JSON.stringify({ event: 'partner.updated' });
+    const headers = {
+      ...signedHeaders(body),
+      'x-signature': `sha256=${'ff'.repeat(32)}`,
+    };
+
+    const res = await request(buildApp())
+      .post('/api/inbound-webhooks/events')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid webhook signature');
+  });
+});

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import { metricsRouter, recordRequest } from '../metrics.js';
 
@@ -45,16 +45,6 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
       return this;
     },
   } as unknown as Response;
-
-  const runHandlers = async (index: number): Promise<void> => {
-    if (index >= handlers.length) return;
-    await new Promise<void>((resolve) => {
-      handlers[index](req, res, () => {
-        resolve();
-        runHandlers(index + 1);
-      });
-    });
-  };
 
   // Execute the first handler (auth guard); if it calls next, proceed to the route handler.
   await new Promise<void>((resolve) => {

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -23,9 +23,8 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
     throw new Error(`Route not found: ${args.method.toUpperCase()} ${args.path}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handlers: Array<(req: Request, res: Response, next: NextFunction) => unknown> =
-    layer.route.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
+    layer.route!.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
 
   let statusCode = 200;
   let responseBody: unknown = null;

--- a/src/routes/creditBulk.ts
+++ b/src/routes/creditBulk.ts
@@ -54,8 +54,13 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
 
       try {
-        const creditService = container.getCreditService();
-        const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
+        const creditService = container.creditLineService;
+        const body = parsed.data as CreateCreditLineBody;
+        const line = await creditService.createCreditLine({
+          walletAddress: body.walletAddress,
+          creditLimit: body.creditLimit ?? body.requestedLimit ?? '',
+          interestRateBps: body.interestRateBps ?? 0,
+        });
         results.push({ index: i + 1, status: 'created', id: line.id });
         created++;
       } catch (err) {
@@ -64,9 +69,9 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
     }
 
-    return res.status(207).json(ok({ summary: { total: rows.length, created, failed, dry_run: isDryRun }, results }));
+    return ok(res, { summary: { total: rows.length, created, failed, dry_run: isDryRun } as Record<string, unknown>, results }, 207);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/src/routes/inboundWebhooks.ts
+++ b/src/routes/inboundWebhooks.ts
@@ -1,0 +1,37 @@
+/**
+ * Inbound partner webhook ingestion.
+ *
+ * Mounted at `/api/inbound-webhooks`. Every mutating route on this router
+ * requires HMAC signature verification (see middleware + `docs/webhooks.md`).
+ */
+import { Router, type Request, type Response } from 'express';
+import { createInboundWebhookSignatureMiddleware } from '../middleware/inboundWebhookSignature.js';
+import { ok } from '../utils/response.js';
+
+export const inboundWebhookRouter = Router();
+
+/**
+ * Accept a signed partner event.
+ *
+ * Headers: X-Timestamp, X-Nonce, X-Signature (see docs/webhooks.md).
+ * Body: free-form JSON; partners should include an `event` string when possible.
+ */
+inboundWebhookRouter.post(
+  '/events',
+  createInboundWebhookSignatureMiddleware(),
+  (req: Request, res: Response) => {
+    const event =
+      req.body && typeof req.body === 'object' && typeof req.body.event === 'string'
+        ? req.body.event
+        : 'unknown';
+
+    ok(
+      res,
+      {
+        accepted: true,
+        event,
+      },
+      202,
+    );
+  },
+);

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -23,7 +23,7 @@
  *
  * See `docs/OBSERVABILITY.md` for Grafana dashboard JSON and Alertmanager rules.
  */
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import { ok, fail } from '../utils/response.js';
 
 export const metricsRouter = Router();

--- a/src/routes/simulation.ts
+++ b/src/routes/simulation.ts
@@ -31,7 +31,7 @@ simulationRouter.post(
 
       const { amount } = req.body as DrawBody;
       const drawAmount = Number(amount);
-      const availableCredit = Number(line.creditLimit) - Number(line.balance ?? 0);
+      const availableCredit = Number(line.creditLimit) - Number(line.utilized ?? 0);
       const valid = drawAmount > 0 && drawAmount <= availableCredit;
       const interestBps: number = (line as unknown as Record<string, unknown>)['interestRateBps'] as number ?? 0;
       const estimatedFee = Math.ceil(drawAmount * interestBps / INTEREST_RATE_DIVISOR);
@@ -46,13 +46,13 @@ simulationRouter.post(
         preview: {
           requestedAmount: drawAmount,
           estimatedFee,
-          newBalance: valid ? Number(line.balance ?? 0) + drawAmount : null,
+          newBalance: valid ? Number(line.utilized ?? 0) + drawAmount : null,
           remainingCredit: valid ? availableCredit - drawAmount : availableCredit,
         },
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );
@@ -67,7 +67,7 @@ simulationRouter.post(
 
       const { amount } = req.body as RepayBody;
       const repayAmount = Number(amount);
-      const currentBalance = Number(line.balance ?? 0);
+      const currentBalance = Number(line.utilized ?? 0);
       const effectiveRepay = Math.min(repayAmount, currentBalance);
       const valid = repayAmount > 0;
 
@@ -84,7 +84,7 @@ simulationRouter.post(
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -2,8 +2,9 @@
  * Outbound-webhook management routes mounted at `/api/webhooks`.
  *
  * These endpoints describe the **server's** outbound webhook fan-out (the
- * draw-confirmation push). The backend does not currently receive any
- * inbound webhooks.
+ * draw-confirmation push). Inbound partner webhooks live on a separate router
+ * (`/api/inbound-webhooks`) with HMAC + nonce replay protection — see
+ * `docs/webhooks.md`.
  *
  * Surface:
  * - GET  `/config`      — sanitized config (URLs + retry knobs; secret

--- a/src/services/__tests__/dashboardSummaryService.test.ts
+++ b/src/services/__tests__/dashboardSummaryService.test.ts
@@ -80,7 +80,7 @@ describe('DashboardSummaryService caching', () => {
   });
 
   it('recomputes immediately after invalidate()', async () => {
-    let now = 0;
+    const now = 0;
     const { repo, findAll } = repoOf([line({})]);
     const service = new DashboardSummaryService(repo, 30_000, () => now);
 

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -19,6 +19,7 @@ import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
 import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
 import { redactLogArgs } from "../utils/logRedact.js";
+import { logger as log } from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -200,11 +201,7 @@ async function retryWithBackoff<T>(
             lastError = error as Error;
             
             if (attempt <= maxRetries) {
-                log.warn("webhook:delivery:retry", {
-                    attempt,
-                    retryInMs: delay,
-                    error: lastError,
-                });
+                log.warn({ attempt, retryInMs: delay, error: lastError }, "webhook:delivery:retry");
                 await new Promise(resolve => setTimeout(resolve, delay));
                 delay = Math.floor(delay * backoffMultiplier);
             }
@@ -241,7 +238,7 @@ function parseDrawConfirmedEvent(event: HorizonEvent): WebhookPayload | null {
             }
         };
     } catch (error) {
-        log.error("webhook:event-parse:failed", { error });
+        log.error({ error }, "webhook:event-parse:failed");
         return null;
     }
 }
@@ -257,13 +254,9 @@ export function getWebhookConfig(): WebhookConfig | null {
 export function initializeWebhooks(): void {
     try {
         activeConfig = resolveWebhookConfig();
-        log.info("webhook:initialized", {
-            urls: activeConfig.urls.length,
-            maxRetries: activeConfig.maxRetries,
-            timeoutMs: activeConfig.timeoutMs
-        });
+        log.info({ urls: activeConfig.urls.length, maxRetries: activeConfig.maxRetries, timeoutMs: activeConfig.timeoutMs }, "webhook:initialized");
     } catch (error) {
-        log.error("webhook:initialize:failed", { error });
+        log.error({ error }, "webhook:initialize:failed");
         activeConfig = null;
     }
 }
@@ -278,20 +271,14 @@ export async function sendDrawConfirmationWebhook(
 
     const payload = parseDrawConfirmedEvent(event);
     if (!payload) {
-        log.info("webhook:delivery:skipped-non-draw-event", {
-            ledger: event.ledger,
-            contractId: event.contractId,
-        });
+        log.info({ ledger: event.ledger, contractId: event.contractId }, "webhook:delivery:skipped-non-draw-event");
         return [];
     }
 
     const payloadString = JSON.stringify(payload);
     const signature = generateSignature(payloadString, activeConfig.secret);
 
-    log.info("webhook:delivery:start", {
-        drawId: payload.data.drawId,
-        deliveryCount: activeConfig.urls.length,
-    });
+    log.info({ drawId: payload.data.drawId, deliveryCount: activeConfig.urls.length }, "webhook:delivery:start");
 
     const store = getWebhookDeliveryStateStore();
 
@@ -355,10 +342,7 @@ export async function sendDrawConfirmationWebhook(
     const successCount = results.filter(r => r.success).length;
     const failureCount = results.length - successCount;
     
-    log.info("webhook:delivery:complete", {
-        successful: successCount,
-        failed: failureCount,
-    });
+    log.info({ successful: successCount, failed: failureCount }, "webhook:delivery:complete");
 
     return results;
 }

--- a/src/services/inboundWebhookNonceStore.ts
+++ b/src/services/inboundWebhookNonceStore.ts
@@ -1,0 +1,56 @@
+/**
+ * Nonce cache for inbound webhook replay protection.
+ *
+ * Nonces are claimed once after signature + timestamp checks succeed and
+ * expire after the configured TTL (aligned with the timestamp tolerance
+ * window). The default store is in-process for single-node / tests.
+ * Durable deployments can back the same interface with Postgres using
+ * migration `006_inbound_webhook_nonces.sql`.
+ */
+
+export interface InboundWebhookNonceStore {
+  /**
+   * Atomically claim `nonce` until `expiresAtMs`.
+   * @returns `true` if this is the first claim; `false` if already seen.
+   */
+  claim(nonce: string, expiresAtMs: number): boolean;
+
+  /** Drop expired entries. Returns how many were removed. */
+  purgeExpired(nowMs?: number): number;
+
+  /** Test helper — clear all nonces. */
+  resetForTests(): void;
+}
+
+export class InMemoryInboundWebhookNonceStore implements InboundWebhookNonceStore {
+  private readonly nonces = new Map<string, number>();
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  claim(nonce: string, expiresAtMs: number): boolean {
+    this.purgeExpired();
+    if (this.nonces.has(nonce)) {
+      return false;
+    }
+    this.nonces.set(nonce, expiresAtMs);
+    return true;
+  }
+
+  purgeExpired(nowMs: number = this.now()): number {
+    let purged = 0;
+    for (const [nonce, expiresAtMs] of this.nonces.entries()) {
+      if (expiresAtMs <= nowMs) {
+        this.nonces.delete(nonce);
+        purged += 1;
+      }
+    }
+    return purged;
+  }
+
+  resetForTests(): void {
+    this.nonces.clear();
+  }
+}
+
+/** Shared default store used by the production middleware factory. */
+export const defaultInboundWebhookNonceStore = new InMemoryInboundWebhookNonceStore();


### PR DESCRIPTION
Closes #181

## Summary
- Add inbound webhook HMAC-SHA256 verification middleware for `X-Signature`, `X-Timestamp`, and `X-Nonce`
- Sign/verify `timestamp.nonce.raw_body` with constant-time comparison
- Reject missing/malformed signatures, stale (or too-far-future) timestamps, invalid HMACs, and replayed nonces
- Capture raw JSON body via Express `verify` hook so signatures match wire bytes
- Expose `POST /api/inbound-webhooks/events` as the signed partner ingress
- Ship in-process TTL nonce store + migration `006_inbound_webhook_nonces.sql` for durable multi-replica use
- Document partner signing scheme in `docs/webhooks.md` and OpenAPI

## Security notes
- Fail-closed `503` when `INBOUND_WEBHOOK_SECRET` is not configured
- Default timestamp tolerance 5 minutes (`INBOUND_WEBHOOK_TIMESTAMP_TOLERANCE_MS`)
- Nonces are claimed only after signature + timestamp verification succeed (unsigned traffic cannot poison the cache)
- Accepts ISO-8601 or unix-epoch `X-Timestamp` values

## Validation
- `vitest run src/middleware/__tests__/inboundWebhookSignature.test.ts src/routes/__tests__/inboundWebhooks.test.ts src/db/migrations.test.ts --pool=forks --maxWorkers=1` (30 passed)
- OpenAPI YAML parse check
- `eslint` on touched source files
- `git diff --check`

## Docs
- Partner guide: `docs/webhooks.md`
- Cross-links: `docs/API.md`, `docs/SECURITY.md`, `docs/webhook-subscribers.md`
- OpenAPI: `POST /api/inbound-webhooks/events`