### PR TITLE
test(logredact): broaden redaction coverage for nested and edge inputs

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -23,6 +23,22 @@ the route, service, and repository layers. Anything placed here MUST:
 | `strings.ts`       | `isNonEmptyString`, `truncate`, `capitalize`              |
 | `time.ts`          | Duration constants and `sleep` / `nowSeconds` helpers     |
 
+## `logRedact.ts` — tested behaviors
+
+The redactor is the last line of defense before secrets reach stdout (used by
+Horizon listener and webhook logging). Coverage lives in
+[`src/__test__/logRedact.test.ts`](../src/__test__/logRedact.test.ts).
+
+| API | Behavior under test |
+| --- | --- |
+| `redactLogString` | Truncates Stellar **G…** public keys to `6…4`; replaces **S…** secret seeds, **M…** muxed accounts, and email addresses with fixed tokens. |
+| `redactLogValue` | Walks plain objects and arrays (including deep nests); redacts `Error.message` / `Error.stack`; breaks cycles with `"[Circular]"` via a `WeakSet`; passes numbers, booleans, `null`, and `undefined` through unchanged. |
+| `redactLogArgs` | Maps each arg through `redactLogValue`; returns a new array (does not mutate the input). |
+| `isLogRedactionDebugEnabled` | Truthy only for env values `"1"` and `"true"` (case-insensitive, trimmed). When enabled, all redact helpers return inputs **verbatim** (same reference for args/objects). |
+
+`LOG_REDACTION_DEBUG` must never be enabled in production. Tests that toggle the
+flag restore `process.env` in `afterEach`.
+
 ## Adding a new utility
 
 1. Create the module in `src/utils/<name>.ts` with full JSDoc.

--- a/src/__test__/logRedact.test.ts
+++ b/src/__test__/logRedact.test.ts
@@ -124,14 +124,117 @@ describe("logRedact", () => {
     expect(output).toBe(args);
   });
 
-  it("reads debug mode from LOG_REDACTION_DEBUG", () => {
+  it("redacts mixed-type arrays via redactLogArgs", () => {
+    const nested = {
+      walletAddress: STELLAR_ADDRESS,
+      count: 3,
+      ok: true,
+    };
+    const args: unknown[] = [
+      `seed=${STELLAR_SECRET_SEED}`,
+      nested,
+      [STELLAR_MUXED_ACCOUNT, EMAIL, 42],
+      null,
+      undefined,
+      false,
+      99,
+    ];
+
+    const output = redactLogArgs(args, false);
+
+    expect(output[0]).toBe("seed=[REDACTED_STELLAR_SECRET]");
+    expect(output[1]).toEqual({
+      walletAddress: "GCKFBE...EKJA",
+      count: 3,
+      ok: true,
+    });
+    expect(output[2]).toEqual([
+      "[REDACTED_MUXED_ACCOUNT]",
+      "[REDACTED_EMAIL]",
+      42,
+    ]);
+    expect(output[3]).toBeNull();
+    expect(output[4]).toBeUndefined();
+    expect(output[5]).toBe(false);
+    expect(output[6]).toBe(99);
+    // Structural copy — original nested object is not mutated.
+    expect(output[1]).not.toBe(nested);
+    expect(nested.walletAddress).toBe(STELLAR_ADDRESS);
+  });
+
+  it("passes non-string primitives through redactLogValue unchanged", () => {
+    expect(redactLogValue(0, false)).toBe(0);
+    expect(redactLogValue(42, false)).toBe(42);
+    expect(redactLogValue(true, false)).toBe(true);
+    expect(redactLogValue(false, false)).toBe(false);
+    expect(redactLogValue(null, false)).toBeNull();
+    expect(redactLogValue(undefined, false)).toBeUndefined();
+  });
+
+  it("returns primitives and Error references unchanged when debugEnabled is true", () => {
+    const err = new Error(`wallet=${STELLAR_ADDRESS}`);
+    expect(redactLogValue(err, true)).toBe(err);
+    expect(redactLogValue(STELLAR_ADDRESS, true)).toBe(STELLAR_ADDRESS);
+    expect(redactLogValue({ a: 1 }, true)).toEqual({ a: 1 });
+  });
+
+  it("reads debug mode from LOG_REDACTION_DEBUG including truthy '1' and 'true'", () => {
     process.env.LOG_REDACTION_DEBUG = "true";
     expect(isLogRedactionDebugEnabled()).toBe(true);
 
     process.env.LOG_REDACTION_DEBUG = "1";
     expect(isLogRedactionDebugEnabled()).toBe(true);
 
+    process.env.LOG_REDACTION_DEBUG = " TRUE ";
+    expect(isLogRedactionDebugEnabled()).toBe(true);
+
     process.env.LOG_REDACTION_DEBUG = "false";
     expect(isLogRedactionDebugEnabled()).toBe(false);
+
+    process.env.LOG_REDACTION_DEBUG = "yes";
+    expect(isLogRedactionDebugEnabled()).toBe(false);
+
+    delete process.env.LOG_REDACTION_DEBUG;
+    expect(isLogRedactionDebugEnabled()).toBe(false);
+  });
+
+  it("bypasses redaction via env for redactLogString and redactLogValue when LOG_REDACTION_DEBUG is set", () => {
+    process.env.LOG_REDACTION_DEBUG = "1";
+    expect(redactLogString(`wallet=${STELLAR_ADDRESS}`)).toBe(
+      `wallet=${STELLAR_ADDRESS}`,
+    );
+    expect(redactLogValue({ walletAddress: STELLAR_ADDRESS })).toEqual({
+      walletAddress: STELLAR_ADDRESS,
+    });
+
+    process.env.LOG_REDACTION_DEBUG = "true";
+    const args = [STELLAR_SECRET_SEED, EMAIL];
+    expect(redactLogArgs(args)).toBe(args);
+  });
+
+  it("redacts deeply nested plain objects without mutating the input", () => {
+    const input = {
+      level1: {
+        level2: {
+          level3: {
+            wallet: STELLAR_ADDRESS,
+            note: `contact ${EMAIL}`,
+            flags: [true, null, STELLAR_MUXED_ACCOUNT],
+          },
+        },
+      },
+    };
+
+    const output = redactLogValue(input, false);
+
+    expect(output.level1.level2.level3.wallet).toBe("GCKFBE...EKJA");
+    expect(output.level1.level2.level3.note).toBe("contact [REDACTED_EMAIL]");
+    expect(output.level1.level2.level3.flags).toEqual([
+      true,
+      null,
+      "[REDACTED_MUXED_ACCOUNT]",
+    ]);
+    expect(input.level1.level2.level3.wallet).toBe(STELLAR_ADDRESS);
+    expect(input.level1.level2.level3.note).toContain(EMAIL);
   });
 });


### PR DESCRIPTION
## Summary
Expands the `logRedact` test matrix (tests + docs only; no production-code change):

- `redactLogArgs` mixed-type arrays (string/object/array/null/undefined/bool/number)
- Primitive pass-through for `redactLogValue`
- Deep nested plain objects without mutating input
- `LOG_REDACTION_DEBUG` truthy variants (`1` / `true` / trimmed case) and full bypass paths
- Documents the redactor contract in `docs/utils.md`

Closes #236

## Test plan
- [x] `npx vitest run src/__test__/logRedact.test.ts` (15/15)
- [x] `process.env` restored after debug-flag tests via `afterEach`

Payout wallet (Stellar): `GBVHELLD2JE235Y2NGTDT3MWI3T65ON6SY4N6FBHYVDAQ5FZC2CP5QXH`
GrantFox OSS campaign — smart escrow payout on merge.