### PR TITLE
feat(api): strict request/response JSON schema validation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,17 +37,19 @@ Every error response (`4xx`, `5xx`) has this shape:
 }
 ```
 
-Validation errors additionally include `details`:
+Validation errors additionally include `details` (Zod request schemas — see [`json-schema-validation.md`](./json-schema-validation.md)):
 
 ```json
 {
   "data": null,
   "error": "Validation failed",
   "details": [
-    { "field": "walletAddress", "message": "Invalid Stellar address" }
+    { "field": "walletAddress", "message": "walletAddress must be a valid Stellar address" }
   ]
 }
 ```
+
+Every public route validates body, query, and path params via `validateBody` / `validateQuery` / `validateParams`. Response contracts are asserted in integration tests with `assertMatchesSchema`; set `ENABLE_RESPONSE_VALIDATION=true` to enforce them at runtime.
 
 Rate-limit responses additionally include `retryAfter` and the `Retry-After` HTTP header. See [`docs/error-envelope.md`](./error-envelope.md) for the helper API.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,8 @@ This directory holds the long-form documentation for the Creditra backend. The t
 |---|---|
 | [`data-model.md`](./data-model.md) | Per-table column reference. |
 | [`REPOSITORY_ARCHITECTURE.md`](./REPOSITORY_ARCHITECTURE.md) | Repository / DIP layout. |
-| [`schema-validation.md`](./schema-validation.md) | Boot-time schema validator. |
+| [`schema-validation.md`](./schema-validation.md) | Boot-time **database** schema validator. |
+| [`json-schema-validation.md`](./json-schema-validation.md) | Strict Zod request/response JSON validation for the HTTP API. |
 | [`cursor-pagination.md`](./cursor-pagination.md) | Cursor pagination contract. |
 | [`error-envelope.md`](./error-envelope.md) | `{ data, error }` envelope reference. |
 | [`http-timeouts.md`](./http-timeouts.md) | Outbound HTTP timeout policy. |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -69,20 +69,24 @@ Both middlewares register **after** rate-limit but **before** the handler so an 
 
 ## 4. Input Validation Policy
 
-Every external boundary validates via Zod ([`src/schemas/`](../src/schemas/)). Three middleware factories wrap the schemas — body, query, params — from [`src/middleware/validate.ts`](../src/middleware/validate.ts):
+Every external boundary validates via Zod ([`src/schemas/`](../src/schemas/)). Middleware factories wrap the schemas — body, query, params, and optional response — from [`src/middleware/validate.ts`](../src/middleware/validate.ts):
 
 ```ts
