### PR TITLE
chore(security): harden Express security headers and proxy trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ See [`docs/OBSERVABILITY.md`](./docs/OBSERVABILITY.md).
 - Per-route token-bucket rate limit emitting `X-RateLimit-*` headers ([`src/middleware/rateLimit.ts`](./src/middleware/rateLimit.ts)).
 - HMAC-SHA256 webhook signatures (`X-Webhook-Signature: sha256=…`).
 - Outbound HTTP guarded by [`src/utils/fetchWithTimeout.ts`](./src/utils/fetchWithTimeout.ts).
+- Helmet security headers (HSTS, CSP, `X-Frame-Options: DENY`, `nosniff`, referrer policy) via [`src/middleware/securityHeaders.ts`](./src/middleware/securityHeaders.ts).
+- Configurable `TRUST_PROXY` for reverse-proxy deployments so `req.ip` / rate limits see the real client ([`src/config/security.ts`](./src/config/security.ts)).
+
+**Production (behind a reverse proxy):** set `TRUST_PROXY=1` (or the hop count matching your topology). See [`docs/SECURITY.md`](./docs/SECURITY.md) §5.
 
 Full model: [`docs/SECURITY.md`](./docs/SECURITY.md) and [`SECURITY.md`](./SECURITY.md).
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -86,19 +86,57 @@ Behaviour:
 
 Validator chain order:
 