-validateBody(schema)   // replaces req.body with parsed value
-validateQuery(schema)  // replaces req.query
-validateParams(schema) // replaces req.params
+validateBody(schema)       // replaces req.body with parsed value
+validateQuery(schema)      // replaces req.query
+validateParams(schema)     // replaces req.params
+validateResponse(schema)   // opt-in response contract check (ENABLE_RESPONSE_VALIDATION)
 ```
 
 Behaviour:
 
-- On failure → `400` with structured `{ field, message }[]`.
+- On request failure → `400` with stable `{ data: null, error: "Validation failed", details: [{ field, message }] }`.
 - On success → the parsed (and coerced) value **replaces** the raw input, so downstream handlers receive well-typed data.
-- All credit/risk endpoints reject unknown keys via `additionalProperties: false`.
+- All credit/risk endpoints reject unknown keys via Zod `.strict()` (`additionalProperties: false` in OpenAPI).
 - Stellar address validation lives in [`stellarAddress.ts`](../src/utils/stellarAddress.ts) (regex `/^G[A-Z2-7]{55}$/`) and is shared by `walletAddressSchema` and `walletAddressParamSchema`.
+- Response validation (when enabled) never leaks Zod internals; clients see `{ data: null, error: "Response contract violation" }`.
+
+Full policy, route coverage table, and test helpers: [`docs/json-schema-validation.md`](./json-schema-validation.md).
 
 Validator chain order:
 
@@ -93,7 +97,7 @@ Validator chain order:
 5. Auth middleware (route-specific)
 6. Rate limit middleware (route-specific)
 7. Zod validate(Body|Query|Params)
-8. Handler
+8. Handler (+ optional response schema check)
 9. `errorHandler` catches anything unhandled
 
 ---

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -63,7 +63,9 @@ Boundaries exercised end-to-end against an in-memory container:
 - `tests/draw-credit.test.ts` — draw endpoint validation, Stellar address parsing, pending status.
 - `tests/cors.test.ts` — `isAllowedCorsOrigin()` matrix (loopback fallback, production allowlist).
 - `tests/response.test.ts` — `ok()`/`fail()` envelope helpers.
-- `tests/middleware/*` — `errorHandler`, `rateLimit`, `validate`, body limits.
+- `tests/middleware/*` — `errorHandler`, `rateLimit`, `validate`, response-schema validation, body limits.
+- `tests/response-contract.test.ts` — Zod `assertMatchesSchema` checks on live HTTP responses (prevents API contract drift).
+- `tests/schemas/*` — request + response schema unit tests (strict keys, Stellar addresses, pagination bounds).
 - `src/routes/__tests__/reconciliation.integration.test.ts` — schedule → run → status flow.
 
 ### System (~11 files)

--- a/docs/error-envelope.md
+++ b/docs/error-envelope.md
@@ -29,3 +29,23 @@ Use `ok(res, payload, status?)` and `fail(res, error, status?)` from
 `src/utils/response.ts` instead of building envelopes inline. This keeps
 internal details (stack traces, SQL errors) from leaking into 5xx
 responses by default.
+
+## Schema validation errors
+
+Request schema failures (Zod) always use:
+
+```json
+{
+  "data": null,
+  "error": "Validation failed",
+  "details": [{ "field": "amount", "message": "Required" }]
+}
+```
+
+Response contract violations (only when `ENABLE_RESPONSE_VALIDATION=true`) use:
+
+```json
+{ "data": null, "error": "Response contract violation" }
+```
+
+See [`json-schema-validation.md`](./json-schema-validation.md).

--- a/docs/json-schema-validation.md
+++ b/docs/json-schema-validation.md
@@ -1,0 +1,135 @@
+# Strict JSON Schema Validation (Request + Response)
+
+Zod schemas under [`src/schemas/`](../src/schemas/) are the **single source of truth** for public API request and response contracts. OpenAPI (`src/openapi.yaml`) and human docs should track these schemas; when they disagree, fix OpenAPI.
+
+## Goals
+
+1. Every public route validates inputs (`body` / `query` / `params`) before the handler runs.
+2. Invalid input returns a **stable** envelope — no stack traces, SQL, or internal exception text.
+3. Response shapes can be asserted in tests (and optionally at runtime) to catch contract drift early.
+
+## Request validation
+
+Middleware factories in [`src/middleware/validate.ts`](../src/middleware/validate.ts):
+
+| Factory | Applies to | On failure |
+|---|---|---|
+| `validateBody(schema)` | JSON body | `400` + details |
+| `validateQuery(schema)` | Query string | `400` + details |
+| `validateParams(schema)` | Path params | `400` + details |
+
+### Error envelope
+
+```json
+{
+  "data": null,
+  "error": "Validation failed",
+  "details": [
+    { "field": "walletAddress", "message": "walletAddress must be a valid Stellar address" }
+  ]
+}
+```
+
+Rules:
+
+- `error` is always the literal `"Validation failed"` for schema failures.
+- `details[].field` is a dotted path (`user.email`) or `"(root)"`.
+- Unknown keys are rejected via `.strict()` on request schemas (`additionalProperties: false` in OpenAPI).
+- Stellar addresses use `^G[A-Z2-7]{55}$` via [`stellarAddress.ts`](../src/utils/stellarAddress.ts).
+
+### Schema modules
+
+| Module | Contents |
+|---|---|
+| `common.schema.ts` | Shared field primitives (wallet address) |
+| `credit.schema.ts` | Create / update / draw / repay / list / transactions |
+| `risk.schema.ts` | Evaluate body, history query |
+| `params.schema.ts` | `:id`, `:walletAddress` path params |
+| `admin.schema.ts` | API keys, maintenance, bulk ingest |
+| `response.schema.ts` | Output contracts + envelope helpers |
+
+## Response validation
+
+### Runtime (opt-in)
+
+```bash
+ENABLE_RESPONSE_VALIDATION=true npm start
+# or
+RESPONSE_SCHEMA_VALIDATION=true npm test
+```
+
+When enabled, `validateResponse(schema)` wraps `res.json` and:
+
+- Allows the response through if it matches the schema.
+- On mismatch, logs field-level details server-side and returns:
+
+```json
+{ "data": null, "error": "Response contract violation" }
+```
+
+HTTP status is forced to `500`. Clients never receive Zod issue text for response failures.
+
+Default is **off** so production stays fail-open on response shape while request validation remains mandatory.
+
+### Integration tests (always on for assertions)
+
+Use `assertMatchesSchema(schema, body, label)` from the validate middleware:
+
+```ts
+import { assertMatchesSchema } from '../src/middleware/validate.js';
+import { envelopedRiskResultSchema } from '../src/schemas/index.js';
+
+const res = await request(app).post('/api/risk/evaluate').send({ walletAddress });
+assertMatchesSchema(envelopedRiskResultSchema, res.body, 'POST /api/risk/evaluate');
+```
+
+See [`tests/response-contract.test.ts`](../tests/response-contract.test.ts).
+
+## Route coverage checklist
+
+| Route | Request schema | Response schema (test / optional runtime) |
+|---|---|---|
+| `GET /health` | — | `envelopedHealthSchema` |
+| `GET /api/credit/lines` | `creditLinesQuerySchema` | list / cursor schemas |
+| `GET /api/credit/lines/:id` | `idParamSchema` | `envelopedCreditLineSchema` |
+| `POST /api/credit/lines` | `createCreditLineSchema` | `envelopedCreditLineSchema` |
+| `PUT /api/credit/lines/:id` | `idParamSchema` + `updateCreditLineSchema` | `envelopedCreditLineSchema` |
+| `DELETE /api/credit/lines/:id` | `idParamSchema` | 204 empty |
+| `GET /api/credit/wallet/:walletAddress/lines` | `walletAddressParamSchema` | `envelopedWalletCreditLinesSchema` |
+| `GET /api/credit/lines/:id/transactions` | id + `transactionHistoryQuerySchema` | `envelopedTransactionHistorySchema` |
+| `POST …/draw` / `…/repay` | id + draw/repay body | `drawRepayResultSchema` |
+| `POST /api/risk/evaluate` | `riskEvaluateSchema` | `envelopedRiskResultSchema` |
+| `GET /api/risk/evaluations/:id` | `idParamSchema` | `envelopedRiskEvaluationSchema` |
+| `GET /api/risk/wallet/...` | wallet (+ history query) | evaluation / history envelopes |
+| `POST /api/admin/maintenance` | `maintenanceToggleSchema` | status JSON |
+| `POST /api/admin/api-keys` | `issueApiKeySchema` | key issue envelope |
+| `POST /api/credit/lines/bulk` | bulk body + query | multi-status payload |
+| Reconciliation admin | auth only | enveloped trigger / status |
+
+## OpenAPI
+
+- Spec: [`src/openapi.yaml`](../src/openapi.yaml) (served at `/docs` and `/docs.json`).
+- Validation errors document `ValidationErrorResponse` with `details[]`.
+- Keep `additionalProperties: false` on request bodies in sync with Zod `.strict()`.
+- Validate YAML structure: `npm run validate:spec`.
+
+## Adding a new endpoint
+
+1. Add request Zod schema(s) under `src/schemas/` and export from `index.ts`.
+2. Wire `validateBody` / `validateQuery` / `validateParams` on the route **before** the handler.
+3. Add a response schema; attach `validateResponse(...)` if the success path is stable.
+4. Extend unit tests in `tests/schemas/` and a contract assertion in `tests/response-contract.test.ts` (or route tests).
+5. Update `src/openapi.yaml` + `docs/API.md`.
+
+## Security notes
+
+- Request validation runs after auth middleware where routes are protected — unauthenticated clients still get `401`/`403` without revealing schema details of protected bodies when auth fails first.
+- 5xx paths continue to use `fail()` which strips non-string Error objects (see [`docs/error-envelope.md`](./error-envelope.md)).
+- Response contract violations never echo Zod internals to the client.
+
+## Related
+
+- [`docs/error-envelope.md`](./error-envelope.md) — `{ data, error }` helpers
+- [`docs/SECURITY.md`](./SECURITY.md) § Input Validation Policy
+- [`docs/schema-validation.md`](./schema-validation.md) — **database** boot-time schema checks (different concern)
+- [`docs/TESTING.md`](./TESTING.md) — test pyramid

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -14,9 +14,12 @@ info:
     API keys are configured via the `API_KEYS` environment variable (comma-separated).
 
     ## Keeping the spec in sync
+    - **Zod schemas** in `src/schemas/` are the runtime source of truth for request
+      and response validation. This OpenAPI document should mirror those schemas.
     - Every new route **must** have a corresponding entry here before merging.
     - Run `npm run validate:spec` in CI to catch YAML/structural errors early.
     - Use path-level `operationId` values as the source of truth for client generation.
+    - See `docs/json-schema-validation.md` for request/response validation policy.
 
 servers:
   - url: http://localhost:3000
@@ -31,6 +34,8 @@ tags:
     description: On-chain risk evaluation
   - name: Webhooks
     description: Draw confirmation webhook management
+  - name: Reconciliation
+    description: Admin control plane for DB-vs-chain reconciliation
 
 security:
   - ApiKeyAuth: []
@@ -78,6 +83,9 @@ components:
 
     UpdateCreditLineRequest:
       type: object
+      description: |
+        Partial update body (updateCreditLineSchema). At least one of the
+        updatable fields must be present. Unknown keys are rejected.
       properties:
         creditLimit:
           type: string
@@ -92,6 +100,14 @@ components:
           type: string
           enum: [active, suspended, closed]
           description: Credit line status
+        expectedVersion:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking guard. When provided, the update only succeeds
+            if it equals the stored `version`; otherwise the server returns
+            `409 Conflict`. Omit for unconditional (last-write-wins) updates.
+          example: 3
       additionalProperties: false
 
     CreditLine:
@@ -125,6 +141,14 @@ components:
           type: string
           enum: [active, suspended, closed]
           description: Current credit line status
+        version:
+          type: integer
+          minimum: 1
+          description: >
+            Optimistic-locking version, incremented on each update. Pass the
+            value you read back as `expectedVersion` on a subsequent update to
+            guard against lost writes.
+          example: 1
         createdAt:
           type: string
           format: date-time
@@ -390,17 +414,86 @@ components:
           type: string
           example: "Risk model recalibration triggered"
 
+    ReconciliationTriggerResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [jobId, message]
+          properties:
+            jobId:
+              type: string
+              description: Identifier for the scheduled reconciliation job
+            message:
+              type: string
+              example: Reconciliation job scheduled
+        error:
+          type: string
+          nullable: true
+
+    ReconciliationStatusResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required: [workerRunning, queueSize, failedJobs]
+          properties:
+            workerRunning:
+              type: boolean
+            queueSize:
+              type: integer
+              minimum: 0
+            failedJobs:
+              type: integer
+              minimum: 0
+        error:
+          type: string
+          nullable: true
+
     # ── Error Schemas ─────────────────────────────────────────────────────────
 
     ErrorResponse:
       type: object
-      required: [error]
+      required: [data, error]
       properties:
+        data:
+          nullable: true
+          description: Always null on error
         error:
           type: string
         id:
           type: string
           description: Present on 404 responses that reference a specific resource
+
+    ValidationErrorResponse:
+      type: object
+      required: [data, error, details]
+      description: |
+        Returned for Zod request-schema failures (body, query, or path params).
+        Stable shape — never includes stack traces or internal exception text.
+      properties:
+        data:
+          nullable: true
+          example: null
+        error:
+          type: string
+          enum: [Validation failed]
+          example: Validation failed
+        details:
+          type: array
+          items:
+            type: object
+            required: [field, message]
+            additionalProperties: false
+            properties:
+              field:
+                type: string
+                description: Dotted path to the invalid field, or "(root)"
+                example: walletAddress
+              message:
+                type: string
+                example: walletAddress must be a valid Stellar address
+      additionalProperties: false
 
     RateLimitErrorResponse:
       type: object
@@ -428,21 +521,91 @@ paths:
                 status: ok
                 service: creditra-backend
 
+  # ── Reconciliation Routes ───────────────────────────────────────────────────
+
+  /api/reconciliation/trigger:
+    post:
+      tags: [Reconciliation]
+      operationId: triggerReconciliation
+      summary: Schedule a reconciliation job
+      description: Admin-gated endpoint that schedules a DB-vs-chain reconciliation job and returns immediately.
+      responses:
+        "202":
+          description: Reconciliation job scheduled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconciliationTriggerResponse"
+              example:
+                data:
+                  jobId: "reconciliation-1710000000000"
+                  message: Reconciliation job scheduled
+                error: null
+        "401":
+          description: Missing API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to schedule reconciliation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/reconciliation/status:
+    get:
+      tags: [Reconciliation]
+      operationId: getReconciliationStatus
+      summary: Get reconciliation worker and queue status
+      description: Admin-gated endpoint for dashboards and alerts to inspect worker and queue health.
+      responses:
+        "200":
+          description: Reconciliation status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconciliationStatusResponse"
+              example:
+                data:
+                  workerRunning: true
+                  queueSize: 0
+                  failedJobs: 0
+                error: null
+        "401":
+          description: Missing API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to get reconciliation status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   # ── Credit Lines Routes ─────────────────────────────────────────────────────
 
   /api/credit/lines:
     get:
-      summary: Get Credit Lines
-      description: |
-        Returns all available credit lines with pagination support.
-        
-        Supports two pagination modes:
-        - **Offset-based** (legacy): Use `offset` and `limit` parameters
-        - **Cursor-based** (recommended): Use `cursor` and `limit` parameters
-        
-        Cursor pagination provides stable results for large datasets and is recommended
-        for production use. The response includes a `nextCursor` field that can be used
-        to fetch the next page of results.
+      tags: [Credit]
+      operationId: listCreditLines
+      summary: List all credit lines
+      security: []
       parameters:
         - name: offset
           in: query
@@ -451,9 +614,7 @@ paths:
             type: integer
             minimum: 0
             default: 0
-          description: |
-            Pagination offset (offset-based pagination only).
-            Cannot be used together with `cursor` parameter.
+          description: Pagination offset (offset mode; ignored when `cursor` is present)
         - name: limit
           in: query
           required: false
@@ -462,19 +623,21 @@ paths:
             minimum: 1
             maximum: 100
             default: 100
-          description: Number of credit lines per page (works with both pagination modes)
+          description: Number of credit lines per page (validated by creditLinesQuerySchema)
         - name: cursor
           in: query
           required: false
           schema:
             type: string
           description: |
-            Cursor for pagination (cursor-based pagination).
-            Use the `nextCursor` value from a previous response to fetch the next page.
-            When provided, `offset` parameter is ignored.
+            When present (including empty string), switches to cursor pagination.
+            Pass `nextCursor` from the previous page for subsequent pages.
       responses:
         "200":
-          description: Array of credit lines (may be empty)
+          description: |
+            Offset mode returns `{ data: { creditLines, pagination }, error: null }`.
+            Cursor mode returns an unenveloped `{ creditLines, pagination }` body
+            (see docs/cursor-pagination.md).
           headers:
             X-RateLimit-Limit:
               description: Maximum requests allowed per window
@@ -494,15 +657,21 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/CreditLinesOffsetResponse'
-                  - $ref: '#/components/schemas/CreditLinesCursorResponse'
-        '400':
-          description: Bad Request (Invalid pagination parameters)
+                $ref: "#/components/schemas/CreditLinesResponse"
+              example:
+                data:
+                  creditLines: []
+                  pagination:
+                    total: 0
+                    offset: 0
+                    limit: 100
+                error: null
+        "400":
+          description: Invalid query parameter (Zod validation)
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/ValidationErrorResponse"
         "429":
           description: Rate limit exceeded
           headers:
@@ -634,6 +803,7 @@ paths:
               creditLimit: "1500.00"
               interestRateBps: 640
               status: active
+              expectedVersion: 3
       responses:
         "200":
           description: Credit line updated successfully
@@ -649,6 +819,16 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Credit line not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: >
+            Optimistic-locking conflict. The supplied `expectedVersion` did not
+            match the stored `version`, meaning a concurrent update won the
+            race. Re-read the credit line to get the current `version` and
+            retry the update with it.
           content:
             application/json:
               schema:
@@ -963,221 +1143,204 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: Validation failed
-        "429":
-          description: Rate limit exceeded
+        "413":
+          description: Request body exceeds the 100 kb limit
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RateLimitErrorResponse"
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                data: null
+                error: Request body too large. Maximum size is 100kb.
+        "415":
+          description: Content-Type is not application/json
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                data: null
+                error: Content-Type must be application/json
 
-  /api/reconciliation/trigger:
-    post:
-      summary: Trigger Credit Reconciliation
-      description: |
-        Manually trigger a reconciliation job that compares on-chain Credit contract 
-        records with database credit lines and flags any drift.
-        
-        Requires admin authentication via X-API-Key header.
-      security:
-        - ApiKeyAuth: []
-      responses:
-        '202':
-          description: Reconciliation job scheduled
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      jobId:
-                        type: string
-                        description: Unique identifier for the scheduled job
-                      message:
-                        type: string
-                        example: 'Reconciliation job scheduled'
-                  error:
-                    type: "null"
-        '401':
-          description: Unauthorized (Missing or invalid API key)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
-  /api/reconciliation/status:
+  /api/webhooks/config:
     get:
-      summary: Get Reconciliation Status
-      description: |
-        Returns the current status of the reconciliation worker including:
-        - Whether the worker is running
-        - Number of jobs in the queue
-        - Number of failed jobs
-        
-        Requires admin authentication via X-API-Key header.
-      security:
-        - ApiKeyAuth: []
+      tags: [Webhooks]
+      operationId: getWebhookConfig
+      summary: Get webhook configuration
+      description: Returns the current webhook configuration (excluding sensitive data)
+      security: []
       responses:
-        '200':
-          description: Reconciliation status
+        "200":
+          description: Webhook configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookConfigResponse"
+              example:
+                urls: ["https://example.com/webhook"]
+                maxRetries: 3
+                initialBackoffMs: 1000
+                backoffMultiplier: 2.0
+                timeoutMs: 10000
+                configured: true
+
+  /api/webhooks/test:
+    post:
+      tags: [Webhooks]
+      operationId: testWebhooks
+      summary: Test webhook connectivity
+      description: Sends a test payload to all configured webhook endpoints
+      security: []
+      responses:
+        "200":
+          description: Test results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookTestResponse"
+              example:
+                total: 2
+                reachable: 1
+                unreachable: 1
+                results:
+                  - url: "https://example.com/webhook"
+                    reachable: true
+                  - url: "https://test.com/hook"
+                    reachable: false
+                    error: "Connection refused"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/webhooks/health:
+    get:
+      tags: [Webhooks]
+      operationId: getWebhookHealth
+      summary: Webhook service health check
+      description: Returns the health status of the webhook service
+      security: []
+      responses:
+        "200":
+          description: Webhook service health
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookHealthResponse"
+              example:
+                status: active
+                urls: 2
+                maxRetries: 3
+                timeoutMs: 10000
+
+  /api/risk/evaluations/{id}:
+    get:
+      tags: [Risk]
+      operationId: getRiskEvaluationById
+      summary: Fetch a stored risk evaluation by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Risk evaluation identifier
+      responses:
+        "200":
+          description: Risk evaluation found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluation"
+        "404":
+          description: Risk evaluation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Risk evaluation not found
+                id: "abc123"
+
+  /api/risk/wallet/{walletAddress}/latest:
+    get:
+      tags: [Risk]
+      operationId: getLatestRiskEvaluation
+      summary: Get the latest risk evaluation for a wallet
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^G[A-Z2-7]{55}$'
+          description: Stellar public key
+      responses:
+        "200":
+          description: Risk evaluation found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskEvaluateResponse"
+        "400":
+          description: Invalid wallet address
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No risk evaluation found for wallet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/risk/wallet/{walletAddress}/history:
+    get:
+      tags: [Risk]
+      operationId: getRiskEvaluationHistory
+      summary: Get risk evaluation history for a wallet
+      parameters:
+        - name: walletAddress
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^G[A-Z2-7]{55}$'
+          description: Stellar public key
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: Pagination offset
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          description: Pagination limit
+      responses:
+        "200":
+          description: Array of risk evaluations
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  data:
-                    type: object
-                    properties:
-                      workerRunning:
-                        type: boolean
-                        description: Whether the reconciliation worker is active
-                      queueSize:
-                        type: integer
-                        description: Number of pending jobs in the queue
-                      failedJobs:
-                        type: integer
-                        description: Number of jobs that have failed
-                  error:
-                    type: "null"
-        '401':
-          description: Unauthorized (Missing or invalid API key)
+                  evaluations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RiskEvaluation"
+        "400":
+          description: Invalid parameters
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FailureResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
-components:
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
-      description: API key for admin endpoints
-
-  schemas:
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          description: The payload of the successful response. Varies by endpoint.
-          type: object
-        error:
-          description: Error message. Always null for successful responses.
-          type: "null"
-      required:
-        - data
-        - error
-
-    FailureResponse:
-      type: object
-      properties:
-        data:
-          description: Data payload. Always null for failed responses.
-          type: "null"
-        error:
-          description: The error message detailing what went wrong.
-          type: string
-      required:
-        - data
-        - error
-
-    CreditLine:
-      type: object
-      properties:
-        id:
-          type: string
-          description: Unique identifier for the credit line
-        walletAddress:
-          type: string
-          description: Stellar wallet address
-        creditLimit:
-          type: string
-          description: Maximum credit limit (decimal string)
-        availableCredit:
-          type: string
-          description: Currently available credit (decimal string)
-        interestRateBps:
-          type: integer
-          description: Interest rate in basis points (e.g., 500 = 5%)
-        status:
-          type: string
-          enum: [active, suspended, closed, pending]
-          description: Current status of the credit line
-        createdAt:
-          type: string
-          format: date-time
-          description: Creation timestamp
-        updatedAt:
-          type: string
-          format: date-time
-          description: Last update timestamp
-
-    CreditLinesOffsetResponse:
-      type: object
-      description: Response format for offset-based pagination
-      properties:
-        creditLines:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreditLine'
-        pagination:
-          type: object
-          properties:
-            total:
-              type: integer
-              description: Total number of credit lines
-            offset:
-              type: integer
-              description: Current offset
-            limit:
-              type: integer
-              description: Number of items per page
-          required:
-            - total
-            - offset
-            - limit
-      required:
-        - creditLines
-        - pagination
-
-    CreditLinesCursorResponse:
-      type: object
-      description: Response format for cursor-based pagination
-      properties:
-        creditLines:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreditLine'
-        pagination:
-          type: object
-          properties:
-            limit:
-              type: integer
-              description: Number of items per page
-            nextCursor:
-              type: string
-              nullable: true
-              description: Cursor for the next page (null if no more pages)
-            hasMore:
-              type: boolean
-              description: Whether more results are available
-          required:
-            - limit
-            - nextCursor
-            - hasMore
-      required:
-        - creditLines
-        - pagination
+                $ref: "#/components/schemas/ErrorResponse"

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -58,6 +58,7 @@ export class Container {
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -156,6 +157,10 @@ export class Container {
 
   get reconciliationWorker(): ReconciliationWorker {
     return this._reconciliationWorker;
+  }
+
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
   }
 
   /** Process-wide in-process domain event bus for credit lifecycle events. */

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -2,6 +2,77 @@ import type { Request, Response, NextFunction } from 'express';
 import type { z } from 'zod';
 
 /**
+ * Stable validation error envelope used by every request/response validator.
+ * Never includes stack traces or internal exception text.
+ */
+export interface ValidationIssue {
+  field: string;
+  message: string;
+}
+
+export interface ValidationErrorBody {
+  data: null;
+  error: 'Validation failed';
+  details: ValidationIssue[];
+}
+
+export function toValidationDetails(error: z.ZodError): ValidationIssue[] {
+  return error.issues.map((issue) => ({
+    field: issue.path.length > 0 ? issue.path.join('.') : '(root)',
+    message: issue.message,
+  }));
+}
+
+export function validationFailed(details: ValidationIssue[]): ValidationErrorBody {
+  return {
+    data: null,
+    error: 'Validation failed',
+    details,
+  };
+}
+
+function sendValidationError(res: Response, error: z.ZodError): void {
+  res.status(400).json(validationFailed(toValidationDetails(error)));
+}
+
+/**
+ * True when response bodies should be checked against Zod schemas.
+ * Opt-in via env so production stays fail-open on response shape; enable in
+ * CI / local contract tests with `ENABLE_RESPONSE_VALIDATION=true`.
+ */
+export function isResponseValidationEnabled(): boolean {
+  const flag = process.env.ENABLE_RESPONSE_VALIDATION ?? process.env.RESPONSE_SCHEMA_VALIDATION;
+  if (flag === 'true' || flag === '1') return true;
+  // Default on under NODE_ENV=test when explicitly not disabled.
+  if (process.env.NODE_ENV === 'test' && flag !== 'false' && flag !== '0') {
+    // Soft default: only when RESPONSE_SCHEMA_SOFT is not forcing off.
+    // We keep default OFF for NODE_ENV=test to avoid breaking legacy handlers
+    // that still return non-envelope shapes; tests opt in per-suite.
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Assert `value` matches `schema`. Throws a descriptive Error on mismatch so
+ * integration tests fail loudly when the API drifts from its contract.
+ */
+export function assertMatchesSchema<T>(
+  schema: z.ZodType<T>,
+  value: unknown,
+  label = 'response',
+): T {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    const details = toValidationDetails(result.error)
+      .map((d) => `${d.field}: ${d.message}`)
+      .join('; ');
+    throw new Error(`Schema validation failed for ${label}: ${details}`);
+  }
+  return result.data;
+}
+
+/**
  * Express middleware factory that validates `req.body` against a Zod schema.
  *
  * On success the parsed (and potentially transformed) body replaces `req.body`
@@ -10,6 +81,7 @@ import type { z } from 'zod';
  * On failure a `400` response is returned with structured error details:
  * ```json
  * {
+ *   "data": null,
  *   "error": "Validation failed",
  *   "details": [
  *     { "field": "walletAddress", "message": "Required" }
@@ -22,16 +94,10 @@ export function validateBody<T>(schema: z.ZodType<T>) {
     const result = schema.safeParse(req.body);
 
     if (!result.success) {
-      const details = result.error.issues.map((issue) => ({
-        field: issue.path.join('.'),
-        message: issue.message,
-      }));
-
-      res.status(400).json({ data: null, error: 'Validation failed', details });
+      sendValidationError(res, result.error);
       return;
     }
 
-    // Replace body with the parsed & coerced value
     req.body = result.data;
     next();
   };
@@ -48,12 +114,7 @@ export function validateQuery<T>(schema: z.ZodType<T>) {
     const result = schema.safeParse(req.query);
 
     if (!result.success) {
-      const details = result.error.issues.map((issue) => ({
-        field: issue.path.join('.'),
-        message: issue.message,
-      }));
-
-      res.status(400).json({ data: null, error: 'Validation failed', details });
+      sendValidationError(res, result.error);
       return;
     }
 
@@ -70,16 +131,58 @@ export function validateParams<T>(schema: z.ZodType<T>) {
     const result = schema.safeParse(req.params);
 
     if (!result.success) {
-      const details = result.error.issues.map((issue) => ({
-        field: issue.path.join('.'),
-        message: issue.message,
-      }));
-
-      res.status(400).json({ error: 'Validation failed', details });
+      sendValidationError(res, result.error);
       return;
     }
 
-    req.params = result.data as any;
+    req.params = result.data as Request['params'];
+    next();
+  };
+}
+
+/**
+ * Wraps `res.json` so the outgoing body is checked against `schema` when
+ * response validation is enabled (`ENABLE_RESPONSE_VALIDATION=true`).
+ *
+ * On mismatch:
+ * - Does **not** leak Zod internals to clients in production paths
+ * - Replaces the body with a stable 500 envelope: `{ data: null, error: "Response contract violation" }`
+ * - Attaches a non-enumerable symbol on the response for tests to assert
+ *
+ * When disabled (default), this is a no-op next().
+ */
+export function validateResponse<T>(schema: z.ZodType<T>) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!isResponseValidationEnabled()) {
+      next();
+      return;
+    }
+
+    const originalJson = res.json.bind(res);
+    res.json = ((body: unknown) => {
+      const result = schema.safeParse(body);
+      if (!result.success) {
+        // Keep contract-violation details off the wire; log for operators/tests.
+        const details = toValidationDetails(result.error);
+        // eslint-disable-next-line no-console
+        console.error(
+          `[response-schema] ${req.method} ${req.originalUrl ?? req.url} failed:`,
+          details,
+        );
+        (res as Response & { responseSchemaViolation?: ValidationIssue[] }).responseSchemaViolation =
+          details;
+        if (!res.headersSent) {
+          res.status(500);
+        }
+        return originalJson(
+          validationFailed(details).error
+            ? { data: null, error: 'Response contract violation' }
+            : { data: null, error: 'Response contract violation' },
+        );
+      }
+      return originalJson(body);
+    }) as Response['json'];
+
     next();
   };
 }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -14,9 +14,12 @@ info:
     API keys are configured via the `API_KEYS` environment variable (comma-separated).
 
     ## Keeping the spec in sync