-1. CORS allowlist ([`src/config/cors.ts`](../src/config/cors.ts))
-2. JSON body parser (100 kB)
+1. Security posture — `trust proxy` + Helmet headers ([`src/config/security.ts`](../src/config/security.ts), [`src/middleware/securityHeaders.ts`](../src/middleware/securityHeaders.ts))
+2. CORS allowlist ([`src/config/cors.ts`](../src/config/cors.ts))
 3. Content-Type guard (returns 415 if `POST/PUT/PATCH` has a body that isn't `application/json`)
-4. Request logger (assigns / propagates `x-request-id`)
-5. Auth middleware (route-specific)
-6. Rate limit middleware (route-specific)
-7. Zod validate(Body|Query|Params)
-8. Handler
-9. `errorHandler` catches anything unhandled
+4. JSON body parser (100 kB)
+5. Request logger (assigns / propagates `x-request-id`)
+6. Auth middleware (route-specific)
+7. Rate limit middleware (route-specific)
+8. Zod validate(Body|Query|Params)
+9. Handler
+10. `errorHandler` catches anything unhandled
 
 ---
 
-## 5. Rate Limiting Strategy
+## 5. HTTP security headers & proxy trust
+
+Baseline posture is applied once at bootstrap via `applySecurityPosture(app)`:
+
+| Control | Implementation | Notes |
+|---|---|---|
+| Trust proxy | `app.set('trust proxy', …)` from `TRUST_PROXY` | Required behind ALB/nginx/Cloudflare so `req.ip` and rate-limit keys see the real client. Default `false` (do not trust spoofed `X-Forwarded-For`). Accepts `true`/`false`, hop count (`1`), or Express presets (`loopback`, CIDR). |
+| HSTS | Helmet `Strict-Transport-Security` | Default `max-age=15552000` (180d) + `includeSubDomains`. Override with `HSTS_MAX_AGE`; set `HSTS_PRELOAD=true` only after preload registration. |
+| CSP | Helmet Content-Security-Policy | `default-src 'self'`, `frame-ancestors 'none'`, inline script/style allowed so `/docs` (Swagger UI) keeps working. COEP disabled for the same reason. |
+| Clickjacking | `X-Frame-Options: DENY` | Also reinforced by CSP `frame-ancestors`. |
+| MIME sniffing | `X-Content-Type-Options: nosniff` | Always on. |
+| Referrer | `Referrer-Policy: no-referrer` | Avoids leaking path tokens. |
+| Fingerprint | `X-Powered-By` removed | Helmet `hidePoweredBy`. |
+
+### Secure cookies (future)
+
+The API is header-auth only today (`X-API-Key` / `X-Admin-Api-Key`) and does **not** set cookies. If session or JWT cookies are introduced, use the defaults from `loadCookieDefaults()`:
+
+- `httpOnly: true`
+- `secure: true` in production (or when `COOKIE_SECURE=true`)
+- `sameSite: 'lax'`
+- `path: '/'`
+
+### Production deploy checklist (proxy)
+
+```env
+# Behind one reverse-proxy hop (ALB / nginx):
+TRUST_PROXY=1
+# Optional HSTS tuning:
+# HSTS_MAX_AGE=31536000
+# HSTS_PRELOAD=true
+```
+
+Without `TRUST_PROXY`, clients can forge `X-Forwarded-For` and bypass IP-based rate limits. With it set too aggressively (e.g. `true` when no proxy is present), clients can still spoof the header — match the hop count to your real topology.
+
+---
+
+## 6. Rate Limiting Strategy
 
 Implementation: [`src/middleware/rateLimit.ts`](../src/middleware/rateLimit.ts) — fixed-window token bucket per key.
 
@@ -137,7 +175,7 @@ Redis increments use a single Lua script that performs `INCR`, sets `PEXPIRE` wh
 
 ---
 
-## 6. Idempotency
+## 7. Idempotency
 
 Three independent layers:
 
@@ -149,7 +187,7 @@ Three independent layers:
 
 ---
 
-## 7. Webhook Signature Verification
+## 8. Webhook Signature Verification
 
 The backend ships **outbound** webhooks (no inbound webhook surface today). Each delivery includes:
 
@@ -173,7 +211,7 @@ Subscriber expectation (documented in [`webhook-subscribers.md`](./webhook-subsc
 
 ---
 
-## 8. Secret Management
+## 9. Secret Management
 
 - **Sources.** All secrets enter through environment variables — see [`.env.example`](../.env.example) for the canonical list. The container loaders in [`src/config/`](../src/config/) are the only code paths that read them.
 - **Validation.** `validateEnv()` in [`src/config/env.ts`](../src/config/env.ts) asserts presence of `DATABASE_URL` and `API_KEYS` at boot and refuses to start otherwise. Production additionally requires `CORS_ORIGINS` ([`src/config/cors.ts`](../src/config/cors.ts)).
@@ -188,7 +226,7 @@ Subscriber expectation (documented in [`webhook-subscribers.md`](./webhook-subsc
 
 ---
 
-## 9. Audit Logging
+## 10. Audit Logging
 
 - **Request lifecycle.** [`requestLogger.ts`](../src/middleware/requestLogger.ts) logs `request:start` and `request:end` with `{ requestId, method, path, statusCode, durationMs, walletAddress (sanitized) }`. The same `requestId` is propagated to the response via `x-request-id`.
 - **Domain events.** Persisted to the `events` table with `event_type`, `aggregate_type/id`, JSONB `payload`, `idempotency_key` for replay safety, and `created_at`. Indexed on `(aggregate_type, aggregate_id)` and `created_at` for time-range queries.
@@ -197,7 +235,7 @@ Subscriber expectation (documented in [`webhook-subscribers.md`](./webhook-subsc
 
 ---
 
-## 10. Defence-in-Depth Quick Reference
+## 11. Defence-in-Depth Quick Reference
 
 | Concern | Where to look |
 |---|---|
@@ -210,16 +248,17 @@ Subscriber expectation (documented in [`webhook-subscribers.md`](./webhook-subsc
 | Container hardening | `Dockerfile` runs as non-root `node` user, multi-stage build, Alpine runtime |
 | Slowloris / connection abuse | Reverse proxy (deployment concern); we time-bound outbound, not inbound — pair with nginx/envoy timeouts |
 | Shutdown DoS | `SHUTDOWN_TIMEOUT_MS` ceiling prevents stuck shutdowns blocking orchestrator restarts |
+| Clickjacking / MIME sniff / HSTS | Helmet baseline in `applySecurityPosture` (§5); set `TRUST_PROXY` behind reverse proxies |
 
 ---
 
-## 11. Reporting a vulnerability
+## 12. Reporting a vulnerability
 
 See the repo-root [`SECURITY.md`](../SECURITY.md). In short: **do not** open a public issue; email the security alias. Include reproduction steps, observed vs expected behavior, and the affected commit SHA. We commit to acknowledging within 72 hours.
 
 ---
 
-## 12. References
+## 13. References
 
 - [`SECURITY.md`](../SECURITY.md) — disclosure policy
 - [`docs/security-checklist-backend.md`](./security-checklist-backend.md) — pre-deploy checklist

--- a/docs/security-checklist-backend.md
+++ b/docs/security-checklist-backend.md
@@ -106,11 +106,12 @@ For **external penetration-test preparation** (scope, auth bypass checks, rate l
 - [ ] Preflight requests handled correctly
 
 ### HTTP Headers
-- [ ] `Strict-Transport-Security` header set (HSTS)
-- [ ] `X-Content-Type-Options: nosniff` header set
-- [ ] `X-Frame-Options: DENY` or `SAMEORIGIN` header set
-- [ ] `Content-Security-Policy` header configured
-- [ ] `X-XSS-Protection` header set (legacy browsers)
+- [x] `Strict-Transport-Security` header set (HSTS) — Helmet via `applySecurityPosture`
+- [x] `X-Content-Type-Options: nosniff` header set
+- [x] `X-Frame-Options: DENY` or `SAMEORIGIN` header set (`DENY`)
+- [x] `Content-Security-Policy` header configured (self + Swagger-safe inline)
+- [x] `X-Powered-By` removed; `Referrer-Policy: no-referrer`
+- [x] `TRUST_PROXY` documented for reverse-proxy deployments (`src/config/security.ts`)
 
 ### API Keys & Secrets
 - [ ] API keys are not hardcoded in source code

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@stellar/stellar-sdk": "^15.1.0",
         "cors": "^2.8.5",
         "express": "^4.22.2",
+        "helmet": "^8.3.0",
         "pg": "^8.11.3",
         "pino": "^10.3.1",
         "pino-http": "^11.0.0",
@@ -81,7 +82,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2698,7 +2698,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3291,7 +3290,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3753,7 +3751,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4555,7 +4552,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5507,6 +5503,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5901,7 +5909,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7475,7 +7482,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9074,7 +9080,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9158,7 +9163,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9318,7 +9322,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -9397,7 +9400,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -9708,7 +9710,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@stellar/stellar-sdk": "^15.1.0",
     "cors": "^2.8.5",
     "express": "^4.22.2",
+    "helmet": "^8.3.0",
     "pg": "^8.11.3",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",

--- a/src/config/__tests__/security.test.ts
+++ b/src/config/__tests__/security.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadCookieDefaults,
+  loadHelmetOptions,
+  loadSecurityPosture,
+  loadTrustProxy,
+} from "../security.js";
+
+describe("loadTrustProxy", () => {
+  it("defaults to false when unset", () => {
+    expect(loadTrustProxy({})).toBe(false);
+    expect(loadTrustProxy({ TRUST_PROXY: "" })).toBe(false);
+    expect(loadTrustProxy({ TRUST_PROXY: "   " })).toBe(false);
+  });
+
+  it("parses boolean-ish values", () => {
+    expect(loadTrustProxy({ TRUST_PROXY: "true" })).toBe(true);
+    expect(loadTrustProxy({ TRUST_PROXY: "YES" })).toBe(true);
+    expect(loadTrustProxy({ TRUST_PROXY: "1" })).toBe(1); // hop count, not bool
+    expect(loadTrustProxy({ TRUST_PROXY: "false" })).toBe(false);
+    expect(loadTrustProxy({ TRUST_PROXY: "off" })).toBe(false);
+  });
+
+  it("parses hop counts and named presets", () => {
+    expect(loadTrustProxy({ TRUST_PROXY: "2" })).toBe(2);
+    expect(loadTrustProxy({ TRUST_PROXY: "loopback" })).toBe("loopback");
+    expect(loadTrustProxy({ TRUST_PROXY: "10.0.0.0/8" })).toBe("10.0.0.0/8");
+  });
+});
+
+describe("loadHelmetOptions", () => {
+  it("enables HSTS with a positive maxAge", () => {
+    const opts = loadHelmetOptions({ NODE_ENV: "production" });
+    expect(opts.hsts).toMatchObject({
+      maxAge: 15_552_000,
+      includeSubDomains: true,
+    });
+  });
+
+  it("honours HSTS_MAX_AGE and HSTS_PRELOAD", () => {
+    const opts = loadHelmetOptions({
+      HSTS_MAX_AGE: "31536000",
+      HSTS_PRELOAD: "true",
+    });
+    expect(opts.hsts).toMatchObject({
+      maxAge: 31_536_000,
+      preload: true,
+    });
+  });
+
+  it("denies framing and enables nosniff", () => {
+    const opts = loadHelmetOptions({});
+    expect(opts.frameguard).toEqual({ action: "deny" });
+    expect(opts.noSniff).toBe(true);
+    expect(opts.hidePoweredBy).toBe(true);
+  });
+
+  it("keeps COEP off so Swagger UI assets load", () => {
+    const opts = loadHelmetOptions({});
+    expect(opts.crossOriginEmbedderPolicy).toBe(false);
+  });
+});
+
+describe("loadCookieDefaults", () => {
+  it("uses httpOnly + Secure in production", () => {
+    expect(loadCookieDefaults({ NODE_ENV: "production" })).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+    });
+  });
+
+  it("allows COOKIE_SECURE override in non-production", () => {
+    expect(
+      loadCookieDefaults({ NODE_ENV: "development", COOKIE_SECURE: "true" }),
+    ).toMatchObject({ secure: true, httpOnly: true });
+  });
+});
+
+describe("loadSecurityPosture", () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it("aggregates trust proxy, helmet, and cookie defaults", () => {
+    const posture = loadSecurityPosture({
+      TRUST_PROXY: "1",
+      NODE_ENV: "test",
+    });
+    expect(posture.trustProxy).toBe(1);
+    expect(posture.helmet.frameguard).toEqual({ action: "deny" });
+    expect(posture.cookieDefaults.httpOnly).toBe(true);
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -89,6 +89,22 @@ const envSchema = z.object({
 
   /** Redis outage policy for rate limiting. Defaults to fail-open. */
   RATE_LIMIT_REDIS_FAILURE_MODE: z.enum(["open", "closed"]).default("open"),
+
+  /**
+   * Express `trust proxy` setting for reverse-proxy deployments.
+   * Accepts boolean-ish values, hop counts, or Express IP/CIDR presets.
+   * See `src/config/security.ts` and `docs/SECURITY.md`.
+   */
+  TRUST_PROXY: z.string().optional(),
+
+  /** HSTS max-age in seconds (Helmet). Defaults to 180 days when unset. */
+  HSTS_MAX_AGE: z.string().optional(),
+
+  /** When `true`, Helmet HSTS includes the preload directive. */
+  HSTS_PRELOAD: z.string().optional(),
+
+  /** Force `Secure` on future cookies even outside production. */
+  COOKIE_SECURE: z.string().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -1,0 +1,158 @@
+/**
+ * Express security posture loaders.
+ *
+ * Covers:
+ * - `trust proxy` hop configuration for deployments behind reverse proxies
+ * - Helmet header policy (HSTS, CSP, frame deny, nosniff, …)
+ * - Secure cookie defaults (documented for future session/JWT work)
+ *
+ * See `docs/SECURITY.md` § "HTTP security headers & proxy trust".
+ */
+
+import type { HelmetOptions } from "helmet";
+
+/** Parsed trust-proxy setting for `app.set('trust proxy', …)`. */
+export type TrustProxySetting = boolean | number | string;
+
+export interface SecurityPosture {
+  /** Value passed to `app.set('trust proxy', value)`. */
+  trustProxy: TrustProxySetting;
+  /** Helmet configuration applied as global middleware. */
+  helmet: HelmetOptions;
+  /**
+   * Defaults to apply when the API starts issuing cookies (sessions/JWT).
+   * The API is header-auth today and does not set cookies; these are the
+   * required defaults if cookies are introduced.
+   */
+  cookieDefaults: {
+    httpOnly: true;
+    secure: boolean;
+    sameSite: "strict" | "lax" | "none";
+    path: string;
+  };
+}
+
+/**
+ * Parse `TRUST_PROXY` into an Express-compatible trust proxy setting.
+ *
+ * Accepted forms:
+ * - unset / empty → `false` (direct client; safest local default)
+ * - `true` / `1` / `yes` → `true` (trust first proxy hop)
+ * - `false` / `0` / `no` → `false`
+ * - integer hop count (e.g. `1`, `2`) → number of proxies to trust
+ * - CIDR / IP / subnet string (e.g. `loopback`, `10.0.0.0/8`) → passed through
+ *
+ * Production deployments behind ALB/nginx/Cloudflare **must** set this so
+ * rate-limit and request-IP logic see the real client address. Leaving it
+ * false when a proxy is present lets clients spoof `X-Forwarded-For`.
+ */
+export function loadTrustProxy(
+  env: NodeJS.ProcessEnv = process.env,
+): TrustProxySetting {
+  const raw = env.TRUST_PROXY;
+  if (raw === undefined || raw.trim() === "") {
+    return false;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (["true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  if (/^\d+$/.test(normalized)) {
+    return Number.parseInt(normalized, 10);
+  }
+
+  // Express accepts named presets (`loopback`, `linklocal`, `uniquelocal`)
+  // and IP/CIDR strings. Pass through after trim.
+  return raw.trim();
+}
+
+/**
+ * Build Helmet options suitable for a JSON API that also serves Swagger UI.
+ *
+ * CSP allows self + inline script/style so `/docs` (swagger-ui-express)
+ * continues to render. COEP is disabled because Swagger embeds assets that
+ * break under a strict embedder policy. HSTS is only meaningful over TLS;
+ * Helmet still emits the header so browsers remember it after the first
+ * HTTPS hit (maxAge 180 days, includeSubDomains, no preload by default).
+ */
+export function loadHelmetOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): HelmetOptions {
+  const isProduction = (env.NODE_ENV ?? "development") === "production";
+
+  return {
+    // Keep HSTS on in all envs so header presence is testable; browsers
+    // ignore it over plain HTTP. Production can raise maxAge via HSTS_MAX_AGE.
+    hsts: {
+      maxAge: parsePositiveInt(env.HSTS_MAX_AGE, 15_552_000), // 180 days
+      includeSubDomains: true,
+      preload: env.HSTS_PRELOAD === "true",
+    },
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        // swagger-ui needs inline scripts/styles; API responses are JSON.
+        "script-src": ["'self'", "'unsafe-inline'"],
+        "style-src": ["'self'", "'unsafe-inline'"],
+        "img-src": ["'self'", "data:"],
+        "default-src": ["'self'"],
+        "object-src": ["'none'"],
+        "base-uri": ["'self'"],
+        "frame-ancestors": ["'none'"],
+      },
+    },
+    // API + Swagger are not cross-origin embeddable documents.
+    crossOriginEmbedderPolicy: false,
+    frameguard: { action: "deny" },
+    noSniff: true,
+    // Referrer-Policy: avoid leaking path tokens to third parties.
+    referrerPolicy: { policy: "no-referrer" },
+    // X-DNS-Prefetch-Control off reduces incidental network side channels.
+    dnsPrefetchControl: { allow: false },
+    // Hide Express fingerprint.
+    hidePoweredBy: true,
+    // Only force HTTPS redirect header semantics in production.
+    // (Helmet does not redirect; this documents intent via options shape.)
+    ...(isProduction ? {} : {}),
+  };
+}
+
+/**
+ * Secure cookie defaults for any future cookie-based auth.
+ * Not applied automatically — the API currently uses header auth only.
+ */
+export function loadCookieDefaults(
+  env: NodeJS.ProcessEnv = process.env,
+): SecurityPosture["cookieDefaults"] {
+  const isProduction = (env.NODE_ENV ?? "development") === "production";
+  return {
+    httpOnly: true,
+    secure: isProduction || env.COOKIE_SECURE === "true",
+    sameSite: "lax",
+    path: "/",
+  };
+}
+
+/** Aggregate security posture for bootstrap. */
+export function loadSecurityPosture(
+  env: NodeJS.ProcessEnv = process.env,
+): SecurityPosture {
+  return {
+    trustProxy: loadTrustProxy(env),
+    helmet: loadHelmetOptions(env),
+    cookieDefaults: loadCookieDefaults(env),
+  };
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,9 @@ import {
 } from "./middleware/rateLimit.js";
 import { loadCorsPolicy, isAllowedCorsOrigin } from "./config/cors.js";
 import { loadRateLimitConfig, loadRateLimitStoreConfig } from "./config/rateLimit.js";
+import { loadSecurityPosture } from "./config/security.js";
 import { validateEnv } from "./config/env.js";
+import { applySecurityPosture } from "./middleware/securityHeaders.js";
 import { Container } from "./container/Container.js";
 import { initializeWebhooks } from "./services/drawWebhookService.js";
 import { logger } from "./utils/logger.js";
@@ -42,6 +44,10 @@ const openapiSpec = yaml.parse(
 ) as Record<string, unknown>;
 
 export const app = express();
+
+// Baseline security posture: trust proxy + Helmet headers (HSTS/CSP/XFO/…).
+// Must run before routes so every response, including errors, carries headers.
+applySecurityPosture(app, loadSecurityPosture());
 
 // ✅ Keep strict typing
 const port = Number(process.env.PORT ?? 3000);

--- a/src/middleware/__tests__/securityHeaders.test.ts
+++ b/src/middleware/__tests__/securityHeaders.test.ts
@@ -1,0 +1,77 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { applySecurityPosture } from "../securityHeaders.js";
+import { loadSecurityPosture } from "../../config/security.js";
+
+function buildApp(env: NodeJS.ProcessEnv = { NODE_ENV: "test" }) {
+  const app = express();
+  const posture = applySecurityPosture(app, loadSecurityPosture(env));
+  app.get("/health", (_req, res) => {
+    res.status(200).json({ status: "ok", ip: _req.ip });
+  });
+  return { app, posture };
+}
+
+describe("applySecurityPosture headers", () => {
+  it("sets baseline security headers on responses", async () => {
+    const { app } = buildApp({ NODE_ENV: "test" });
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+
+    // X-Content-Type-Options
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+
+    // X-Frame-Options
+    expect(res.headers["x-frame-options"]).toBe("DENY");
+
+    // HSTS
+    expect(res.headers["strict-transport-security"]).toMatch(/max-age=\d+/i);
+    expect(res.headers["strict-transport-security"]).toMatch(/includesubdomains/i);
+
+    // CSP present with self default
+    expect(res.headers["content-security-policy"]).toMatch(/default-src 'self'/i);
+    expect(res.headers["content-security-policy"]).toMatch(/frame-ancestors 'none'/i);
+
+    // Referrer-Policy
+    expect(res.headers["referrer-policy"]).toBe("no-referrer");
+
+    // X-DNS-Prefetch-Control
+    expect(res.headers["x-dns-prefetch-control"]).toBe("off");
+
+    // X-Powered-By stripped
+    expect(res.headers["x-powered-by"]).toBeUndefined();
+  });
+
+  it("configures trust proxy hop count so req.ip uses X-Forwarded-For", async () => {
+    const { app, posture } = buildApp({
+      NODE_ENV: "test",
+      TRUST_PROXY: "1",
+    });
+    expect(posture.trustProxy).toBe(1);
+
+    const res = await request(app)
+      .get("/health")
+      .set("X-Forwarded-For", "203.0.113.9");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ip).toBe("203.0.113.9");
+  });
+
+  it("ignores spoofed X-Forwarded-For when trust proxy is disabled", async () => {
+    const { app, posture } = buildApp({
+      NODE_ENV: "test",
+      TRUST_PROXY: "false",
+    });
+    expect(posture.trustProxy).toBe(false);
+
+    const res = await request(app)
+      .get("/health")
+      .set("X-Forwarded-For", "203.0.113.9");
+
+    expect(res.status).toBe(200);
+    // Without trust proxy, Express uses the direct socket address (loopback in tests).
+    expect(res.body.ip).not.toBe("203.0.113.9");
+  });
+});

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -1,0 +1,27 @@
+/**
+ * Applies the global Express security posture:
+ * - `trust proxy` (so `req.ip` / rate-limit keys reflect the real client)
+ * - Helmet security headers (HSTS, CSP, X-Frame-Options, nosniff, …)
+ *
+ * Call once during app bootstrap, before routes.
+ */
+
+import type { Express } from "express";
+import helmet from "helmet";
+import {
+  loadSecurityPosture,
+  type SecurityPosture,
+} from "../config/security.js";
+
+/**
+ * Configure trust-proxy and register Helmet middleware on `app`.
+ * Returns the resolved posture so callers can log or assert it in tests.
+ */
+export function applySecurityPosture(
+  app: Express,
+  posture: SecurityPosture = loadSecurityPosture(),
+): SecurityPosture {
+  app.set("trust proxy", posture.trustProxy);
+  app.use(helmet(posture.helmet));
+  return posture;
+}


### PR DESCRIPTION
## Summary
Hardens the Express security posture for production reverse-proxy deployments:

- **Helmet** baseline headers: HSTS, CSP (Swagger-safe), `X-Frame-Options: DENY`, `nosniff`, `Referrer-Policy: no-referrer`, hide `X-Powered-By`
- **`TRUST_PROXY`** env → `app.set('trust proxy', …)` so `req.ip` / rate-limit keys use the real client IP
- **Secure cookie defaults** documented/exported for future session/JWT work (API remains header-auth today)
- Unit + supertest coverage for headers and trust-proxy hop behavior
- Docs: `docs/SECURITY.md` §5, README production note, security checklist

Closes #192

## Test plan
- [x] `npx vitest run src/config/__tests__/security.test.ts src/middleware/__tests__/securityHeaders.test.ts` (13/13)
- [x] Header assertions: HSTS, CSP, XFO DENY, nosniff, no X-Powered-By
- [x] `TRUST_PROXY=1` makes `req.ip` honor `X-Forwarded-For`; disabled ignores spoofed header

Payout wallet (Stellar): `GBVHELLD2JE235Y2NGTDT3MWI3T65ON6SY4N6FBHYVDAQ5FZC2CP5QXH`
GrantFox OSS campaign — smart escrow payout on merge.