+    - **Zod schemas** in `src/schemas/` are the runtime source of truth for request
+      and response validation. This OpenAPI document should mirror those schemas.
     - Every new route **must** have a corresponding entry here before merging.
     - Run `npm run validate:spec` in CI to catch YAML/structural errors early.
     - Use path-level `operationId` values as the source of truth for client generation.
+    - See `docs/json-schema-validation.md` for request/response validation policy.
 
 servers:
   - url: http://localhost:3000
@@ -80,6 +83,9 @@ components:
 
     UpdateCreditLineRequest:
       type: object
+      description: |
+        Partial update body (updateCreditLineSchema). At least one of the
+        updatable fields must be present. Unknown keys are rejected.
       properties:
         creditLimit:
           type: string
@@ -448,13 +454,46 @@ components:
 
     ErrorResponse:
       type: object
-      required: [error]
+      required: [data, error]
       properties:
+        data:
+          nullable: true
+          description: Always null on error
         error:
           type: string
         id:
           type: string
           description: Present on 404 responses that reference a specific resource
+
+    ValidationErrorResponse:
+      type: object
+      required: [data, error, details]
+      description: |
+        Returned for Zod request-schema failures (body, query, or path params).
+        Stable shape — never includes stack traces or internal exception text.
+      properties:
+        data:
+          nullable: true
+          example: null
+        error:
+          type: string
+          enum: [Validation failed]
+          example: Validation failed
+        details:
+          type: array
+          items:
+            type: object
+            required: [field, message]
+            additionalProperties: false
+            properties:
+              field:
+                type: string
+                description: Dotted path to the invalid field, or "(root)"
+                example: walletAddress
+              message:
+                type: string
+                example: walletAddress must be a valid Stellar address
+      additionalProperties: false
 
     RateLimitErrorResponse:
       type: object
@@ -575,7 +614,7 @@ paths:
             type: integer
             minimum: 0
             default: 0
-          description: Pagination offset
+          description: Pagination offset (offset mode; ignored when `cursor` is present)
         - name: limit
           in: query
           required: false
@@ -584,10 +623,21 @@ paths:
             minimum: 1
             maximum: 100
             default: 100
-          description: Number of credit lines per page
+          description: Number of credit lines per page (validated by creditLinesQuerySchema)
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |
+            When present (including empty string), switches to cursor pagination.
+            Pass `nextCursor` from the previous page for subsequent pages.
       responses:
         "200":
-          description: Array of credit lines (may be empty)
+          description: |
+            Offset mode returns `{ data: { creditLines, pagination }, error: null }`.
+            Cursor mode returns an unenveloped `{ creditLines, pagination }` body
+            (see docs/cursor-pagination.md).
           headers:
             X-RateLimit-Limit:
               description: Maximum requests allowed per window
@@ -609,17 +659,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/CreditLinesResponse"
               example:
-                creditLines: []
-                pagination:
-                  total: 0
-                  offset: 0
-                  limit: 100
+                data:
+                  creditLines: []
+                  pagination:
+                    total: 0
+                    offset: 0
+                    limit: 100
+                error: null
         "400":
-          description: Invalid query parameter
+          description: Invalid query parameter (Zod validation)
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/ValidationErrorResponse"
         "429":
           description: Rate limit exceeded
           headers:

--- a/src/routes/__tests__/credit.test.ts
+++ b/src/routes/__tests__/credit.test.ts
@@ -67,24 +67,27 @@ describe('Credit Routes', () => {
       const response = await request(app)
         .get('/api/credit/lines?offset=-1')
         .expect(400);
-      expect(response.body.error).toBe('Offset cannot be negative');
+      expect(response.body.error).toBe('Validation failed');
       expect(response.body.data).toBeNull();
+      expect(response.body.details.some((d: { field: string }) => d.field === 'offset')).toBe(true);
     });
 
     it('should return 400 for zero limit', async () => {
       const response = await request(app)
         .get('/api/credit/lines?limit=0')
         .expect(400);
-      expect(response.body.error).toBe('Limit must be greater than 0');
+      expect(response.body.error).toBe('Validation failed');
       expect(response.body.data).toBeNull();
+      expect(response.body.details.some((d: { field: string }) => d.field === 'limit')).toBe(true);
     });
 
     it('should return 400 for oversized limit', async () => {
       const response = await request(app)
         .get('/api/credit/lines?limit=101')
         .expect(400);
-      expect(response.body.error).toBe('Limit cannot exceed 100');
+      expect(response.body.error).toBe('Validation failed');
       expect(response.body.data).toBeNull();
+      expect(response.body.details.some((d: { field: string }) => d.field === 'limit')).toBe(true);
     });
 
     it('should handle server errors gracefully', async () => {
@@ -176,7 +179,8 @@ describe('Credit Routes', () => {
         .get('/api/credit/lines?cursor&limit=0')
         .expect(400);
 
-      expect(response.body.error).toBe('Limit must be greater than 0');
+      expect(response.body.error).toBe('Validation failed');
+      expect(response.body.details.some((d: { field: string }) => d.field === 'limit')).toBe(true);
     });
 
     it('should handle cursor with oversized limit error', async () => {
@@ -184,7 +188,8 @@ describe('Credit Routes', () => {
         .get('/api/credit/lines?cursor&limit=101')
         .expect(400);
 
-      expect(response.body.error).toBe('Limit cannot exceed 100');
+      expect(response.body.error).toBe('Validation failed');
+      expect(response.body.details.some((d: { field: string }) => d.field === 'limit')).toBe(true);
     });
 
     it('should return empty result with cursor when no items exist', async () => {
@@ -395,8 +400,13 @@ describe('Credit Routes', () => {
         })
         .expect(400);
 
-      expect(response.body.error).toBe('Credit limit must be greater than 0');
+      expect(response.body.error).toBe('Validation failed');
       expect(response.body.data).toBeNull();
+      expect(
+        response.body.details.some((d: { message: string }) =>
+          d.message.includes('greater than 0'),
+        ),
+      ).toBe(true);
     });
 
     it('should handle service errors with generic message', async () => {
@@ -517,8 +527,9 @@ describe('Credit Routes', () => {
     });
 
     it('should return empty array when no credit lines found for wallet', async () => {
+      const emptyWallet = 'G' + 'B'.repeat(55);
       const response = await request(app)
-        .get('/api/credit/wallet/GBAHQCUPC7G2B4D2F2I2K2M2O2Q2W2Y2A2C2E2G2I2K2M2O2Q2S5/lines')
+        .get(`/api/credit/wallet/${emptyWallet}/lines`)
         .expect(200);
 
       expect(response.body.data.creditLines).toEqual([]);
@@ -538,8 +549,9 @@ describe('Credit Routes', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (container as any)._creditLineService = mockService;
 
+      const validWallet = 'G' + 'C'.repeat(55);
       const response = await request(app)
-        .get('/api/credit/wallet/GBAHQCUPC7G2B4D2F2I2K2M2O2Q2W2Y2A2C2E2G2I2K2M2O2Q2S6/lines')
+        .get(`/api/credit/wallet/${validWallet}/lines`)
         .expect(500);
 
       expect(response.body.error).toBe('Internal server error');
@@ -548,6 +560,18 @@ describe('Credit Routes', () => {
       // Restore original service
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (container as any)._creditLineService = originalService;
+    });
+
+    it('should reject invalid wallet path params with validation envelope', async () => {
+      const response = await request(app)
+        .get('/api/credit/wallet/not-a-stellar-address/lines')
+        .expect(400);
+
+      expect(response.body.error).toBe('Validation failed');
+      expect(response.body.data).toBeNull();
+      expect(response.body.details.some((d: { field: string }) => d.field === 'walletAddress')).toBe(
+        true,
+      );
     });
   });
 });

--- a/src/routes/__tests__/risk.test.ts
+++ b/src/routes/__tests__/risk.test.ts
@@ -262,14 +262,26 @@ describe('Risk Routes', () => {
     });
 
     it('returns 404 for missing latest evaluation', async () => {
+      const missingWallet = 'G' + 'D'.repeat(55);
+      const response = await invokeRoute({
+        method: 'get',
+        path: '/wallet/:walletAddress/latest',
+        params: { walletAddress: missingWallet },
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ data: null, error: 'No risk evaluation found for wallet' });
+    });
+
+    it('returns 400 for invalid wallet path param on latest', async () => {
       const response = await invokeRoute({
         method: 'get',
         path: '/wallet/:walletAddress/latest',
         params: { walletAddress: 'missing' },
       });
 
-      expect(response.status).toBe(404);
-      expect(response.body).toEqual({ data: null, error: 'No risk evaluation found for wallet' });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Validation failed');
     });
 
     it('returns 500 when latest evaluation fetch throws', async () => {

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -16,25 +16,33 @@
 import { Router, type Request, type Response } from 'express';
 import { adminAuth } from '../middleware/adminAuth.js';
 import { defaultApiKeyStore } from '../services/apiKeyStore.js';
+import { validateBody, validateParams } from '../middleware/validate.js';
+import { issueApiKeySchema, idParamSchema } from '../schemas/index.js';
+import type { IssueApiKeyBody } from '../schemas/index.js';
 
 export const apiKeysRouter = Router();
 
 /** POST /api/admin/api-keys — issue a new key (returns plaintext once). */
-apiKeysRouter.post('/', adminAuth, (req: Request, res: Response) => {
-  const label = typeof req.body?.label === 'string' && req.body.label.trim()
-    ? req.body.label.trim()
-    : 'unlabelled';
-  const { id, plaintext, metadata } = defaultApiKeyStore.issue(label);
-  res.status(201).json({
-    data: {
-      id,
-      // Surfaced exactly once — clients must store it now.
-      key: plaintext,
-      metadata,
-    },
-    error: null,
-  });
-});
+apiKeysRouter.post(
+  '/',
+  adminAuth,
+  validateBody(issueApiKeySchema),
+  (req: Request, res: Response) => {
+    const body = req.body as IssueApiKeyBody;
+    const label =
+      typeof body.label === 'string' && body.label.trim() ? body.label.trim() : 'unlabelled';
+    const { id, plaintext, metadata } = defaultApiKeyStore.issue(label);
+    res.status(201).json({
+      data: {
+        id,
+        // Surfaced exactly once — clients must store it now.
+        key: plaintext,
+        metadata,
+      },
+      error: null,
+    });
+  },
+);
 
 /** GET /api/admin/api-keys — list metadata (never secrets). */
 apiKeysRouter.get('/', adminAuth, (_req: Request, res: Response) => {
@@ -47,11 +55,16 @@ apiKeysRouter.get('/audit', adminAuth, (_req: Request, res: Response) => {
 });
 
 /** DELETE /api/admin/api-keys/:id — revoke (enters grace period). */
-apiKeysRouter.delete('/:id', adminAuth, (req: Request, res: Response) => {
-  const ok = defaultApiKeyStore.revoke(req.params.id);
-  if (!ok) {
-    res.status(404).json({ data: null, error: 'API key not found' });
-    return;
-  }
-  res.json({ data: { id: req.params.id, status: 'revoked' }, error: null });
-});
+apiKeysRouter.delete(
+  '/:id',
+  adminAuth,
+  validateParams(idParamSchema),
+  (req: Request, res: Response) => {
+    const ok = defaultApiKeyStore.revoke(req.params.id);
+    if (!ok) {
+      res.status(404).json({ data: null, error: 'API key not found' });
+      return;
+    }
+    res.json({ data: { id: req.params.id, status: 'revoked' }, error: null });
+  },
+);

--- a/src/routes/credit.ts
+++ b/src/routes/credit.ts
@@ -21,15 +21,38 @@
  *
  * Successful responses use the shared envelope helpers `ok()` / `fail()`
  * from `src/utils/response.ts` so every body looks like `{ data, error }`.
+ *
+ * Request inputs are validated by Zod middleware (`validateBody|Query|Params`).
+ * Response shapes are checked when `ENABLE_RESPONSE_VALIDATION=true`.
  */
 import { Router, type Request, type Response } from 'express';
-import { validateBody } from '../middleware/validate.js';
+import {
+  validateBody,
+  validateParams,
+  validateQuery,
+  validateResponse,
+} from '../middleware/validate.js';
 import {
   createCreditLineSchema,
+  creditLinesQuerySchema,
+  updateCreditLineSchema,
   drawSchema,
   repaySchema,
+  transactionHistoryQuerySchema,
+  idParamSchema,
+  walletAddressParamSchema,
+  envelopedCreditLineSchema,
+  envelopedCreditLinesListSchema,
+  creditLinesCursorDataSchema,
+  envelopedWalletCreditLinesSchema,
+  envelopedTransactionHistorySchema,
+  drawRepayResultSchema,
+  type CreditLinesQuery,
+  type DrawBody,
+  type RepayBody,
+  type TransactionHistoryQuery,
+  type UpdateCreditLineBody,
 } from '../schemas/index.js';
-import type { DrawBody, RepayBody } from '../schemas/index.js';
 import { Container } from '../container/Container.js';
 import { adminAuth } from '../middleware/adminAuth.js';
 import { ok, fail } from '../utils/response.js';
@@ -48,18 +71,8 @@ import {
 export const creditRouter = Router();
 const container = Container.getInstance();
 
-const VALID_TRANSACTION_TYPES = Object.values(TransactionType);
-
 /**
  * Maps a thrown service-layer error to an HTTP status + envelope.
- *
- * - {@link CreditLineNotFoundError} → 404
- * - {@link InvalidTransitionError}  → 409
- * - anything else                   → 500 with the error message
- *
- * Keeping this in one place means every credit-line endpoint produces a
- * consistent error envelope without each handler reimplementing the
- * mapping.
  */
 function handleServiceError(err: unknown, res: Response): void {
   if (err instanceof CreditLineNotFoundError) {
@@ -75,164 +88,192 @@ function handleServiceError(err: unknown, res: Response): void {
     return;
   }
   const message = err instanceof Error ? err.message : 'Internal server error';
-  res.status(500).json({ error: message });
+  res.status(500).json({ data: null, error: message });
 }
 
-function parseIntegerQuery(value: unknown, defaultValue: number): number {
-  if (value === undefined || value === '') {
-    return defaultValue;
-  }
-  return Number.parseInt(String(value), 10);
-}
+creditRouter.get(
+  '/lines',
+  validateQuery(creditLinesQuerySchema),
+  // Response schema depends on pagination mode; cursor mode is unenveloped.
+  async (req, res) => {
+    const query = req.query as unknown as CreditLinesQuery;
+    const limit = query.limit ?? 100;
 
-creditRouter.get('/lines', async (req, res) => {
-  const limit = parseIntegerQuery(req.query.limit, 100);
-
-  try {
-    if ('cursor' in req.query) {
-      const cursorValue = req.query.cursor;
-      const cursor = typeof cursorValue === 'string' && cursorValue.length > 0
-        ? cursorValue
-        : undefined;
-      const result = await container.creditLineService.getAllCreditLinesWithCursor(cursor, limit);
-
-      return res.json({
-        creditLines: result.items,
-        pagination: {
+    try {
+      // Presence of `cursor` (including empty string) selects cursor pagination.
+      if (query.cursor !== undefined) {
+        const cursor =
+          typeof query.cursor === 'string' && query.cursor.length > 0
+            ? query.cursor
+            : undefined;
+        const result = await container.creditLineService.getAllCreditLinesWithCursor(
+          cursor,
           limit,
-          nextCursor: result.nextCursor,
-          hasMore: result.hasMore,
-        },
+        );
+
+        const body = {
+          creditLines: result.items,
+          pagination: {
+            limit,
+            nextCursor: result.nextCursor,
+            hasMore: result.hasMore,
+          },
+        };
+
+        // Optional response contract check (cursor mode is not enveloped).
+        if (process.env.ENABLE_RESPONSE_VALIDATION === 'true') {
+          const parsed = creditLinesCursorDataSchema.safeParse(body);
+          if (!parsed.success) {
+            return res.status(500).json({ data: null, error: 'Response contract violation' });
+          }
+        }
+
+        return res.json(body);
+      }
+
+      const offset = query.offset ?? 0;
+      const creditLines = await container.creditLineService.getAllCreditLines(offset, limit);
+      const total = await container.creditLineService.getCreditLineCount();
+
+      // Envelope success path — validate when enabled via middleware-equivalent check.
+      const payload = {
+        creditLines,
+        pagination: { total, offset, limit },
+      };
+
+      if (process.env.ENABLE_RESPONSE_VALIDATION === 'true') {
+        const parsed = envelopedCreditLinesListSchema.safeParse({ data: payload, error: null });
+        if (!parsed.success) {
+          return res.status(500).json({ data: null, error: 'Response contract violation' });
+        }
+      }
+
+      return ok(res, payload);
+    } catch (error) {
+      return fail(res, error instanceof Error ? error : undefined, 400);
+    }
+  },
+);
+
+creditRouter.get(
+  '/lines/:id',
+  validateParams(idParamSchema),
+  validateResponse(envelopedCreditLineSchema),
+  async (req, res) => {
+    try {
+      const line = await container.creditLineService.getCreditLine(req.params.id);
+      if (!line) {
+        return fail(res, 'Credit line not found', 404);
+      }
+      return ok(res, line);
+    } catch {
+      return fail(res, 'Internal server error');
+    }
+  },
+);
+
+creditRouter.post(
+  '/lines',
+  validateBody(createCreditLineSchema),
+  validateResponse(envelopedCreditLineSchema),
+  async (req, res) => {
+    try {
+      const { walletAddress, creditLimit, requestedLimit, interestRateBps } = req.body ?? {};
+      const finalLimit = creditLimit ?? requestedLimit;
+      const creditLine = await container.creditLineService.createCreditLine({
+        walletAddress,
+        creditLimit: finalLimit,
+        interestRateBps: interestRateBps ?? 0,
       });
+      // Keep the dashboard read model correct on mutation (not just TTL-fresh).
+      container.dashboardSummaryService.invalidate();
+      return ok(res, creditLine, 201);
+    } catch (error) {
+      return fail(res, error instanceof Error ? error : undefined, 400);
     }
+  },
+);
 
-    const offset = parseIntegerQuery(req.query.offset, 0);
-    const creditLines = await container.creditLineService.getAllCreditLines(offset, limit);
-    const total = await container.creditLineService.getCreditLineCount();
-
-    return ok(res, {
-      creditLines,
-      pagination: { total, offset, limit },
-    });
-  } catch (error) {
-    return fail(res, error instanceof Error ? error : undefined, 400);
-  }
-});
-
-creditRouter.get('/lines/:id', async (req, res) => {
-  try {
-    const line = await container.creditLineService.getCreditLine(req.params.id);
-    if (!line) {
-      return fail(res, 'Credit line not found', 404);
+creditRouter.put(
+  '/lines/:id',
+  validateParams(idParamSchema),
+  validateBody(updateCreditLineSchema),
+  validateResponse(envelopedCreditLineSchema),
+  async (req, res) => {
+    try {
+      const body = req.body as UpdateCreditLineBody;
+      const creditLine = await container.creditLineService.updateCreditLine(req.params.id, {
+        creditLimit: body.creditLimit,
+        interestRateBps: body.interestRateBps,
+        status: body.status as never,
+        expectedVersion: body.expectedVersion,
+      });
+      if (!creditLine) {
+        return fail(res, 'Credit line not found', 404);
+      }
+      container.dashboardSummaryService.invalidate();
+      return ok(res, creditLine);
+    } catch (error) {
+      // Optimistic-locking conflicts surface as 409; other validation as 400.
+      if (error instanceof VersionConflictError) {
+        return handleServiceError(error, res);
+      }
+      return fail(res, error instanceof Error ? error : undefined, 400);
     }
-    return ok(res, line);
-  } catch {
-    return fail(res, 'Internal server error');
-  }
-});
+  },
+);
 
-creditRouter.post('/lines', validateBody(createCreditLineSchema), async (req, res) => {
-  try {
-    const { walletAddress, creditLimit, requestedLimit, interestRateBps } = req.body ?? {};
-    const finalLimit = creditLimit ?? requestedLimit;
-    const creditLine = await container.creditLineService.createCreditLine({
-      walletAddress,
-      creditLimit: finalLimit,
-      interestRateBps: interestRateBps ?? 0,
-    });
-    // Keep the dashboard read model correct on mutation (not just TTL-fresh).
-    container.dashboardSummaryService.invalidate();
-    return ok(res, creditLine, 201);
-  } catch (error) {
-    return fail(res, error instanceof Error ? error : undefined, 400);
-  }
-});
-
-creditRouter.put('/lines/:id', async (req, res) => {
-  try {
-    const { creditLimit, interestRateBps, status, expectedVersion } = req.body;
-    const creditLine = await container.creditLineService.updateCreditLine(req.params.id, {
-      creditLimit,
-      interestRateBps,
-      status,
-      expectedVersion,
-    });
-    if (!creditLine) {
-      return fail(res, 'Credit line not found', 404);
+creditRouter.delete(
+  '/lines/:id',
+  validateParams(idParamSchema),
+  async (req, res) => {
+    try {
+      const deleted = await container.creditLineService.deleteCreditLine(req.params.id);
+      if (!deleted) {
+        return fail(res, 'Credit line not found', 404);
+      }
+      container.dashboardSummaryService.invalidate();
+      return res.status(204).send();
+    } catch {
+      return fail(res, 'Internal server error');
     }
-    container.dashboardSummaryService.invalidate();
-    return ok(res, creditLine);
-  } catch (error) {
-    // Optimistic-locking conflicts surface as 409; other validation as 400.
-    if (error instanceof VersionConflictError) {
-      return handleServiceError(error, res);
-    }
-    return fail(res, error instanceof Error ? error : undefined, 400);
-  }
-});
-
-creditRouter.delete('/lines/:id', async (req, res) => {
-  try {
-    const deleted = await container.creditLineService.deleteCreditLine(req.params.id);
-    if (!deleted) {
-      return fail(res, 'Credit line not found', 404);
-    }
-    container.dashboardSummaryService.invalidate();
-    return res.status(204).send();
-  } catch {
-    return fail(res, 'Internal server error');
-  }
-});
+  },
+);
 
 creditRouter.get(
   '/wallet/:walletAddress/lines',
+  validateParams(walletAddressParamSchema),
+  validateResponse(envelopedWalletCreditLinesSchema),
   async (req, res) => {
-  try {
-    const lines = await container.creditLineService.getCreditLinesByWallet(
-      req.params.walletAddress,
-    );
-    ok(res, { creditLines: lines });
-  } catch {
-    fail(res, 'Internal server error');
-  }
-});
+    try {
+      const lines = await container.creditLineService.getCreditLinesByWallet(
+        req.params.walletAddress,
+      );
+      ok(res, { creditLines: lines });
+    } catch {
+      fail(res, 'Internal server error');
+    }
+  },
+);
 
 creditRouter.get(
   '/lines/:id/transactions',
+  validateParams(idParamSchema),
+  validateQuery(transactionHistoryQuerySchema),
+  validateResponse(envelopedTransactionHistorySchema),
   async (req: Request, res: Response): Promise<void> => {
     const id = req.params.id;
-    const { type, from, to, page: pageParam, limit: limitParam } = req.query;
-
-    if (type !== undefined && !VALID_TRANSACTION_TYPES.includes(type as TransactionType)) {
-      fail(res, `Invalid type filter. Must be one of: ${VALID_TRANSACTION_TYPES.join(', ')}.`, 400);
-      return;
-    }
-    if (from !== undefined && isNaN(new Date(from as string).getTime())) {
-      fail(res, "Invalid 'from' date. Must be a valid ISO 8601 date.", 400);
-      return;
-    }
-    if (to !== undefined && isNaN(new Date(to as string).getTime())) {
-      fail(res, "Invalid 'to' date. Must be a valid ISO 8601 date.", 400);
-      return;
-    }
-
-    const page = pageParam !== undefined ? parseInt(pageParam as string, 10) : 1;
-    const limit = limitParam !== undefined ? parseInt(limitParam as string, 10) : 20;
-
-    if (isNaN(page) || page < 1) {
-      fail(res, "Invalid 'page'. Must be a positive integer.", 400);
-      return;
-    }
-    if (isNaN(limit) || limit < 1 || limit > 100) {
-      fail(res, "Invalid 'limit'. Must be between 1 and 100.", 400);
-      return;
-    }
+    const { type, from, to, page, limit } = req.query as unknown as TransactionHistoryQuery;
 
     try {
       const result = getTransactions(
         id,
-        { type: type as TransactionType | undefined, from: from as string | undefined, to: to as string | undefined },
-        { page, limit },
+        {
+          type: type as TransactionType | undefined,
+          from: from as string | undefined,
+          to: to as string | undefined,
+        },
+        { page: page ?? 1, limit: limit ?? 20 },
       );
       ok(res, result);
     } catch (err) {
@@ -244,6 +285,7 @@ creditRouter.get(
 creditRouter.post(
   '/lines/:id/suspend',
   adminAuth,
+  validateParams(idParamSchema),
   (req: Request, res: Response): void => {
     try {
       const line = suspendCreditLine(req.params.id);
@@ -257,6 +299,7 @@ creditRouter.post(
 creditRouter.post(
   '/lines/:id/close',
   adminAuth,
+  validateParams(idParamSchema),
   (req: Request, res: Response): void => {
     try {
       const line = closeCreditLine(req.params.id);
@@ -267,22 +310,34 @@ creditRouter.post(
   },
 );
 
-creditRouter.post('/lines/:id/draw', validateBody(drawSchema), async (req, res, next) => {
-  try {
-    const result = await submitDrawRequest(req.params.id, req.body as DrawBody);
-    res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
+creditRouter.post(
+  '/lines/:id/draw',
+  validateParams(idParamSchema),
+  validateBody(drawSchema),
+  validateResponse(drawRepayResultSchema),
+  async (req, res, next) => {
+    try {
+      const result = await submitDrawRequest(req.params.id, req.body as DrawBody);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
-creditRouter.post('/lines/:id/repay', validateBody(repaySchema), async (req, res, next) => {
-  try {
-    const result = await submitRepayRequest(req.params.id, req.body as RepayBody);
-    res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
+creditRouter.post(
+  '/lines/:id/repay',
+  validateParams(idParamSchema),
+  validateBody(repaySchema),
+  validateResponse(drawRepayResultSchema),
+  async (req, res, next) => {
+    try {
+      const result = await submitRepayRequest(req.params.id, req.body as RepayBody);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 export default creditRouter;

--- a/src/routes/creditBulk.ts
+++ b/src/routes/creditBulk.ts
@@ -6,15 +6,17 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { createCreditLineSchema } from '../schemas/index.js';
-import type { CreateCreditLineBody } from '../schemas/index.js';
-import { ok } from '../utils/response.js';
+import {
+  createCreditLineSchema,
+  bulkCreditLinesSchema,
+  bulkCreditLinesQuerySchema,
+} from '../schemas/index.js';
+import type { CreateCreditLineBody, BulkCreditLinesQuery } from '../schemas/index.js';
+import { validateBody, validateQuery } from '../middleware/validate.js';
 import { Container } from '../container/Container.js';
 
 export const creditBulkRouter = Router();
 const container = Container.getInstance();
-
-const MAX_ROWS = 200;
 
 interface BulkRowResult {
   index: number;
@@ -23,51 +25,64 @@ interface BulkRowResult {
   error?: string;
 }
 
-creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) => {
-  try {
-    const isDryRun = req.query['dry_run'] === 'true';
-    const rows: unknown[] = Array.isArray(req.body?.rows) ? req.body.rows : [];
+creditBulkRouter.post(
+  '/lines/bulk',
+  validateQuery(bulkCreditLinesQuerySchema),
+  validateBody(bulkCreditLinesSchema),
+  async (req: Request, res: Response, next) => {
+    try {
+      const query = req.query as unknown as BulkCreditLinesQuery;
+      const isDryRun = query.dry_run === true;
+      const rows: unknown[] = req.body.rows as unknown[];
 
-    if (rows.length === 0) {
-      return res.status(400).json({ error: { code: 'MISSING_ROWS', message: 'rows array is required and must not be empty' } });
-    }
-    if (rows.length > MAX_ROWS) {
-      return res.status(400).json({ error: { code: 'TOO_MANY_ROWS', message: `Maximum ${MAX_ROWS} rows per request` } });
-    }
+      const results: BulkRowResult[] = [];
+      let created = 0;
+      let failed = 0;
 
-    const results: BulkRowResult[] = [];
-    let created = 0;
-    let failed = 0;
+      for (let i = 0; i < rows.length; i++) {
+        const parsed = createCreditLineSchema.safeParse(rows[i]);
+        if (!parsed.success) {
+          results.push({
+            index: i + 1,
+            status: 'error',
+            error: parsed.error.issues.map((e) => e.message).join('; '),
+          });
+          failed++;
+          continue;
+        }
 
-    for (let i = 0; i < rows.length; i++) {
-      const parsed = createCreditLineSchema.safeParse(rows[i]);
-      if (!parsed.success) {
-        results.push({ index: i + 1, status: 'error', error: parsed.error.issues.map(e => e.message).join('; ') });
-        failed++;
-        continue;
+        if (isDryRun) {
+          results.push({ index: i + 1, status: 'dry_run_valid' });
+          created++;
+          continue;
+        }
+
+        try {
+          const creditService = container.getCreditService();
+          const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
+          results.push({ index: i + 1, status: 'created', id: line.id });
+          created++;
+        } catch (err) {
+          results.push({
+            index: i + 1,
+            status: 'error',
+            error: err instanceof Error ? err.message : 'Unknown error',
+          });
+          failed++;
+        }
       }
 
-      if (isDryRun) {
-        results.push({ index: i + 1, status: 'dry_run_valid' });
-        created++;
-        continue;
-      }
-
-      try {
-        const creditService = container.getCreditService();
-        const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
-        results.push({ index: i + 1, status: 'created', id: line.id });
-        created++;
-      } catch (err) {
-        results.push({ index: i + 1, status: 'error', error: err instanceof Error ? err.message : 'Unknown error' });
-        failed++;
-      }
+      return res.status(207).json({
+        data: {
+          summary: { total: rows.length, created, failed, dry_run: isDryRun },
+          results,
+        },
+        error: null,
+      });
+    } catch (err) {
+      next(err);
     }
-
-    return res.status(207).json(ok({ summary: { total: rows.length, created, failed, dry_run: isDryRun }, results }));
-  } catch (err) {
-    next(err);
-  }
-});
+  },
+);
 
 export default creditBulkRouter;

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -20,6 +20,8 @@ import { Router } from 'express';
 import { ok } from '../utils/response.js';
 import { getConnection } from '../db/client.js';
 import { resolveConfig } from '../services/horizonListener.js';
+import { validateResponse } from '../middleware/validate.js';
+import { envelopedHealthSchema } from '../schemas/index.js';
 
 export const healthRouter = Router();
 
@@ -109,7 +111,7 @@ async function checkHorizon(): Promise<DependencyHealth> {
      }
 }
 
-healthRouter.get('/', async (_req, res) => {
+healthRouter.get('/', validateResponse(envelopedHealthSchema), async (_req, res) => {
      const [dbStatus, horizonStatus] = await Promise.all([checkDatabase(), checkHorizon()]);
      const ready = dbStatus.status === 'ok' && horizonStatus.status === 'ok';
 

--- a/src/routes/maintenance.ts
+++ b/src/routes/maintenance.ts
@@ -1,10 +1,13 @@
 import { Router } from 'express';
 import { adminAuth } from '../middleware/adminAuth.js';
 import {
-    isMaintenanceModeEnabled,
-    setMaintenanceMode,
-    getAuditLog,
+  isMaintenanceModeEnabled,
+  setMaintenanceMode,
+  getAuditLog,
 } from '../middleware/maintenanceMode.js';
+import { validateBody } from '../middleware/validate.js';
+import { maintenanceToggleSchema } from '../schemas/index.js';
+import type { MaintenanceToggleBody } from '../schemas/index.js';
 
 export const maintenanceRouter = Router();
 
@@ -14,10 +17,10 @@ export const maintenanceRouter = Router();
  * Requires admin authentication.
  */
 maintenanceRouter.get('/', adminAuth, (_req, res) => {
-    res.json({
-        maintenanceMode: isMaintenanceModeEnabled(),
-        auditLog: getAuditLog(),
-    });
+  res.json({
+    maintenanceMode: isMaintenanceModeEnabled(),
+    auditLog: getAuditLog(),
+  });
 });
 
 /**
@@ -26,23 +29,23 @@ maintenanceRouter.get('/', adminAuth, (_req, res) => {
  * Toggles maintenance mode on or off.
  * Requires admin authentication.
  */
-maintenanceRouter.post('/', adminAuth, (req, res) => {
-    const { enabled } = req.body as { enabled?: unknown };
-
-    if (typeof enabled !== 'boolean') {
-        res.status(400).json({ error: 'Bad Request', message: '"enabled" must be a boolean.' });
-        return;
-    }
+maintenanceRouter.post(
+  '/',
+  adminAuth,
+  validateBody(maintenanceToggleSchema),
+  (req, res) => {
+    const { enabled } = req.body as MaintenanceToggleBody;
 
     const actor =
-        (Array.isArray(req.headers['x-admin-api-key'])
-            ? req.headers['x-admin-api-key'][0]
-            : req.headers['x-admin-api-key']) ?? 'unknown';
+      (Array.isArray(req.headers['x-admin-api-key'])
+        ? req.headers['x-admin-api-key'][0]
+        : req.headers['x-admin-api-key']) ?? 'unknown';
 
     setMaintenanceMode(enabled, actor);
 
     res.json({
-        maintenanceMode: isMaintenanceModeEnabled(),
-        message: `Maintenance mode ${enabled ? 'enabled' : 'disabled'}.`,
+      maintenanceMode: isMaintenanceModeEnabled(),
+      message: `Maintenance mode ${enabled ? 'enabled' : 'disabled'}.`,
     });
-});
+  },
+);

--- a/src/routes/reconciliation.ts
+++ b/src/routes/reconciliation.ts
@@ -9,11 +9,18 @@
  *   returns the job id immediately (`202 Accepted`).
  * - GET  `/status`  — exposes `{ workerRunning, queueSize, failedJobs }`
  *   so dashboards can alert on stuck queues or non-zero failure counts.
+ *
+ * Response bodies are validated when `ENABLE_RESPONSE_VALIDATION=true`.
  */
 import { Router, type Request, type Response } from 'express';
 import { Container } from '../container/Container.js';
 import { createApiKeyMiddleware } from '../middleware/auth.js';
 import { loadApiKeys } from '../config/apiKeys.js';
+import { validateResponse } from '../middleware/validate.js';
+import {
+  envelopedReconciliationTriggerSchema,
+  envelopedReconciliationStatusSchema,
+} from '../schemas/index.js';
 
 export const reconciliationRouter = Router();
 
@@ -24,49 +31,60 @@ const requireApiKey = createApiKeyMiddleware(() => loadApiKeys());
  * POST /api/reconciliation/trigger
  * Manually trigger a reconciliation job (admin only)
  */
-reconciliationRouter.post('/trigger', requireApiKey, (req: Request, res: Response) => {
-  try {
-    const jobId = container.reconciliationService.scheduleReconciliation();
-    
-    res.status(202).json({
-      data: {
-        jobId,
-        message: 'Reconciliation job scheduled',
-      },
-      error: null,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to schedule reconciliation';
-    res.status(500).json({
-      data: null,
-      error: message,
-    });
-  }
-});
+reconciliationRouter.post(
+  '/trigger',
+  requireApiKey,
+  validateResponse(envelopedReconciliationTriggerSchema),
+  (req: Request, res: Response) => {
+    try {
+      const jobId = container.reconciliationService.scheduleReconciliation();
+
+      res.status(202).json({
+        data: {
+          jobId,
+          message: 'Reconciliation job scheduled',
+        },
+        error: null,
+      });
+    } catch (error) {
+      // Stable envelope; avoid leaking stack / SQL details.
+      res.status(500).json({
+        data: null,
+        error: 'Failed to schedule reconciliation',
+      });
+      void error;
+    }
+  },
+);
 
 /**
  * GET /api/reconciliation/status
  * Get reconciliation worker status (admin only)
  */
-reconciliationRouter.get('/status', requireApiKey, (req: Request, res: Response) => {
-  try {
-    const isRunning = container.reconciliationWorker.isRunning();
-    
-    res.json({
-      data: {
-        workerRunning: isRunning,
-        queueSize: container.reconciliationService['jobQueue'].size(),
-        failedJobs: container.reconciliationService['jobQueue'].getFailedJobs().length,
-      },
-      error: null,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to get status';
-    res.status(500).json({
-      data: null,
-      error: message,
-    });
-  }
-});
+reconciliationRouter.get(
+  '/status',
+  requireApiKey,
+  validateResponse(envelopedReconciliationStatusSchema),
+  (req: Request, res: Response) => {
+    try {
+      const isRunning = container.reconciliationWorker.isRunning();
+
+      res.json({
+        data: {
+          workerRunning: isRunning,
+          queueSize: container.reconciliationService['jobQueue'].size(),
+          failedJobs: container.reconciliationService['jobQueue'].getFailedJobs().length,
+        },
+        error: null,
+      });
+    } catch (error) {
+      res.status(500).json({
+        data: null,
+        error: 'Failed to get status',
+      });
+      void error;
+    }
+  },
+);
 
 export default reconciliationRouter;

--- a/src/routes/risk.ts
+++ b/src/routes/risk.ts
@@ -9,19 +9,28 @@
  * - GET  `/wallet/:walletAddress/history`     — paginated history.
  * - POST `/admin/recalibrate`                 — protected by `X-API-Key`.
  *
- * Wallet path params are passed through to the risk service so missing
- * evaluations can return domain 404s. The provider behind these routes is
- * pluggable — see `RISK_PROVIDER` and `src/services/providers/`.
+ * Wallet path params are validated by Zod (`walletAddressParamSchema`).
+ * Response validation is opt-in via `ENABLE_RESPONSE_VALIDATION=true`.
  */
 import { Router, type Request, type Response } from 'express';
 import { createApiKeyMiddleware } from '../middleware/auth.js';
 import { loadApiKeys } from '../config/apiKeys.js';
-import { validateBody, validateQuery } from '../middleware/validate.js';
+import {
+  validateBody,
+  validateParams,
+  validateQuery,
+  validateResponse,
+} from '../middleware/validate.js';
 import { ok, fail } from '../utils/response.js';
 import { Container } from '../container/Container.js';
 import {
   riskEvaluateSchema,
   riskHistoryQuerySchema,
+  idParamSchema,
+  walletAddressParamSchema,
+  envelopedRiskResultSchema,
+  envelopedRiskEvaluationSchema,
+  envelopedRiskHistorySchema,
   type RiskEvaluateBody,
   type RiskHistoryQuery,
 } from '../schemas/index.js';
@@ -33,6 +42,7 @@ const requireApiKey = createApiKeyMiddleware(() => loadApiKeys());
 riskRouter.post(
   '/evaluate',
   validateBody(riskEvaluateSchema),
+  validateResponse(envelopedRiskResultSchema),
   async (req: Request, res: Response): Promise<void> => {
     try {
       const { walletAddress, forceRefresh } = req.body as RiskEvaluateBody;
@@ -48,41 +58,53 @@ riskRouter.post(
   },
 );
 
-riskRouter.get('/evaluations/:id', async (req: Request, res: Response): Promise<void> => {
-  try {
-    const evaluation = await container.riskEvaluationService.getRiskEvaluation(req.params.id);
+riskRouter.get(
+  '/evaluations/:id',
+  validateParams(idParamSchema),
+  validateResponse(envelopedRiskEvaluationSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const evaluation = await container.riskEvaluationService.getRiskEvaluation(req.params.id);
 
-    if (!evaluation) {
-      fail(res, 'Risk evaluation not found', 404);
-      return;
+      if (!evaluation) {
+        fail(res, 'Risk evaluation not found', 404);
+        return;
+      }
+
+      ok(res, evaluation);
+    } catch {
+      fail(res, 'Failed to fetch risk evaluation', 500);
     }
-
-    ok(res, evaluation);
-  } catch {
-    fail(res, 'Failed to fetch risk evaluation', 500);
-  }
-});
+  },
+);
 
 riskRouter.get(
   '/wallet/:walletAddress/latest',
+  validateParams(walletAddressParamSchema),
+  validateResponse(envelopedRiskEvaluationSchema),
   async (req: Request, res: Response): Promise<void> => {
-  try {
-    const evaluation = await container.riskEvaluationService.getLatestRiskEvaluation(req.params.walletAddress);
+    try {
+      const evaluation = await container.riskEvaluationService.getLatestRiskEvaluation(
+        req.params.walletAddress,
+      );
 
-    if (!evaluation) {
-      fail(res, 'No risk evaluation found for wallet', 404);
-      return;
+      if (!evaluation) {
+        fail(res, 'No risk evaluation found for wallet', 404);
+        return;
+      }
+
+      ok(res, evaluation);
+    } catch {
+      fail(res, 'Failed to fetch latest risk evaluation', 500);
     }
-
-    ok(res, evaluation);
-  } catch {
-    fail(res, 'Failed to fetch latest risk evaluation', 500);
-  }
-});
+  },
+);
 
 riskRouter.get(
   '/wallet/:walletAddress/history',
+  validateParams(walletAddressParamSchema),
   validateQuery(riskHistoryQuerySchema),
+  validateResponse(envelopedRiskHistorySchema),
   async (req: Request, res: Response): Promise<void> => {
     try {
       const { offset, limit } = req.query as unknown as RiskHistoryQuery;

--- a/src/routes/simulation.ts
+++ b/src/routes/simulation.ts
@@ -9,8 +9,8 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { validateBody } from '../middleware/validate.js';
-import { drawSchema, repaySchema } from '../schemas/index.js';
+import { validateBody, validateParams } from '../middleware/validate.js';
+import { drawSchema, repaySchema, idParamSchema } from '../schemas/index.js';
 import type { DrawBody, RepayBody } from '../schemas/index.js';
 import { ok, fail } from '../utils/response.js';
 import { Container } from '../container/Container.js';
@@ -23,6 +23,7 @@ const INTEREST_RATE_DIVISOR = 10_000; // bps denominator
 
 simulationRouter.post(
   '/lines/:id/draw/simulate',
+  validateParams(idParamSchema),
   validateBody(drawSchema),
   async (req: Request, res: Response, next) => {
     try {
@@ -33,16 +34,21 @@ simulationRouter.post(
       const drawAmount = Number(amount);
       const availableCredit = Number(line.creditLimit) - Number(line.balance ?? 0);
       const valid = drawAmount > 0 && drawAmount <= availableCredit;
-      const interestBps: number = (line as unknown as Record<string, unknown>)['interestRateBps'] as number ?? 0;
-      const estimatedFee = Math.ceil(drawAmount * interestBps / INTEREST_RATE_DIVISOR);
+      const interestBps: number =
+        ((line as unknown as Record<string, unknown>)['interestRateBps'] as number) ?? 0;
+      const estimatedFee = Math.ceil((drawAmount * interestBps) / INTEREST_RATE_DIVISOR);
 
       return ok(res, {
         simulation: 'draw',
         valid,
-        issues: valid ? [] : [
-          drawAmount <= 0 ? 'amount must be positive' : null,
-          drawAmount > availableCredit ? `amount ${drawAmount} exceeds available credit ${availableCredit}` : null,
-        ].filter(Boolean),
+        issues: valid
+          ? []
+          : [
+              drawAmount <= 0 ? 'amount must be positive' : null,
+              drawAmount > availableCredit
+                ? `amount ${drawAmount} exceeds available credit ${availableCredit}`
+                : null,
+            ].filter(Boolean),
         preview: {
           requestedAmount: drawAmount,
           estimatedFee,
@@ -59,6 +65,7 @@ simulationRouter.post(
 
 simulationRouter.post(
   '/lines/:id/repay/simulate',
+  validateParams(idParamSchema),
   validateBody(repaySchema),
   async (req: Request, res: Response, next) => {
     try {

--- a/src/schemas/admin.schema.ts
+++ b/src/schemas/admin.schema.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/** POST /api/admin/api-keys */
+export const issueApiKeySchema = z
+  .object({
+    label: z.string().trim().min(1).max(128).optional(),
+  })
+  .strict();
+
+export type IssueApiKeyBody = z.infer<typeof issueApiKeySchema>;
+
+/** POST /api/admin/maintenance */
+export const maintenanceToggleSchema = z
+  .object({
+    enabled: z.boolean(),
+  })
+  .strict();
+
+export type MaintenanceToggleBody = z.infer<typeof maintenanceToggleSchema>;
+
+/** POST /api/credit/lines/bulk */
+export const bulkCreditLinesSchema = z
+  .object({
+    rows: z
+      .array(z.unknown())
+      .min(1, 'rows array is required and must not be empty')
+      .max(200, 'Maximum 200 rows per request'),
+  })
+  .strict();
+
+export type BulkCreditLinesBody = z.infer<typeof bulkCreditLinesSchema>;
+
+/** Query for bulk dry-run */
+export const bulkCreditLinesQuerySchema = z
+  .object({
+    dry_run: z
+      .enum(['true', 'false'])
+      .optional()
+      .transform((v) => v === 'true'),
+  })
+  .strict();
+
+export type BulkCreditLinesQuery = z.infer<typeof bulkCreditLinesQuerySchema>;

--- a/src/schemas/credit.schema.ts
+++ b/src/schemas/credit.schema.ts
@@ -11,57 +11,100 @@ const stellarAddressField = z
   .string()
   .refine(isValidStellarAddress, 'walletAddress must be a valid Stellar address');
 
-export const createCreditLineSchema = z.object({
-  walletAddress: stellarAddressField,
-  creditLimit: z
-    .string()
-    .regex(numericString, 'creditLimit must be a numeric string')
-    .optional(),
-  requestedLimit: z
-    .string()
-    .regex(numericString, 'requestedLimit must be a numeric string')
-    .optional(),
-  interestRateBps: nonNegativeIntString.optional(),
-}).strict().refine(data => data.creditLimit || data.requestedLimit, {
-  message: "Either creditLimit or requestedLimit must be provided",
-  path: ["creditLimit"]
-});
+export const createCreditLineSchema = z
+  .object({
+    walletAddress: stellarAddressField,
+    creditLimit: z
+      .string()
+      .regex(numericString, 'creditLimit must be a numeric string')
+      .optional(),
+    requestedLimit: z
+      .string()
+      .regex(numericString, 'requestedLimit must be a numeric string')
+      .optional(),
+    interestRateBps: nonNegativeIntString.optional(),
+  })
+  .strict()
+  .refine((data) => data.creditLimit || data.requestedLimit, {
+    message: 'Either creditLimit or requestedLimit must be provided',
+    path: ['creditLimit'],
+  });
 
 export type CreateCreditLineBody = z.infer<typeof createCreditLineSchema>;
 
-export const creditLinesQuerySchema = z.object({
-  offset: nonNegativeIntString.optional(),
-  limit: positiveIntString.max(100).optional(),
-}).strict();
+/**
+ * GET /api/credit/lines query.
+ * - Offset mode: `offset` + `limit`
+ * - Cursor mode: presence of `cursor` (may be empty string for first page)
+ */
+export const creditLinesQuerySchema = z
+  .object({
+    offset: nonNegativeIntString.optional(),
+    limit: positiveIntString.max(100).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
 
 export type CreditLinesQuery = z.infer<typeof creditLinesQuerySchema>;
 
-export const drawSchema = z.object({
-  walletAddress: stellarAddressField,
-  amount: z
-    .string()
-    .min(1, 'amount is required')
-    .regex(numericString, 'amount must be a numeric string'),
-}).strict();
+export const updateCreditLineSchema = z
+  .object({
+    creditLimit: z
+      .string()
+      .regex(numericString, 'creditLimit must be a numeric string')
+      .refine((v) => parseFloat(v) > 0, 'Credit limit must be greater than 0')
+      .optional(),
+    interestRateBps: nonNegativeIntString.optional(),
+    status: z.enum(['active', 'suspended', 'closed']).optional(),
+    expectedVersion: positiveIntString.optional(),
+  })
+  .strict()
+  .refine(
+    (data) =>
+      data.creditLimit !== undefined ||
+      data.interestRateBps !== undefined ||
+      data.status !== undefined ||
+      data.expectedVersion !== undefined,
+    {
+      message: 'At least one updatable field is required',
+      path: ['creditLimit'],
+    },
+  );
+
+export type UpdateCreditLineBody = z.infer<typeof updateCreditLineSchema>;
+
+export const drawSchema = z
+  .object({
+    walletAddress: stellarAddressField,
+    amount: z
+      .string()
+      .min(1, 'amount is required')
+      .regex(numericString, 'amount must be a numeric string'),
+  })
+  .strict();
 
 export type DrawBody = z.infer<typeof drawSchema>;
 
-export const repaySchema = z.object({
-  walletAddress: stellarAddressField,
-  amount: z
-    .string()
-    .min(1, 'amount is required')
-    .regex(numericString, 'amount must be a numeric string'),
-}).strict();
+export const repaySchema = z
+  .object({
+    walletAddress: stellarAddressField,
+    amount: z
+      .string()
+      .min(1, 'amount is required')
+      .regex(numericString, 'amount must be a numeric string'),
+  })
+  .strict();
 
 export type RepayBody = z.infer<typeof repaySchema>;
 
-export const transactionHistoryQuerySchema = z.object({
-  type: z.nativeEnum(TransactionType).optional(),
-  from: isoDateTime.optional(),
-  to: isoDateTime.optional(),
-  page: positiveIntString.optional(),
-  limit: positiveIntString.max(100).optional(),
-}).strict();
+export const transactionHistoryQuerySchema = z
+  .object({
+    type: z.nativeEnum(TransactionType).optional(),
+    from: isoDateTime.optional(),
+    to: isoDateTime.optional(),
+    page: positiveIntString.optional(),
+    limit: positiveIntString.max(100).optional(),
+  })
+  .strict();
 
 export type TransactionHistoryQuery = z.infer<typeof transactionHistoryQuerySchema>;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,11 +1,17 @@
 export { walletAddressSchema } from './common.schema.js';
-export { walletAddressParamSchema } from './params.schema.js';
+export {
+  walletAddressParamSchema,
+  idParamSchema,
+  type WalletAddressParams,
+  type IdParams,
+} from './params.schema.js';
 export { riskEvaluateSchema, riskHistoryQuerySchema } from './risk.schema.js';
 export type { RiskEvaluateBody, RiskHistoryQuery } from './risk.schema.js';
 
 export {
   createCreditLineSchema,
   creditLinesQuerySchema,
+  updateCreditLineSchema,
   drawSchema,
   repaySchema,
   transactionHistoryQuerySchema,
@@ -13,7 +19,50 @@ export {
 export type {
   CreateCreditLineBody,
   CreditLinesQuery,
+  UpdateCreditLineBody,
   DrawBody,
   RepayBody,
   TransactionHistoryQuery,
 } from './credit.schema.js';
+
+export {
+  issueApiKeySchema,
+  maintenanceToggleSchema,
+  bulkCreditLinesSchema,
+  bulkCreditLinesQuerySchema,
+} from './admin.schema.js';
+export type {
+  IssueApiKeyBody,
+  MaintenanceToggleBody,
+  BulkCreditLinesBody,
+  BulkCreditLinesQuery,
+} from './admin.schema.js';
+
+export {
+  apiEnvelopeSchema,
+  errorEnvelopeSchema,
+  creditLineSchema,
+  creditLinesListDataSchema,
+  creditLinesCursorDataSchema,
+  walletCreditLinesDataSchema,
+  drawRepayResultSchema,
+  transactionSchema,
+  transactionHistoryDataSchema,
+  riskEvaluationResultSchema,
+  riskEvaluationSchema,
+  riskHistoryDataSchema,
+  healthDataSchema,
+  reconciliationTriggerDataSchema,
+  reconciliationStatusDataSchema,
+  envelopedCreditLineSchema,
+  envelopedCreditLinesListSchema,
+  envelopedWalletCreditLinesSchema,
+  envelopedRiskResultSchema,
+  envelopedRiskEvaluationSchema,
+  envelopedRiskHistorySchema,
+  envelopedHealthSchema,
+  envelopedDrawRepaySchema,
+  envelopedTransactionHistorySchema,
+  envelopedReconciliationTriggerSchema,
+  envelopedReconciliationStatusSchema,
+} from './response.schema.js';

--- a/src/schemas/params.schema.ts
+++ b/src/schemas/params.schema.ts
@@ -1,6 +1,23 @@
 import { z } from 'zod';
 import { walletAddressSchema } from './common.schema.js';
 
-export const walletAddressParamSchema = z.object({
-  walletAddress: walletAddressSchema,
-});
+/** Path param: Stellar wallet address. */
+export const walletAddressParamSchema = z
+  .object({
+    walletAddress: walletAddressSchema,
+  })
+  .strict();
+
+/**
+ * Path param: opaque resource id (UUID or product-prefixed ids).
+ * Kept permissive on format so existing non-UUID fixtures keep working;
+ * empty / missing ids are rejected.
+ */
+export const idParamSchema = z
+  .object({
+    id: z.string().min(1, 'id is required').max(128, 'id is too long'),
+  })
+  .strict();
+
+export type WalletAddressParams = z.infer<typeof walletAddressParamSchema>;
+export type IdParams = z.infer<typeof idParamSchema>;

--- a/src/schemas/response.schema.ts
+++ b/src/schemas/response.schema.ts
@@ -1,0 +1,196 @@
+import { z } from 'zod';
+import { TransactionType } from '../models/Transaction.js';
+
+/**
+ * Response (output) Zod schemas — the contract clients rely on.
+ * Used by:
+ *  - `validateResponse(...)` middleware when ENABLE_RESPONSE_VALIDATION=true
+ *  - `assertMatchesSchema(...)` in integration tests
+ *
+ * Dates may arrive as `Date` (handler → res.json) or ISO strings (HTTP clients).
+ */
+
+const dateLike = z.union([z.string(), z.date()]);
+
+/** Shared `{ data, error }` envelope. */
+export function apiEnvelopeSchema<T extends z.ZodTypeAny>(dataSchema: T) {
+  return z
+    .object({
+      data: dataSchema.nullable(),
+      error: z.string().nullable(),
+    })
+    .strict();
+}
+
+/** Error-only envelope used by fail() / validation failures (details optional). */
+export const errorEnvelopeSchema = z
+  .object({
+    data: z.null(),
+    error: z.string(),
+    details: z
+      .array(
+        z
+          .object({
+            field: z.string(),
+            message: z.string(),
+          })
+          .strict(),
+      )
+      .optional(),
+    retryAfter: z.number().optional(),
+  })
+  .passthrough();
+
+// ── Domain payloads ──────────────────────────────────────────────────────────
+
+export const creditLineStatusSchema = z.enum(['active', 'suspended', 'closed', 'pending']);
+
+export const creditLineSchema = z
+  .object({
+    id: z.string().min(1),
+    walletAddress: z.string().min(1),
+    creditLimit: z.string(),
+    availableCredit: z.string().optional(),
+    utilized: z.string().optional(),
+    currentBalance: z.string().optional(),
+    interestRateBps: z.number().int().min(0).max(10_000),
+    status: z.union([creditLineStatusSchema, z.string()]),
+    version: z.number().int().positive().optional(),
+    createdAt: dateLike,
+    updatedAt: dateLike,
+  })
+  .passthrough();
+
+export const creditLinesListDataSchema = z
+  .object({
+    creditLines: z.array(creditLineSchema),
+    pagination: z
+      .object({
+        total: z.number().int().min(0),
+        offset: z.number().int().min(0),
+        limit: z.number().int().positive(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const creditLinesCursorDataSchema = z
+  .object({
+    creditLines: z.array(creditLineSchema),
+    pagination: z
+      .object({
+        limit: z.number().int().positive(),
+        nextCursor: z.string().nullable(),
+        hasMore: z.boolean(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const walletCreditLinesDataSchema = z
+  .object({
+    creditLines: z.array(creditLineSchema),
+  })
+  .strict();
+
+export const drawRepayResultSchema = z
+  .object({
+    id: z.string().min(1),
+    walletAddress: z.string().min(1),
+    amount: z.string(),
+    txHash: z.string().nullable(),
+    status: z.enum(['submitted', 'pending']),
+  })
+  .strict();
+
+export const transactionSchema = z
+  .object({
+    id: z.string(),
+    creditLineId: z.string(),
+    type: z.nativeEnum(TransactionType),
+    amount: z.union([z.string(), z.null()]),
+    currency: z.union([z.string(), z.null()]),
+    timestamp: z.string(),
+    metadata: z.record(z.string(), z.unknown()),
+  })
+  .passthrough();
+
+export const transactionHistoryDataSchema = z
+  .object({
+    transactions: z.array(transactionSchema),
+    total: z.number().int().min(0),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive(),
+    totalPages: z.number().int().positive(),
+  })
+  .strict();
+
+export const riskEvaluationResultSchema = z
+  .object({
+    walletAddress: z.string().min(1),
+    riskScore: z.number(),
+    creditLimit: z.string(),
+    interestRateBps: z.number().int(),
+    message: z.string().optional(),
+  })
+  .passthrough();
+
+export const riskEvaluationSchema = z
+  .object({
+    id: z.string().min(1),
+    walletAddress: z.string().min(1),
+    riskScore: z.number(),
+    creditLimit: z.string(),
+    interestRateBps: z.number().int(),
+    factors: z.array(z.unknown()).optional(),
+    evaluatedAt: dateLike,
+    expiresAt: dateLike.optional(),
+  })
+  .passthrough();
+
+export const riskHistoryDataSchema = z
+  .object({
+    evaluations: z.array(riskEvaluationSchema),
+  })
+  .strict();
+
+export const healthDataSchema = z
+  .object({
+    status: z.string(),
+    service: z.string(),
+    ready: z.boolean().optional(),
+    dependencies: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+export const reconciliationTriggerDataSchema = z
+  .object({
+    jobId: z.string(),
+    message: z.string(),
+  })
+  .strict();
+
+export const reconciliationStatusDataSchema = z
+  .object({
+    workerRunning: z.boolean(),
+    queueSize: z.number().int().min(0),
+    failedJobs: z.number().int().min(0),
+  })
+  .strict();
+
+// Enveloped variants for common success paths
+export const envelopedCreditLineSchema = apiEnvelopeSchema(creditLineSchema);
+export const envelopedCreditLinesListSchema = apiEnvelopeSchema(creditLinesListDataSchema);
+export const envelopedWalletCreditLinesSchema = apiEnvelopeSchema(walletCreditLinesDataSchema);
+export const envelopedRiskResultSchema = apiEnvelopeSchema(riskEvaluationResultSchema);
+export const envelopedRiskEvaluationSchema = apiEnvelopeSchema(riskEvaluationSchema);
+export const envelopedRiskHistorySchema = apiEnvelopeSchema(riskHistoryDataSchema);
+export const envelopedHealthSchema = apiEnvelopeSchema(healthDataSchema);
+export const envelopedDrawRepaySchema = apiEnvelopeSchema(drawRepayResultSchema);
+export const envelopedTransactionHistorySchema = apiEnvelopeSchema(transactionHistoryDataSchema);
+export const envelopedReconciliationTriggerSchema = apiEnvelopeSchema(
+  reconciliationTriggerDataSchema,
+);
+export const envelopedReconciliationStatusSchema = apiEnvelopeSchema(
+  reconciliationStatusDataSchema,
+);

--- a/tests/middleware/responseValidation.test.ts
+++ b/tests/middleware/responseValidation.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { z } from 'zod';
+import {
+  validateBody,
+  validateResponse,
+  assertMatchesSchema,
+  isResponseValidationEnabled,
+  toValidationDetails,
+} from '../../src/middleware/validate.js';
+import {
+  apiEnvelopeSchema,
+  envelopedRiskResultSchema,
+  errorEnvelopeSchema,
+} from '../../src/schemas/index.js';
+
+describe('response schema validation', () => {
+  const prev = process.env.ENABLE_RESPONSE_VALIDATION;
+
+  afterEach(() => {
+    if (prev === undefined) {
+      delete process.env.ENABLE_RESPONSE_VALIDATION;
+    } else {
+      process.env.ENABLE_RESPONSE_VALIDATION = prev;
+    }
+  });
+
+  describe('isResponseValidationEnabled', () => {
+    it('is false by default', () => {
+      delete process.env.ENABLE_RESPONSE_VALIDATION;
+      delete process.env.RESPONSE_SCHEMA_VALIDATION;
+      expect(isResponseValidationEnabled()).toBe(false);
+    });
+
+    it('is true when ENABLE_RESPONSE_VALIDATION=true', () => {
+      process.env.ENABLE_RESPONSE_VALIDATION = 'true';
+      expect(isResponseValidationEnabled()).toBe(true);
+    });
+  });
+
+  describe('validateResponse middleware', () => {
+    const payloadSchema = apiEnvelopeSchema(
+      z.object({ id: z.string(), amount: z.string() }).strict(),
+    );
+
+    function buildApp(enable: boolean) {
+      process.env.ENABLE_RESPONSE_VALIDATION = enable ? 'true' : 'false';
+      const app = express();
+      app.use(express.json());
+      app.get('/ok', validateResponse(payloadSchema), (_req, res) => {
+        res.json({ data: { id: '1', amount: '10' }, error: null });
+      });
+      app.get('/bad', validateResponse(payloadSchema), (_req, res) => {
+        res.json({ data: { id: 1 }, error: null });
+      });
+      return app;
+    }
+
+    it('passes matching responses through when enabled', async () => {
+      const res = await request(buildApp(true)).get('/ok');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ data: { id: '1', amount: '10' }, error: null });
+    });
+
+    it('returns stable 500 envelope on contract violation (no Zod internals)', async () => {
+      const res = await request(buildApp(true)).get('/bad');
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ data: null, error: 'Response contract violation' });
+      expect(JSON.stringify(res.body)).not.toMatch(/ZodError|stack|node_modules/i);
+    });
+
+    it('is a no-op when disabled (mismatched body still returned)', async () => {
+      const res = await request(buildApp(false)).get('/bad');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ data: { id: 1 }, error: null });
+    });
+  });
+
+  describe('assertMatchesSchema', () => {
+    it('returns parsed data on success', () => {
+      const data = assertMatchesSchema(envelopedRiskResultSchema, {
+        data: {
+          walletAddress: 'G' + 'A'.repeat(55),
+          riskScore: 72,
+          creditLimit: '720',
+          interestRateBps: 640,
+          message: 'ok',
+        },
+        error: null,
+      });
+      expect(data.error).toBeNull();
+      expect(data.data?.riskScore).toBe(72);
+    });
+
+    it('throws with field paths on mismatch', () => {
+      expect(() =>
+        assertMatchesSchema(
+          envelopedRiskResultSchema,
+          { data: { walletAddress: 'bad' }, error: null },
+          'risk.evaluate',
+        ),
+      ).toThrow(/Schema validation failed for risk\.evaluate/);
+    });
+
+    it('accepts standard error envelopes', () => {
+      const body = assertMatchesSchema(errorEnvelopeSchema, {
+        data: null,
+        error: 'Validation failed',
+        details: [{ field: 'walletAddress', message: 'Required' }],
+      });
+      expect(body.error).toBe('Validation failed');
+    });
+  });
+
+  describe('toValidationDetails', () => {
+    it('maps nested paths', () => {
+      const schema = z.object({ user: z.object({ email: z.string().email() }) });
+      const result = schema.safeParse({ user: { email: 'nope' } });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const details = toValidationDetails(result.error);
+        expect(details[0].field).toBe('user.email');
+        expect(details[0].message).toBeTruthy();
+      }
+    });
+  });
+
+  describe('request + response pipeline', () => {
+    beforeEach(() => {
+      process.env.ENABLE_RESPONSE_VALIDATION = 'true';
+    });
+
+    it('rejects invalid request with stable validation envelope', async () => {
+      const bodySchema = z.object({ amount: z.string().regex(/^\d+$/) }).strict();
+      const responseSchema = apiEnvelopeSchema(z.object({ amount: z.string() }).strict());
+      const app = express();
+      app.use(express.json());
+      app.post(
+        '/',
+        validateBody(bodySchema),
+        validateResponse(responseSchema),
+        (req, res) => {
+          res.json({ data: { amount: req.body.amount }, error: null });
+        },
+      );
+
+      const res = await request(app).post('/').send({ amount: 'abc' });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        data: null,
+        error: 'Validation failed',
+      });
+      expect(Array.isArray(res.body.details)).toBe(true);
+    });
+  });
+});

--- a/tests/response-contract.test.ts
+++ b/tests/response-contract.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration-level response contract checks.
+ * Uses assertMatchesSchema so API drift fails the suite even when
+ * ENABLE_RESPONSE_VALIDATION is off for handlers.
+ */
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { app } from '../src/index.js';
+import { assertMatchesSchema } from '../src/middleware/validate.js';
+import {
+  envelopedHealthSchema,
+  envelopedCreditLinesListSchema,
+  envelopedRiskResultSchema,
+  errorEnvelopeSchema,
+} from '../src/schemas/index.js';
+
+const VALID_ADDRESS = 'G' + 'A'.repeat(55);
+
+describe('API response contracts (Zod)', () => {
+  it('GET /health matches health envelope schema', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    assertMatchesSchema(envelopedHealthSchema, res.body, 'GET /health');
+  });
+
+  it('GET /api/credit/lines matches list envelope schema', async () => {
+    const res = await request(app).get('/api/credit/lines');
+    expect(res.status).toBe(200);
+    assertMatchesSchema(envelopedCreditLinesListSchema, res.body, 'GET /api/credit/lines');
+  });
+
+  it('POST /api/risk/evaluate success matches risk result schema', async () => {
+    const res = await request(app)
+      .post('/api/risk/evaluate')
+      .send({ walletAddress: VALID_ADDRESS });
+    expect(res.status).toBe(200);
+    assertMatchesSchema(envelopedRiskResultSchema, res.body, 'POST /api/risk/evaluate');
+  });
+
+  it('POST /api/risk/evaluate validation failure matches error envelope', async () => {
+    const res = await request(app).post('/api/risk/evaluate').send({});
+    expect(res.status).toBe(400);
+    assertMatchesSchema(errorEnvelopeSchema, res.body, 'POST /api/risk/evaluate 400');
+    expect(res.body.error).toBe('Validation failed');
+  });
+
+  it('rejects unknown keys on evaluate with field details', async () => {
+    const res = await request(app)
+      .post('/api/risk/evaluate')
+      .send({ walletAddress: VALID_ADDRESS, extra: true });
+    expect(res.status).toBe(400);
+    expect(res.body.data).toBeNull();
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details.length).toBeGreaterThan(0);
+  });
+
+  it('GET /api/credit/wallet/:wallet/lines validates wallet path param', async () => {
+    const bad = await request(app).get('/api/credit/wallet/not-a-wallet/lines');
+    expect(bad.status).toBe(400);
+    assertMatchesSchema(errorEnvelopeSchema, bad.body, 'invalid wallet param');
+
+    const good = await request(app).get(`/api/credit/wallet/${VALID_ADDRESS}/lines`);
+    expect(good.status).toBe(200);
+    expect(good.body).toMatchObject({ data: { creditLines: expect.any(Array) }, error: null });
+  });
+});

--- a/tests/schemas/index.exports.test.ts
+++ b/tests/schemas/index.exports.test.ts
@@ -2,17 +2,27 @@ import { describe, it, expect } from 'vitest';
 import {
   createCreditLineSchema,
   creditLinesQuerySchema,
+  updateCreditLineSchema,
   drawSchema,
   repaySchema,
   riskEvaluateSchema,
   riskHistoryQuerySchema,
   transactionHistoryQuerySchema,
+  idParamSchema,
+  walletAddressParamSchema,
+  issueApiKeySchema,
+  maintenanceToggleSchema,
+  bulkCreditLinesSchema,
+  envelopedCreditLineSchema,
+  envelopedRiskResultSchema,
+  errorEnvelopeSchema,
 } from '../../src/schemas/index.js';
 
 describe('schemas index exports', () => {
   it('re-exports credit schemas', () => {
     expect(createCreditLineSchema).toBeDefined();
     expect(creditLinesQuerySchema).toBeDefined();
+    expect(updateCreditLineSchema).toBeDefined();
     expect(drawSchema).toBeDefined();
     expect(repaySchema).toBeDefined();
     expect(transactionHistoryQuerySchema).toBeDefined();
@@ -22,4 +32,16 @@ describe('schemas index exports', () => {
     expect(riskEvaluateSchema).toBeDefined();
     expect(riskHistoryQuerySchema).toBeDefined();
   });
+
+  it('re-exports params, admin, and response schemas', () => {
+    expect(idParamSchema).toBeDefined();
+    expect(walletAddressParamSchema).toBeDefined();
+    expect(issueApiKeySchema).toBeDefined();
+    expect(maintenanceToggleSchema).toBeDefined();
+    expect(bulkCreditLinesSchema).toBeDefined();
+    expect(envelopedCreditLineSchema).toBeDefined();
+    expect(envelopedRiskResultSchema).toBeDefined();
+    expect(errorEnvelopeSchema).toBeDefined();
+  });
 });
+

--- a/tests/schemas/response.schema.test.ts
+++ b/tests/schemas/response.schema.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  updateCreditLineSchema,
+  creditLinesQuerySchema,
+  idParamSchema,
+  walletAddressParamSchema,
+  issueApiKeySchema,
+  maintenanceToggleSchema,
+  bulkCreditLinesSchema,
+  envelopedCreditLineSchema,
+  envelopedCreditLinesListSchema,
+  creditLinesCursorDataSchema,
+  envelopedRiskResultSchema,
+  drawRepayResultSchema,
+  errorEnvelopeSchema,
+} from '../../src/schemas/index.js';
+
+const VALID_ADDRESS = 'G' + 'A'.repeat(55);
+
+describe('updateCreditLineSchema', () => {
+  it('accepts partial updates', () => {
+    expect(updateCreditLineSchema.safeParse({ creditLimit: '1500.00' }).success).toBe(true);
+    expect(updateCreditLineSchema.safeParse({ interestRateBps: 500 }).success).toBe(true);
+    expect(updateCreditLineSchema.safeParse({ status: 'suspended' }).success).toBe(true);
+    expect(updateCreditLineSchema.safeParse({ expectedVersion: 2 }).success).toBe(true);
+  });
+
+  it('rejects empty body', () => {
+    expect(updateCreditLineSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects unknown keys and invalid status', () => {
+    expect(updateCreditLineSchema.safeParse({ creditLimit: '1', extra: true }).success).toBe(false);
+    expect(updateCreditLineSchema.safeParse({ status: 'pending' }).success).toBe(false);
+  });
+});
+
+describe('creditLinesQuerySchema cursor mode', () => {
+  it('accepts empty cursor string (first page)', () => {
+    const result = creditLinesQuerySchema.safeParse({ cursor: '', limit: '3' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cursor).toBe('');
+      expect(result.data.limit).toBe(3);
+    }
+  });
+});
+
+describe('params schemas', () => {
+  it('idParamSchema rejects empty id', () => {
+    expect(idParamSchema.safeParse({ id: '' }).success).toBe(false);
+    expect(idParamSchema.safeParse({ id: 'cl_abc' }).success).toBe(true);
+  });
+
+  it('walletAddressParamSchema requires valid Stellar address', () => {
+    expect(walletAddressParamSchema.safeParse({ walletAddress: VALID_ADDRESS }).success).toBe(
+      true,
+    );
+    expect(walletAddressParamSchema.safeParse({ walletAddress: 'wallet0' }).success).toBe(false);
+  });
+});
+
+describe('admin schemas', () => {
+  it('issueApiKeySchema accepts empty or labelled body', () => {
+    expect(issueApiKeySchema.safeParse({}).success).toBe(true);
+    expect(issueApiKeySchema.safeParse({ label: 'partner-a' }).success).toBe(true);
+    expect(issueApiKeySchema.safeParse({ label: 'x', extra: 1 }).success).toBe(false);
+  });
+
+  it('maintenanceToggleSchema requires boolean enabled', () => {
+    expect(maintenanceToggleSchema.safeParse({ enabled: true }).success).toBe(true);
+    expect(maintenanceToggleSchema.safeParse({ enabled: 'yes' }).success).toBe(false);
+  });
+
+  it('bulkCreditLinesSchema enforces row bounds', () => {
+    expect(bulkCreditLinesSchema.safeParse({ rows: [] }).success).toBe(false);
+    expect(bulkCreditLinesSchema.safeParse({ rows: [{}] }).success).toBe(true);
+    expect(bulkCreditLinesSchema.safeParse({ rows: new Array(201).fill({}) }).success).toBe(false);
+  });
+});
+
+describe('response schemas', () => {
+  it('validates credit line envelope', () => {
+    const result = envelopedCreditLineSchema.safeParse({
+      data: {
+        id: 'uuid',
+        walletAddress: VALID_ADDRESS,
+        creditLimit: '1000.00',
+        availableCredit: '1000.00',
+        utilized: '0',
+        interestRateBps: 500,
+        status: 'active',
+        version: 1,
+        createdAt: new Date(),
+        updatedAt: new Date().toISOString(),
+      },
+      error: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates list + cursor response shapes', () => {
+    expect(
+      envelopedCreditLinesListSchema.safeParse({
+        data: {
+          creditLines: [],
+          pagination: { total: 0, offset: 0, limit: 100 },
+        },
+        error: null,
+      }).success,
+    ).toBe(true);
+
+    expect(
+      creditLinesCursorDataSchema.safeParse({
+        creditLines: [],
+        pagination: { limit: 10, nextCursor: null, hasMore: false },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('validates risk result and draw/repay contracts', () => {
+    expect(
+      envelopedRiskResultSchema.safeParse({
+        data: {
+          walletAddress: VALID_ADDRESS,
+          riskScore: 80,
+          creditLimit: '800',
+          interestRateBps: 600,
+          message: 'New risk evaluation completed',
+        },
+        error: null,
+      }).success,
+    ).toBe(true);
+
+    expect(
+      drawRepayResultSchema.safeParse({
+        id: 'line-1',
+        walletAddress: VALID_ADDRESS,
+        amount: '50',
+        txHash: null,
+        status: 'pending',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('validates error envelope with optional details', () => {
+    expect(
+      errorEnvelopeSchema.safeParse({
+        data: null,
+        error: 'Validation failed',
+        details: [{ field: 'amount', message: 'Required' }],
+      }).success,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements strict Zod-based JSON schema validation for public API **requests and responses** (issue #185).

- **Request validation** on every public credit/risk route (and admin/bulk/simulation/reconciliation): `validateBody` / `validateQuery` / `validateParams` with strict schemas
- **Stable error envelope** for schema failures: `{ data: null, error: "Validation failed", details: [{ field, message }] }` — no stack traces or internal leaks
- **Response contracts** via `src/schemas/response.schema.ts`, `assertMatchesSchema` in integration tests, and opt-in runtime `validateResponse` (`ENABLE_RESPONSE_VALIDATION=true`)
- **OpenAPI + docs** updated (`ValidationErrorResponse`, cursor query, `docs/json-schema-validation.md`)
- Fixed missing `Container.dashboardSummaryService` getter used by credit mutations

## Test plan

- [x] `npm run validate:spec`
- [x] Schema unit tests (`tests/schemas/*`)
- [x] Middleware tests (`tests/middleware/validate*`, `responseValidation.test.ts`)
- [x] Response contract integration tests (`tests/response-contract.test.ts`)
- [x] Credit/risk route tests updated for validation envelopes
- [x] `npx vitest run` on validation-related suites (all green)

## Docs

- `docs/json-schema-validation.md` — full policy + route coverage table
- Updates: `docs/API.md`, `docs/SECURITY.md`, `docs/TESTING.md`, `docs/error-envelope.md`, `docs/README.md`
- `src/openapi.yaml` (+ docs mirror)

Closes #185
