### PR TITLE
feat(api): cursor pagination standard across list endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -74,9 +74,32 @@ Rate-limit responses additionally include `retryAfter` and the `Retry-After` HTT
 
 ## 3. Pagination & filtering conventions
 
-Two pagination styles ship — pick the one the endpoint advertises in its query schema.
+### Cursor (standard — preferred for all list endpoints)
 
-### Offset/limit (default for risk history, transactions)
+Presence of the `cursor` query param (even empty) selects cursor mode.
+
+| Param | Type | Default | Bounds |
+|---|---|---|---|
+| `cursor` | string | — | opaque |
+| `limit` | int | 25 (varies by endpoint) | 1–100 |
+
+Response pagination block:
+
+```json
+{ "limit": 25, "nextCursor": "<opaque>|null", "hasMore": true }
+```
+
+Applied to:
+
+- `GET /api/credit/lines`
+- `GET /api/credit/lines/:id/transactions`
+- `GET /api/admin/api-keys` and `GET /api/admin/api-keys/audit`
+- `GET /api/webhooks/deliveries`
+
+Cursors are opaque base64url payloads; clients must pass `nextCursor` back
+verbatim. Full details: [`docs/cursor-pagination.md`](./cursor-pagination.md).
+
+### Offset / page (legacy, still supported)
 
 | Param | Type | Default | Bounds |
 |---|---|---|---|
@@ -84,9 +107,8 @@ Two pagination styles ship — pick the one the endpoint advertises in its query
 | `limit` | int | 20 | 1–100 |
 | `page` *(transactions only)* | int | 1 | ≥ 1 |
 
-### Cursor (credit-line list)
-
-`CreditLineService.getAllCreditLinesWithCursor(cursor?, limit?)` returns `{ items, nextCursor }`. Cursor is an opaque string; clients should pass it back verbatim. See [`docs/cursor-pagination.md`](./cursor-pagination.md).
+Used when `cursor` is **omitted** on credit-line list, transaction history, and
+risk history.
 
 ### Filtering — transactions
 
@@ -94,7 +116,7 @@ Two pagination styles ship — pick the one the endpoint advertises in its query
 
 - `type` ∈ `borrow | repay | interest_accrual | fee | status_change`
 - `from`, `to` — ISO-8601 date strings (`new Date(from).getTime()` must be valid)
-- `page`, `limit`
+- `cursor`, `limit` (standard) **or** `page`, `limit` (legacy)
 
 ---
 
@@ -176,7 +198,7 @@ Patches `creditLimit`, `interestRateBps`, or `status`.
 
 Filterable transaction history.
 
-- **Query:** `type`, `from`, `to`, `page`, `limit` (see §3).
+- **Query:** `type`, `from`, `to`, plus `cursor`/`limit` (standard) or `page`/`limit` (legacy). See �3.
 - **Errors:** `400` for any bad filter; `404` if line not found.
 
 #### `POST /api/credit/lines/:id/draw`

--- a/docs/cursor-pagination.md
+++ b/docs/cursor-pagination.md
@@ -1,214 +1,118 @@
-# Cursor Pagination for Credit Lines
+# Cursor Pagination Standard
 
-## Overview
+Creditra list endpoints share a single **cursor-based** pagination model.
+Clients should prefer cursor mode for production traffic: it is stable under
+concurrent inserts, does not require total counts, and uses **opaque** cursors
+so internal sort keys are not part of the public contract.
 
-This document describes the cursor-based pagination implementation for the credit lines API endpoint. Cursor pagination provides stable, efficient pagination for large datasets and is the recommended approach for production use.
+Offset/`page` pagination remains available on some endpoints for backward
+compatibility; new clients should use cursors.
 
-## Features
+## Query parameters
 
-- **Backward Compatible**: The API supports both offset-based (legacy) and cursor-based pagination
-- **Stable Results**: Cursor pagination ensures consistent results even when data changes between requests
-- **Efficient**: No need to count total items or skip records
-- **Simple**: Easy to implement in client applications
+| Param | Type | Default | Bounds | Notes |
+|---|---|---|---|---|
+| `cursor` | string | — | opaque | Presence (even empty: `?cursor`) enables cursor mode |
+| `limit` | int | endpoint default | 1–100 | Shared via `DEFAULT_PAGE_SIZE` / `MAX_PAGE_SIZE` |
 
-## API Usage
+## Response shape
 
-### Endpoint
-
-```
-GET /api/credit/lines
-```
-
-### Pagination Modes
-
-#### 1. Cursor-Based Pagination (Recommended)
-
-Use the `cursor` parameter to enable cursor-based pagination:
-
-```bash
-# First page
-GET /api/credit/lines?cursor&limit=10
-
-# Next page (use nextCursor from previous response)
-GET /api/credit/lines?cursor=<nextCursor>&limit=10
-```
-
-**Response Format:**
 ```json
 {
-  "creditLines": [...],
+  "items": [ /* resource-specific */ ],
   "pagination": {
-    "limit": 10,
-    "nextCursor": "base64EncodedCursor",
+    "limit": 25,
+    "nextCursor": "eyJ2IjoxLCJ0IjoxNzAwMDAwMDAwMDAwLCJpIjoiLi4uIn0",
     "hasMore": true
   }
 }
 ```
 
-**Fields:**
-- `limit`: Number of items per page
-- `nextCursor`: Cursor for the next page (null if no more pages)
-- `hasMore`: Boolean indicating if more results are available
+Field names for the item array vary by resource (`creditLines`, `transactions`,
+`items`, …) but **`pagination` is always** `{ limit, nextCursor, hasMore }`.
 
-#### 2. Offset-Based Pagination (Legacy)
+- `nextCursor` is `null` when `hasMore` is `false`.
+- Clients must treat cursors as **opaque**: pass them back unchanged; do not
+  decode or construct them client-side.
 
-Use `offset` and `limit` parameters for traditional pagination:
+## Ordering (deterministic)
 
-```bash
-GET /api/credit/lines?offset=0&limit=10
-```
+Every cursor page is ordered by a composite key:
 
-**Response Format:**
+1. Primary timestamp (`createdAt` / `timestamp` / `updatedAt` / `at`)
+2. Stable string id tie-break
+
+| Endpoint | Order | Sort key |
+|---|---|---|
+| `GET /api/credit/lines?cursor` | ASC | `createdAt`, `id` |
+| `GET /api/credit/lines/:id/transactions?cursor` | DESC | `timestamp`, `id` |
+| `GET /api/admin/api-keys?cursor` | ASC | `createdAt`, `id` |
+| `GET /api/admin/api-keys/audit?cursor` | DESC | `at`, composite id |
+| `GET /api/webhooks/deliveries` | DESC | `updatedAt`, `drawId::url` |
+
+## Cursor format (server-internal)
+
+Cursors are **base64url**-encoded JSON:
+
 ```json
-{
-  "creditLines": [...],
-  "pagination": {
-    "total": 100,
-    "offset": 0,
-    "limit": 10
-  }
-}
+{ "v": 1, "t": 1700000000000, "i": "<tie-break-id>" }
 ```
 
-## Query Parameters
+- `v` — format version (`1`)
+- `t` — epoch milliseconds of the sort timestamp
+- `i` — unique tie-breaker string
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `cursor` | string | No | - | Cursor for pagination. When present, enables cursor mode |
-| `offset` | integer | No | 0 | Offset for legacy pagination (ignored if cursor is present) |
-| `limit` | integer | No | 100 | Number of items per page (1-100) |
+Legacy credit-line cursors of the form `base64(timestamp|id)` are still
+accepted during decode so in-flight clients are not broken mid-rollout.
+New responses always mint the versioned opaque form.
 
-## Implementation Details
+Malformed cursors are handled **leniently** on list endpoints that predate the
+standard (credit lines restart from the first page). Prefer not relying on that
+behavior; mint cursors only from `nextCursor`.
 
-### Cursor Format
+## Shared implementation
 
-Cursors are base64-encoded strings containing:
-- Timestamp of the last item (createdAt)
-- ID of the last item
+| Module | Role |
+|---|---|
+| [`src/utils/cursorPagination.ts`](../src/utils/cursorPagination.ts) | encode/decode, clamp limit, in-memory page builder, SQL seek helper |
+| [`src/schemas/pagination.schema.ts`](../src/schemas/pagination.schema.ts) | Zod query schemas |
+| [`src/utils/constants.ts`](../src/utils/constants.ts) | `DEFAULT_PAGE_SIZE`, `MAX_PAGE_SIZE`, `MIN_PAGE_SIZE` |
 
-This ensures stable ordering even when items are added or removed.
+Repositories should either call `paginateArray` (in-memory) or over-fetch
+`limit + 1` rows with a seek predicate and `buildPageFromOverfetch`.
 
-### Ordering
-
-Results are ordered by:
-1. `createdAt` timestamp (ascending)
-2. `id` (ascending, for items with same timestamp)
-
-This provides a stable, deterministic ordering for pagination.
-
-### Error Handling
-
-The API returns 400 Bad Request for invalid parameters:
-- `limit` must be between 1 and 100
-- Invalid cursors are handled gracefully by starting from the beginning
-
-## Client Implementation Examples
-
-### JavaScript/TypeScript
+## Client example
 
 ```typescript
-async function fetchAllCreditLines() {
-  const allItems = [];
-  let cursor = undefined;
-  
-  do {
-    const url = cursor 
-      ? `/api/credit/lines?cursor=${cursor}&limit=50`
-      : '/api/credit/lines?cursor&limit=50';
-    
-    const response = await fetch(url);
-    const data = await response.json();
-    
-    allItems.push(...data.creditLines);
-    cursor = data.pagination.nextCursor;
-  } while (cursor);
-  
-  return allItems;
+async function fetchAllCreditLines(baseUrl: string) {
+  const all = [];
+  let cursor: string | undefined;
+  let hasMore = true;
+
+  while (hasMore) {
+    const qs = new URLSearchParams({ limit: '50' });
+    // Empty cursor engages cursor mode on the first page.
+    qs.set('cursor', cursor ?? '');
+    const res = await fetch(`${baseUrl}/api/credit/lines?${qs}`);
+    const body = await res.json();
+    all.push(...body.creditLines);
+    cursor = body.pagination.nextCursor ?? undefined;
+    hasMore = body.pagination.hasMore;
+  }
+  return all;
 }
 ```
 
-### Python
+## Error handling
 
-```python
-def fetch_all_credit_lines():
-    all_items = []
-    cursor = None
-    
-    while True:
-        url = f"/api/credit/lines?cursor={cursor}&limit=50" if cursor else "/api/credit/lines?cursor&limit=50"
-        response = requests.get(url)
-        data = response.json()
-        
-        all_items.extend(data['creditLines'])
-        cursor = data['pagination']['nextCursor']
-        
-        if not cursor:
-            break
-    
-    return all_items
-```
+| Condition | HTTP | Message pattern |
+|---|---|---|
+| `limit` &lt; 1 | 400 | `Limit must be greater than 0` |
+| `limit` &gt; 100 | 400 | `Limit cannot exceed 100` |
+| Invalid filter (e.g. webhook `status`) | 400 | endpoint-specific |
 
-## Testing
+## Migration
 
-Comprehensive tests are included for:
-- First page retrieval
-- Next page using cursor
-- Last page detection (nextCursor = null)
-- Cursor exhaustion
-- Invalid cursor handling
-- Stable ordering across pages
-- Empty result sets
-- Limit validation
-
-Run tests with:
-```bash
-npm test
-```
-
-## Migration Guide
-
-### For Existing Clients
-
-No changes required! The API remains backward compatible with offset-based pagination.
-
-### For New Implementations
-
-Use cursor-based pagination for better performance and stability:
-
-**Before (offset-based):**
-```javascript
-const response = await fetch('/api/credit/lines?offset=20&limit=10');
-```
-
-**After (cursor-based):**
-```javascript
-// First page
-const firstPage = await fetch('/api/credit/lines?cursor&limit=10');
-
-// Next page
-const nextPage = await fetch(
-  `/api/credit/lines?cursor=${firstPage.pagination.nextCursor}&limit=10`
-);
-```
-
-## Performance Considerations
-
-- **Cursor pagination**: O(n) where n is the position of the cursor
-- **Offset pagination**: O(n) where n is the offset value
-- For large offsets, cursor pagination is more efficient as it doesn't require counting/skipping records
-- Cursor pagination provides consistent results even when data changes between requests
-
-## Security Notes
-
-- Cursors are opaque tokens and should not be parsed or modified by clients
-- Invalid cursors are handled gracefully without exposing internal data structures
-- No PII or sensitive data is included in cursors
-- Rate limiting should be applied at the API gateway level
-
-## Future Enhancements
-
-Potential improvements for future versions:
-- Bidirectional pagination (previous page support)
-- Custom ordering fields
-- Filtering support with cursor pagination
-- Cursor expiration/validation
+- Existing offset / page clients keep working when they omit `cursor`.
+- To migrate: request `?cursor&limit=N`, then follow `pagination.nextCursor`
+  until `hasMore` is false.

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -13,6 +13,7 @@ the route, service, and repository layers. Anything placed here MUST:
 | Module             | Purpose                                                   |
 | ------------------ | --------------------------------------------------------- |
 | `constants.ts`     | Pagination and body-size defaults shared by API endpoints |
+| `cursorPagination.ts` | Opaque cursor encode/decode, page builder, limit clamp |
 | `fetchWithTimeout` | HTTP client with structured timeout and request errors    |
 | `httpStatus.ts`    | Named HTTP status code constants                          |
 | `logger.ts`        | Process-wide pino logger configuration                    |

--- a/docs/webhook-subscribers.md
+++ b/docs/webhook-subscribers.md
@@ -164,6 +164,7 @@ The management routes are mounted under `/api/webhooks`.
 | `GET` | `/api/webhooks/config` | Returns sanitized webhook configuration: URLs, retry knobs, timeout, and configured state. It never returns `WEBHOOK_SECRET`. |
 | `POST` | `/api/webhooks/test` | Sends a connectivity probe to every configured URL and returns `{ total, reachable, unreachable, results }`. |
 | `GET` | `/api/webhooks/health` | Returns `disabled` when no URLs are configured, otherwise `active` with URL count and retry settings. |
+| `GET` | `/api/webhooks/deliveries` | Cursor-paginated delivery records (`cursor`, `limit`, optional `status`). See [`cursor-pagination.md`](./cursor-pagination.md). |
 
 ## Subscriber Checklist
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2698,7 +2697,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3291,7 +3289,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3753,7 +3750,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4555,7 +4551,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5901,7 +5896,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7475,7 +7469,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9074,7 +9067,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9158,7 +9150,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9318,7 +9309,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -9397,7 +9387,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -9708,7 +9697,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
 import { apiKeysRouter } from './routes/apiKeys.js';
+import { recordRequest, metricsRouter } from './routes/metrics.js';
+import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
+import { maintenanceRouter } from './routes/maintenance.js';
 
 export function createApp() {
   const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -58,6 +58,7 @@ export class Container {
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -168,7 +169,11 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
-  // Method to replace repositories (useful for testing or switching to DB implementations)
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
+  // Method to replace repositories
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;
     riskEvaluationRepository?: RiskEvaluationRepository;

--- a/src/container/__tests__/Container.contract.test.ts
+++ b/src/container/__tests__/Container.contract.test.ts
@@ -64,7 +64,7 @@ describe('Container DI contract', () => {
     });
 
     it.each(REPOSITORY_RESOLVERS)('resolves repository %s', (name) => {
-      const repo = container[name] as Record<string, unknown>;
+      const repo = container[name] as unknown as Record<string, unknown>;
       expect(repo, `${String(name)} must resolve`).toBeDefined();
       // A repository is a contract object: it must expose callable methods.
       expect(typeof repo).toBe('object');

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -152,6 +152,38 @@ components:
           format: date-time
           description: ISO 8601 last update timestamp
 
+    CursorPagination:
+      type: object
+      description: |
+        Standard cursor pagination meta block used by every list endpoint in
+        cursor mode. Cursors are opaque base64url strings; clients must pass
+        `nextCursor` back verbatim and must not parse them.
+      required: [limit, nextCursor, hasMore]
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Page size applied to this response
+        nextCursor:
+          type: string
+          nullable: true
+          description: Opaque cursor for the next page, or null when hasMore is false
+        hasMore:
+          type: boolean
+          description: True when additional items exist after this page
+
+    CursorPage:
+      type: object
+      description: Generic envelope for cursor-paginated collections
+      required: [items, pagination]
+      properties:
+        items:
+          type: array
+          items: {}
+        pagination:
+          $ref: "#/components/schemas/CursorPagination"
+
     CreditLinesResponse:
       type: object
       required: [creditLines, pagination]
@@ -161,15 +193,18 @@ components:
           items:
             $ref: "#/components/schemas/CreditLine"
         pagination:
-          type: object
-          properties:
-            total:
-              type: integer
-            offset:
-              type: integer
-            limit:
-              type: integer
-          required: [total, offset, limit]
+          oneOf:
+            - type: object
+              description: Offset/limit mode (legacy)
+              properties:
+                total:
+                  type: integer
+                offset:
+                  type: integer
+                limit:
+                  type: integer
+              required: [total, offset, limit]
+            - $ref: "#/components/schemas/CursorPagination"
 
     WalletCreditLinesResponse:
       type: object
@@ -233,25 +268,60 @@ components:
       required: [data]
       properties:
         data:
-          type: object
-          required: [transactions, total, page, limit, totalPages]
-          properties:
-            transactions:
-              type: array
-              items:
-                $ref: "#/components/schemas/Transaction"
-            total:
-              type: integer
-              description: Total number of transactions matching the applied filters
-            page:
-              type: integer
-              description: Current page number (1-indexed)
-            limit:
-              type: integer
-              description: Maximum number of transactions per page
-            totalPages:
-              type: integer
-              description: Total number of pages available
+          oneOf:
+            - type: object
+              description: Legacy page/limit pagination
+              required: [transactions, total, page, limit, totalPages]
+              properties:
+                transactions:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Transaction"
+                total:
+                  type: integer
+                  description: Total number of transactions matching the applied filters
+                page:
+                  type: integer
+                  description: Current page number (1-indexed)
+                limit:
+                  type: integer
+                  description: Maximum number of transactions per page
+                totalPages:
+                  type: integer
+                  description: Total number of pages available
+            - type: object
+              description: Standard cursor pagination (preferred)
+              required: [transactions, pagination]
+              properties:
+                transactions:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Transaction"
+                pagination:
+                  $ref: "#/components/schemas/CursorPagination"
+
+    WebhookDeliveryRecord:
+      type: object
+      required: [drawId, url, status, attempts, updatedAt]
+      properties:
+        drawId:
+          type: string
+        url:
+          type: string
+          format: uri
+        status:
+          type: string
+          enum: [delivered, failed, dead_letter]
+        attempts:
+          type: integer
+        lastError:
+          type: string
+        deliveredAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 
     # ── Risk Evaluation Schemas ───────────────────────────────────────────────
 
@@ -566,8 +636,22 @@ paths:
       tags: [Credit]
       operationId: listCreditLines
       summary: List all credit lines
+      description: |
+        Supports two pagination modes:
+        - **Cursor (preferred):** pass `cursor` (empty for the first page). Response
+          pagination is `{ limit, nextCursor, hasMore }` with opaque cursors.
+        - **Offset (legacy):** pass `offset` / `limit` without `cursor`.
+        See `docs/cursor-pagination.md`.
       security: []
       parameters:
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >
+            Opaque cursor from a previous response. Presence (even empty)
+            enables cursor pagination mode.
         - name: offset
           in: query
           required: false
@@ -575,7 +659,7 @@ paths:
             type: integer
             minimum: 0
             default: 0
-          description: Pagination offset
+          description: Pagination offset (legacy mode; ignored when cursor is present)
         - name: limit
           in: query
           required: false
@@ -608,12 +692,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreditLinesResponse"
-              example:
-                creditLines: []
-                pagination:
-                  total: 0
-                  offset: 0
-                  limit: 100
+              examples:
+                offsetMode:
+                  summary: Legacy offset pagination
+                  value:
+                    data:
+                      creditLines: []
+                      pagination:
+                        total: 0
+                        offset: 0
+                        limit: 100
+                    error: null
+                cursorMode:
+                  summary: Standard cursor pagination
+                  value:
+                    creditLines: []
+                    pagination:
+                      limit: 25
+                      nextCursor: null
+                      hasMore: false
         "400":
           description: Invalid query parameter
           content:
@@ -847,6 +944,14 @@ paths:
             type: string
             format: date-time
           description: Include only transactions at or before this ISO 8601 timestamp (inclusive)
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >
+            Opaque cursor. Presence enables standard cursor pagination
+            (`{ transactions, pagination: { limit, nextCursor, hasMore } }`).
         - name: page
           in: query
           required: false
@@ -854,7 +959,7 @@ paths:
             type: integer
             minimum: 1
             default: 1
-          description: Page number (1-indexed)
+          description: Page number (1-indexed, legacy mode)
         - name: limit
           in: query
           required: false
@@ -871,21 +976,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TransactionHistoryResponse"
-              example:
-                data:
-                  transactions:
-                    - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                      creditLineId: "line-abc"
-                      type: status_change
-                      amount: null
-                      currency: null
-                      timestamp: "2024-01-15T10:00:00.000Z"
-                      metadata:
-                        action: created
-                  total: 1
-                  page: 1
-                  limit: 20
-                  totalPages: 1
+              examples:
+                legacyPage:
+                  summary: Legacy page/limit
+                  value:
+                    data:
+                      transactions:
+                        - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                          creditLineId: "line-abc"
+                          type: status_change
+                          amount: null
+                          currency: null
+                          timestamp: "2024-01-15T10:00:00.000Z"
+                          metadata:
+                            action: created
+                      total: 1
+                      page: 1
+                      limit: 20
+                      totalPages: 1
+                    error: null
+                cursorMode:
+                  summary: Standard cursor pagination
+                  value:
+                    data:
+                      transactions: []
+                      pagination:
+                        limit: 20
+                        nextCursor: null
+                        hasMore: false
+                    error: null
         "400":
           description: Invalid query parameter
           content:
@@ -1182,6 +1301,76 @@ paths:
                 urls: 2
                 maxRetries: 3
                 timeoutMs: 10000
+
+  /api/webhooks/deliveries:
+    get:
+      tags: [Webhooks]
+      operationId: listWebhookDeliveries
+      summary: List webhook delivery records (cursor pagination)
+      description: |
+        Returns outbound delivery attempts using the standard cursor pagination
+        model. Sort order is `updatedAt DESC` with a stable `drawId::url` tie-break.
+        Cursors are opaque; pass `nextCursor` back verbatim.
+      security: []
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Opaque cursor from a previous page (empty/omit for first page)
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 25
+          description: Page size
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [delivered, failed, dead_letter]
+          description: Optional status filter
+      responses:
+        "200":
+          description: Cursor page of delivery records
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, error]
+                properties:
+                  data:
+                    type: object
+                    required: [items, pagination]
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/WebhookDeliveryRecord"
+                      pagination:
+                        $ref: "#/components/schemas/CursorPagination"
+                  error:
+                    type: string
+                    nullable: true
+              example:
+                data:
+                  items: []
+                  pagination:
+                    limit: 25
+                    nextCursor: null
+                    hasMore: false
+                error: null
+        "400":
+          description: Invalid query parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /api/risk/evaluations/{id}:
     get:

--- a/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
+++ b/src/repositories/__contract_tests__/TransactionRepository.contract.test.ts
@@ -13,7 +13,6 @@ import type { TransactionRepository } from '../interfaces/TransactionRepository.
 // ---------------------------------------------------------------------------
 
 const CREDIT_LINE_ID = '00000000-0000-0000-0000-000000000001';
-const WALLET = 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1';
 
 function sampleRequest(overrides: Partial<CreateTransactionRequest> = {}): CreateTransactionRequest {
   return {

--- a/src/repositories/interfaces/CreditLineRepository.ts
+++ b/src/repositories/interfaces/CreditLineRepository.ts
@@ -1,10 +1,7 @@
 import type { CreditLine, CreateCreditLineRequest, UpdateCreditLineRequest } from '../../models/CreditLine.js';
+import type { CursorPaginationResult } from '../../utils/cursorPagination.js';
 
-export interface CursorPaginationResult {
-  items: CreditLine[];
-  nextCursor: string | null;
-  hasMore: boolean;
-}
+export type { CursorPaginationResult };
 
 export interface CreditLineRepository {
   /**
@@ -28,9 +25,9 @@ export interface CreditLineRepository {
   findAll(offset?: number, limit?: number): Promise<CreditLine[]>;
 
   /**
-   * Get all credit lines with cursor-based pagination
+   * Get all credit lines with cursor-based pagination (shared opaque cursor model).
    */
-  findAllWithCursor(cursor?: string, limit?: number): Promise<CursorPaginationResult>;
+  findAllWithCursor(cursor?: string, limit?: number): Promise<CursorPaginationResult<CreditLine>>;
 
   /**
    * Update credit line

--- a/src/repositories/memory/InMemoryCreditLineRepository.ts
+++ b/src/repositories/memory/InMemoryCreditLineRepository.ts
@@ -1,6 +1,7 @@
-import{ type CreditLine, type CreateCreditLineRequest, type UpdateCreditLineRequest, CreditLineStatus } from '../../models/CreditLine.js';
-import type{ CreditLineRepository, CursorPaginationResult } from '../interfaces/CreditLineRepository.js';
+import { type CreditLine, type CreateCreditLineRequest, type UpdateCreditLineRequest, CreditLineStatus } from '../../models/CreditLine.js';
+import type { CreditLineRepository, CursorPaginationResult } from '../interfaces/CreditLineRepository.js';
 import { VersionConflictError } from '../../services/creditService.js';
+import { paginateArray } from '../../utils/cursorPagination.js';
 import { randomUUID } from 'crypto';
 
 export class InMemoryCreditLineRepository implements CreditLineRepository {
@@ -49,54 +50,19 @@ export class InMemoryCreditLineRepository implements CreditLineRepository {
     return all.slice(offset, offset + limit);
   }
 
-  async findAllWithCursor(cursor?: string, limit = 100): Promise<CursorPaginationResult> {
-    // Sort by createdAt and id for stable ordering
-    const all = Array.from(this.creditLines.values())
-      .sort((a, b) => {
-        const timeCompare = a.createdAt.getTime() - b.createdAt.getTime();
-        return timeCompare !== 0 ? timeCompare : a.id.localeCompare(b.id);
-      });
-
-    let startIndex = 0;
-
-    // If cursor is provided, find the starting position
-    if (cursor) {
-      try {
-        const decodedCursor = Buffer.from(cursor, 'base64').toString('utf-8');
-        const [cursorTime, cursorId] = decodedCursor.split('|');
-        
-        startIndex = all.findIndex(cl => {
-          const clTime = cl.createdAt.getTime().toString();
-          return clTime === cursorTime && cl.id === cursorId;
-        });
-
-        // If cursor not found or invalid, start from beginning
-        if (startIndex === -1) {
-          startIndex = 0;
-        } else {
-          // Start from the next item after the cursor
-          startIndex += 1;
-        }
-      } catch {
-        // Invalid cursor format, start from beginning
-        startIndex = 0;
-      }
-    }
-
-    const items = all.slice(startIndex, startIndex + limit);
-    const hasMore = startIndex + limit < all.length;
-
-    let nextCursor: string | null = null;
-    if (hasMore && items.length > 0) {
-      const lastItem = items[items.length - 1];
-      const cursorData = `${lastItem.createdAt.getTime()}|${lastItem.id}`;
-      nextCursor = Buffer.from(cursorData, 'utf-8').toString('base64');
-    }
-
+  async findAllWithCursor(cursor?: string, limit = 100): Promise<CursorPaginationResult<CreditLine>> {
+    // Shared opaque cursor + deterministic (createdAt ASC, id ASC) ordering.
+    const page = paginateArray(Array.from(this.creditLines.values()), {
+      cursor,
+      limit,
+      order: 'asc',
+      defaultLimit: 100,
+      getKey: (cl) => ({ t: cl.createdAt.getTime(), i: cl.id }),
+    });
     return {
-      items,
-      nextCursor,
-      hasMore
+      items: page.items,
+      nextCursor: page.nextCursor,
+      hasMore: page.hasMore,
     };
   }
 

--- a/src/repositories/postgres/PostgresCreditLineRepository.ts
+++ b/src/repositories/postgres/PostgresCreditLineRepository.ts
@@ -2,6 +2,10 @@ import type { CreditLine, CreateCreditLineRequest, UpdateCreditLineRequest, Cred
 import type { CreditLineRepository, CursorPaginationResult } from '../interfaces/CreditLineRepository.js';
 import type { DbClient } from '../../db/client.js';
 import { VersionConflictError } from '../../services/creditService.js';
+import {
+  buildPageFromOverfetch,
+  decodeCursor,
+} from '../../utils/cursorPagination.js';
 
 interface CreditLineRow {
   id: string;
@@ -155,30 +159,13 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
     return creditLines;
   }
 
-  async findAllWithCursor(cursor?: string, limit = 100): Promise<CursorPaginationResult> {
-    let cursorTime: Date | null = null;
-    let cursorId: string | null = null;
-
-    if (cursor) {
-      try {
-        const decodedCursor = Buffer.from(cursor, 'base64').toString('utf-8');
-        const [timestamp, id] = decodedCursor.split('|');
-        const parsedTime = new Date(Number(timestamp));
-        if (!Number.isNaN(parsedTime.getTime()) && id) {
-          cursorTime = parsedTime;
-          cursorId = id;
-        }
-      } catch {
-        cursorTime = null;
-        cursorId = null;
-      }
-    }
-
-    const whereClause = cursorTime && cursorId
+  async findAllWithCursor(cursor?: string, limit = 100): Promise<CursorPaginationResult<CreditLine>> {
+    const decoded = decodeCursor(cursor);
+    const whereClause = decoded
       ? 'WHERE (cl.created_at > $2 OR (cl.created_at = $2 AND cl.id > $3))'
       : '';
-    const values = cursorTime && cursorId
-      ? [limit + 1, cursorTime, cursorId]
+    const values = decoded
+      ? [limit + 1, new Date(decoded.t), decoded.i]
       : [limit + 1];
 
     const query = `
@@ -208,16 +195,15 @@ export class PostgresCreditLineRepository implements CreditLineRepository {
       creditLines.push(this.toCreditLine(row, availableCredit));
     }
 
-    const hasMore = creditLines.length > limit;
-    const items = creditLines.slice(0, limit);
-    const lastItem = items[items.length - 1];
+    const page = buildPageFromOverfetch(creditLines, limit, (cl) => ({
+      t: cl.createdAt.getTime(),
+      i: cl.id,
+    }));
 
     return {
-      items,
-      hasMore,
-      nextCursor: hasMore && lastItem
-        ? Buffer.from(`${lastItem.createdAt.getTime()}|${lastItem.id}`, 'utf-8').toString('base64')
-        : null,
+      items: page.items,
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
     };
   }
 

--- a/src/repositories/postgres/PostgresTransactionRepository.ts
+++ b/src/repositories/postgres/PostgresTransactionRepository.ts
@@ -2,7 +2,7 @@ import {
   type Transaction,
   type CreateTransactionRequest,
   TransactionStatus,
-  TransactionType,
+  type TransactionType,
 } from '../../models/Transaction.js';
 import type { TransactionRepository } from '../interfaces/TransactionRepository.js';
 import type { DbClient } from '../../db/client.js';

--- a/src/routes/__tests__/cursorPagination.routes.test.ts
+++ b/src/routes/__tests__/cursorPagination.routes.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Integration tests for the standard cursor pagination model across list endpoints.
+ */
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
+import { creditRouter } from '../credit.js';
+import { apiKeysRouter } from '../apiKeys.js';
+import { webhookRouter } from '../webhook.js';
+import { Container } from '../../container/Container.js';
+import {
+  createCreditLine,
+  _resetStore,
+  getTransactionsWithCursor,
+} from '../../services/creditService.js';
+import { defaultApiKeyStore } from '../../services/apiKeyStore.js';
+import { ADMIN_KEY_HEADER } from '../../middleware/adminAuth.js';
+import {
+  getWebhookDeliveryStateStore,
+  setWebhookDeliveryStateStore,
+  type WebhookDeliveryStateStore,
+  type DeliveryRecord,
+} from '../../services/webhookDeliveryState.js';
+import { decodeCursor } from '../../utils/cursorPagination.js';
+
+const ADMIN = 'admin-secret-for-cursor-tests';
+
+function clearCreditLines(container: Container): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const repo = container.creditLineRepository as any;
+  if (repo && typeof repo.clear === 'function') {
+    repo.clear();
+  }
+}
+
+describe('cursor pagination standard — routes', () => {
+  let creditApp: express.Application;
+  let adminApp: express.Application;
+  let webhookApp: express.Application;
+  let container: Container;
+  let previousWebhookStore: WebhookDeliveryStateStore;
+  let originalAdmin: string | undefined;
+
+  beforeAll(() => {
+    container = Container.getInstance();
+    creditApp = express();
+    creditApp.use(express.json());
+    creditApp.use('/api/credit', creditRouter);
+
+    adminApp = express();
+    adminApp.use(express.json());
+    adminApp.use('/api/admin/api-keys', apiKeysRouter);
+
+    webhookApp = express();
+    webhookApp.use(express.json());
+    webhookApp.use('/api/webhooks', webhookRouter);
+  });
+
+  beforeEach(() => {
+    originalAdmin = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN;
+    clearCreditLines(container);
+    _resetStore();
+    previousWebhookStore = getWebhookDeliveryStateStore();
+  });
+
+  afterEach(() => {
+    if (originalAdmin === undefined) delete process.env.ADMIN_API_KEY;
+    else process.env.ADMIN_API_KEY = originalAdmin;
+    setWebhookDeliveryStateStore(previousWebhookStore);
+    clearCreditLines(container);
+  });
+
+  describe('GET /api/credit/lines (cursor)', () => {
+    it('pages without overlap and ends with hasMore=false', async () => {
+      for (let i = 0; i < 5; i++) {
+        await container.creditLineService.createCreditLine({
+          walletAddress: `wallet-cursor-${i}`,
+          creditLimit: '1000.00',
+          interestRateBps: 100,
+        });
+        await new Promise((r) => setTimeout(r, 2));
+      }
+
+      const first = await request(creditApp).get('/api/credit/lines?cursor&limit=2').expect(200);
+      expect(first.body.creditLines).toHaveLength(2);
+      expect(first.body.pagination.hasMore).toBe(true);
+      expect(first.body.pagination.nextCursor).toBeTruthy();
+      expect(first.body.pagination.nextCursor).not.toMatch(/\|/);
+
+      const second = await request(creditApp)
+        .get(
+          `/api/credit/lines?cursor=${encodeURIComponent(first.body.pagination.nextCursor)}&limit=2`,
+        )
+        .expect(200);
+      expect(second.body.creditLines).toHaveLength(2);
+
+      const firstIds = first.body.creditLines.map((c: { id: string }) => c.id);
+      const secondIds = second.body.creditLines.map((c: { id: string }) => c.id);
+      expect(firstIds.some((id: string) => secondIds.includes(id))).toBe(false);
+
+      const third = await request(creditApp)
+        .get(
+          `/api/credit/lines?cursor=${encodeURIComponent(second.body.pagination.nextCursor)}&limit=2`,
+        )
+        .expect(200);
+      expect(third.body.creditLines).toHaveLength(1);
+      expect(third.body.pagination.hasMore).toBe(false);
+      expect(third.body.pagination.nextCursor).toBeNull();
+    });
+
+    it('rejects invalid limits', async () => {
+      const zero = await request(creditApp).get('/api/credit/lines?cursor&limit=0').expect(400);
+      expect(zero.body.error).toMatch(/Limit must be greater than 0/);
+      const big = await request(creditApp).get('/api/credit/lines?cursor&limit=101').expect(400);
+      expect(big.body.error).toMatch(/Limit cannot exceed 100/);
+    });
+
+    it('handles invalid cursor gracefully (starts from beginning)', async () => {
+      await container.creditLineService.createCreditLine({
+        walletAddress: 'wallet-invalid-cursor',
+        creditLimit: '1000.00',
+        interestRateBps: 100,
+      });
+      const res = await request(creditApp)
+        .get('/api/credit/lines?cursor=not-a-valid-cursor&limit=10')
+        .expect(200);
+      expect(res.body.creditLines.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /api/credit/lines/:id/transactions (cursor)', () => {
+    it('returns cursor page envelope for transaction history', async () => {
+      const line = createCreditLine('tx-cursor-line');
+      const res = await request(creditApp)
+        .get(`/api/credit/lines/${line.id}/transactions?cursor&limit=10`)
+        .expect(200);
+
+      expect(res.body.data.transactions).toBeDefined();
+      expect(res.body.data.pagination).toMatchObject({
+        limit: 10,
+        hasMore: false,
+        nextCursor: null,
+      });
+      expect(Array.isArray(res.body.data.transactions)).toBe(true);
+      expect(res.body.data.transactions.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('service helper returns CursorPage shape', () => {
+      const id = 'many-tx-line';
+      createCreditLine(id);
+      const page = getTransactionsWithCursor(id, {}, { limit: 10 });
+      expect(page.items.length).toBeGreaterThanOrEqual(1);
+      expect(page).toHaveProperty('nextCursor');
+      expect(page).toHaveProperty('hasMore');
+      expect(page.limit).toBe(10);
+    });
+
+    it('keeps legacy page/limit response when cursor is omitted', async () => {
+      const line = createCreditLine('tx-legacy-line');
+      const res = await request(creditApp)
+        .get(`/api/credit/lines/${line.id}/transactions?page=1&limit=20`)
+        .expect(200);
+      expect(res.body.data).toMatchObject({
+        page: 1,
+        limit: 20,
+      });
+      expect(res.body.data.transactions).toBeDefined();
+      expect(res.body.data.total).toBeDefined();
+    });
+  });
+
+  describe('GET /api/admin/api-keys and /audit (cursor)', () => {
+    it('paginates API key list and audit log', async () => {
+      const issuedIds: string[] = [];
+      for (let i = 0; i < 4; i++) {
+        const { id } = defaultApiKeyStore.issue(`cursor-label-${Date.now()}-${i}`);
+        issuedIds.push(id);
+        await new Promise((r) => setTimeout(r, 2));
+      }
+
+      const list = await request(adminApp)
+        .get('/api/admin/api-keys?cursor&limit=2')
+        .set(ADMIN_KEY_HEADER, ADMIN)
+        .expect(200);
+
+      expect(list.body.data.items).toHaveLength(2);
+      expect(list.body.data.pagination.hasMore).toBe(true);
+      expect(list.body.data.pagination.nextCursor).toBeTruthy();
+      expect(decodeCursor(list.body.data.pagination.nextCursor)).not.toBeNull();
+
+      const list2 = await request(adminApp)
+        .get(
+          `/api/admin/api-keys?cursor=${encodeURIComponent(list.body.data.pagination.nextCursor)}&limit=2`,
+        )
+        .set(ADMIN_KEY_HEADER, ADMIN)
+        .expect(200);
+      expect(list2.body.data.items.length).toBeGreaterThanOrEqual(1);
+
+      const audit = await request(adminApp)
+        .get('/api/admin/api-keys/audit?cursor&limit=2')
+        .set(ADMIN_KEY_HEADER, ADMIN)
+        .expect(200);
+      expect(audit.body.data.items).toHaveLength(2);
+      expect(audit.body.data.pagination.limit).toBe(2);
+      expect(audit.body.data.pagination.hasMore).toBe(true);
+      expect(audit.body.data.pagination.nextCursor).toBeTruthy();
+
+      // Cleanup issued keys (best-effort revoke).
+      for (const id of issuedIds) defaultApiKeyStore.revoke(id);
+    });
+
+    it('keeps legacy unpaginated responses without cursor param', async () => {
+      const list = await request(adminApp)
+        .get('/api/admin/api-keys')
+        .set(ADMIN_KEY_HEADER, ADMIN)
+        .expect(200);
+      expect(Array.isArray(list.body.data)).toBe(true);
+
+      const audit = await request(adminApp)
+        .get('/api/admin/api-keys/audit')
+        .set(ADMIN_KEY_HEADER, ADMIN)
+        .expect(200);
+      expect(Array.isArray(audit.body.data)).toBe(true);
+    });
+  });
+
+  describe('GET /api/webhooks/deliveries', () => {
+    it('paginates delivery records with stable cursors', async () => {
+      const records = new Map<string, DeliveryRecord>();
+      const store: WebhookDeliveryStateStore = {
+        isDelivered: () => false,
+        record: () => undefined,
+        deadLetters: () => [],
+        list: () => [...records.values()],
+        counts: () => ({ total: records.size, delivered: 0, failed: 0, deadLetter: 0 }),
+      };
+      for (let i = 0; i < 5; i++) {
+        const rec: DeliveryRecord = {
+          drawId: `draw-${i}`,
+          url: `https://example.com/hook/${i}`,
+          status: i % 2 === 0 ? 'delivered' : 'failed',
+          attempts: 1,
+          updatedAt: new Date(1_700_000_000_000 + i * 1000).toISOString(),
+        };
+        records.set(`${rec.drawId}::${rec.url}`, rec);
+      }
+      setWebhookDeliveryStateStore(store);
+
+      const first = await request(webhookApp).get('/api/webhooks/deliveries?limit=2').expect(200);
+      expect(first.body.data.items).toHaveLength(2);
+      expect(first.body.data.pagination.hasMore).toBe(true);
+
+      const second = await request(webhookApp)
+        .get(
+          `/api/webhooks/deliveries?cursor=${encodeURIComponent(first.body.data.pagination.nextCursor)}&limit=2`,
+        )
+        .expect(200);
+      expect(second.body.data.items).toHaveLength(2);
+
+      const firstKeys = first.body.data.items.map(
+        (r: DeliveryRecord) => `${r.drawId}::${r.url}`,
+      );
+      const secondKeys = second.body.data.items.map(
+        (r: DeliveryRecord) => `${r.drawId}::${r.url}`,
+      );
+      expect(firstKeys.some((k: string) => secondKeys.includes(k))).toBe(false);
+
+      const filtered = await request(webhookApp)
+        .get('/api/webhooks/deliveries?status=delivered&limit=10')
+        .expect(200);
+      expect(
+        filtered.body.data.items.every((r: DeliveryRecord) => r.status === 'delivered'),
+      ).toBe(true);
+    });
+
+    it('rejects invalid status filter', async () => {
+      await request(webhookApp).get('/api/webhooks/deliveries?status=nope').expect(400);
+    });
+  });
+});

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import { metricsRouter, recordRequest } from '../metrics.js';
 
@@ -45,16 +45,6 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
       return this;
     },
   } as unknown as Response;
-
-  const runHandlers = async (index: number): Promise<void> => {
-    if (index >= handlers.length) return;
-    await new Promise<void>((resolve) => {
-      handlers[index](req, res, () => {
-        resolve();
-        runHandlers(index + 1);
-      });
-    });
-  };
 
   // Execute the first handler (auth guard); if it calls next, proceed to the route handler.
   await new Promise<void>((resolve) => {

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -23,9 +23,8 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
     throw new Error(`Route not found: ${args.method.toUpperCase()} ${args.path}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handlers: Array<(req: Request, res: Response, next: NextFunction) => unknown> =
-    layer.route.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
+    layer.route!.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
 
   let statusCode = 200;
   let responseBody: unknown = null;

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -7,15 +7,19 @@
  *
  * Surface (all require `X-Admin-Api-Key`):
  *  - POST   `/`            — issue a new key. Returns plaintext ONCE.
- *  - GET    `/`            — list key metadata (no secrets).
+ *  - GET    `/`            — list key metadata (no secrets). Supports cursor pagination.
  *  - DELETE `/:id`         — revoke a key (enters grace period).
- *  - GET    `/audit`       — audit log of issue/revoke actions.
+ *  - GET    `/audit`       — audit log of issue/revoke actions (cursor pagination).
  *
  * Operational runbook: see `docs/API_KEY_ROTATION.md`.
  */
 import { Router, type Request, type Response } from 'express';
 import { adminAuth } from '../middleware/adminAuth.js';
 import { defaultApiKeyStore } from '../services/apiKeyStore.js';
+import {
+  parseCursorQuery,
+  toPaginationMeta,
+} from '../utils/cursorPagination.js';
 
 export const apiKeysRouter = Router();
 
@@ -37,13 +41,51 @@ apiKeysRouter.post('/', adminAuth, (req: Request, res: Response) => {
 });
 
 /** GET /api/admin/api-keys — list metadata (never secrets). */
-apiKeysRouter.get('/', adminAuth, (_req: Request, res: Response) => {
-  res.json({ data: defaultApiKeyStore.list(), error: null });
+apiKeysRouter.get('/', adminAuth, (req: Request, res: Response) => {
+  try {
+    if ('cursor' in req.query) {
+      const { cursor, limit } = parseCursorQuery(req.query as Record<string, unknown>);
+      const page = defaultApiKeyStore.listWithCursor(cursor, limit);
+      res.json({
+        data: {
+          items: page.items,
+          pagination: toPaginationMeta(page),
+        },
+        error: null,
+      });
+      return;
+    }
+
+    // Legacy unpaginated response for clients that omit `cursor`.
+    res.json({ data: defaultApiKeyStore.list(), error: null });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Bad request';
+    res.status(400).json({ data: null, error: message });
+  }
 });
 
 /** GET /api/admin/api-keys/audit — issue/revoke audit log. */
-apiKeysRouter.get('/audit', adminAuth, (_req: Request, res: Response) => {
-  res.json({ data: defaultApiKeyStore.auditLog(), error: null });
+apiKeysRouter.get('/audit', adminAuth, (req: Request, res: Response) => {
+  try {
+    if ('cursor' in req.query) {
+      const { cursor, limit } = parseCursorQuery(req.query as Record<string, unknown>);
+      const page = defaultApiKeyStore.auditLogWithCursor(cursor, limit);
+      res.json({
+        data: {
+          items: page.items,
+          pagination: toPaginationMeta(page),
+        },
+        error: null,
+      });
+      return;
+    }
+
+    // Legacy unpaginated response.
+    res.json({ data: defaultApiKeyStore.auditLog(), error: null });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Bad request';
+    res.status(400).json({ data: null, error: message });
+  }
 });
 
 /** DELETE /api/admin/api-keys/:id — revoke (enters grace period). */

--- a/src/routes/credit.ts
+++ b/src/routes/credit.ts
@@ -34,6 +34,11 @@ import { Container } from '../container/Container.js';
 import { adminAuth } from '../middleware/adminAuth.js';
 import { ok, fail } from '../utils/response.js';
 import {
+  parseCursorQuery,
+  toPaginationMeta,
+  InvalidCursorError,
+} from '../utils/cursorPagination.js';
+import {
   CreditLineNotFoundError,
   InvalidTransitionError,
   VersionConflictError,
@@ -41,6 +46,7 @@ import {
   suspendCreditLine,
   closeCreditLine,
   getTransactions,
+  getTransactionsWithCursor,
   submitDrawRequest,
   submitRepayRequest,
 } from '../services/creditService.js';
@@ -86,26 +92,24 @@ function parseIntegerQuery(value: unknown, defaultValue: number): number {
 }
 
 creditRouter.get('/lines', async (req, res) => {
-  const limit = parseIntegerQuery(req.query.limit, 100);
-
   try {
     if ('cursor' in req.query) {
-      const cursorValue = req.query.cursor;
-      const cursor = typeof cursorValue === 'string' && cursorValue.length > 0
-        ? cursorValue
-        : undefined;
+      const { cursor, limit } = parseCursorQuery(req.query as Record<string, unknown>, {
+        defaultLimit: 100,
+      });
       const result = await container.creditLineService.getAllCreditLinesWithCursor(cursor, limit);
 
       return res.json({
         creditLines: result.items,
-        pagination: {
+        pagination: toPaginationMeta({
           limit,
           nextCursor: result.nextCursor,
           hasMore: result.hasMore,
-        },
+        }),
       });
     }
 
+    const limit = parseIntegerQuery(req.query.limit, 100);
     const offset = parseIntegerQuery(req.query.offset, 0);
     const creditLines = await container.creditLineService.getAllCreditLines(offset, limit);
     const total = await container.creditLineService.getCreditLineCount();
@@ -216,26 +220,45 @@ creditRouter.get(
       return;
     }
 
-    const page = pageParam !== undefined ? parseInt(pageParam as string, 10) : 1;
-    const limit = limitParam !== undefined ? parseInt(limitParam as string, 10) : 20;
-
-    if (isNaN(page) || page < 1) {
-      fail(res, "Invalid 'page'. Must be a positive integer.", 400);
-      return;
-    }
-    if (isNaN(limit) || limit < 1 || limit > 100) {
-      fail(res, "Invalid 'limit'. Must be between 1 and 100.", 400);
-      return;
-    }
+    const filters = {
+      type: type as TransactionType | undefined,
+      from: from as string | undefined,
+      to: to as string | undefined,
+    };
 
     try {
-      const result = getTransactions(
-        id,
-        { type: type as TransactionType | undefined, from: from as string | undefined, to: to as string | undefined },
-        { page, limit },
-      );
+      // Cursor mode (standard) when `cursor` is present; page/limit remains for legacy clients.
+      if ('cursor' in req.query) {
+        const { cursor, limit } = parseCursorQuery(req.query as Record<string, unknown>, {
+          defaultLimit: 20,
+        });
+        const result = getTransactionsWithCursor(id, filters, { cursor, limit });
+        ok(res, {
+          transactions: result.items,
+          pagination: toPaginationMeta(result),
+        });
+        return;
+      }
+
+      const page = pageParam !== undefined ? parseInt(pageParam as string, 10) : 1;
+      const limit = limitParam !== undefined ? parseInt(limitParam as string, 10) : 20;
+
+      if (isNaN(page) || page < 1) {
+        fail(res, "Invalid 'page'. Must be a positive integer.", 400);
+        return;
+      }
+      if (isNaN(limit) || limit < 1 || limit > 100) {
+        fail(res, "Invalid 'limit'. Must be between 1 and 100.", 400);
+        return;
+      }
+
+      const result = getTransactions(id, filters, { page, limit });
       ok(res, result);
     } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        fail(res, err.message, 400);
+        return;
+      }
       handleServiceError(err, res);
     }
   },

--- a/src/routes/creditBulk.ts
+++ b/src/routes/creditBulk.ts
@@ -54,8 +54,13 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
 
       try {
-        const creditService = container.getCreditService();
-        const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
+        const creditService = container.creditLineService;
+        const body = parsed.data as CreateCreditLineBody;
+        const line = await creditService.createCreditLine({
+          walletAddress: body.walletAddress,
+          creditLimit: body.creditLimit ?? body.requestedLimit ?? '',
+          interestRateBps: body.interestRateBps ?? 0,
+        });
         results.push({ index: i + 1, status: 'created', id: line.id });
         created++;
       } catch (err) {
@@ -64,9 +69,9 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
     }
 
-    return res.status(207).json(ok({ summary: { total: rows.length, created, failed, dry_run: isDryRun }, results }));
+    return ok(res, { summary: { total: rows.length, created, failed, dry_run: isDryRun } as Record<string, unknown>, results }, 207);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -23,7 +23,7 @@
  *
  * See `docs/OBSERVABILITY.md` for Grafana dashboard JSON and Alertmanager rules.
  */
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import { ok, fail } from '../utils/response.js';
 
 export const metricsRouter = Router();

--- a/src/routes/simulation.ts
+++ b/src/routes/simulation.ts
@@ -31,7 +31,7 @@ simulationRouter.post(
 
       const { amount } = req.body as DrawBody;
       const drawAmount = Number(amount);
-      const availableCredit = Number(line.creditLimit) - Number(line.balance ?? 0);
+      const availableCredit = Number(line.creditLimit) - Number(line.utilized ?? 0);
       const valid = drawAmount > 0 && drawAmount <= availableCredit;
       const interestBps: number = (line as unknown as Record<string, unknown>)['interestRateBps'] as number ?? 0;
       const estimatedFee = Math.ceil(drawAmount * interestBps / INTEREST_RATE_DIVISOR);
@@ -46,13 +46,13 @@ simulationRouter.post(
         preview: {
           requestedAmount: drawAmount,
           estimatedFee,
-          newBalance: valid ? Number(line.balance ?? 0) + drawAmount : null,
+          newBalance: valid ? Number(line.utilized ?? 0) + drawAmount : null,
           remainingCredit: valid ? availableCredit - drawAmount : availableCredit,
         },
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );
@@ -67,7 +67,7 @@ simulationRouter.post(
 
       const { amount } = req.body as RepayBody;
       const repayAmount = Number(amount);
-      const currentBalance = Number(line.balance ?? 0);
+      const currentBalance = Number(line.utilized ?? 0);
       const effectiveRepay = Math.min(repayAmount, currentBalance);
       const valid = repayAmount > 0;
 
@@ -84,7 +84,7 @@ simulationRouter.post(
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -11,6 +11,7 @@
  * - POST `/test`        — sends a connectivity probe to every configured
  *   URL and returns a `{ reachable, unreachable, results[] }` summary.
  * - GET  `/health`      — `active` / `disabled` state, used by dashboards.
+ * - GET  `/deliveries`  — cursor-paginated delivery records (incl. dead letters).
  *
  * Outbound payload contract (subscriber side) is documented in
  * `docs/API.md` §Webhooks: HMAC-SHA256 over the raw body, signed with
@@ -20,6 +21,11 @@ import { Router, type Request, type Response } from 'express';
 import { getWebhookConfig, testWebhookConnectivity } from '../services/drawWebhookService.js';
 import { getWebhookDeliveryStateStore } from '../services/webhookDeliveryState.js';
 import { redactLogArgs } from '../utils/logRedact.js';
+import {
+  paginateArray,
+  parseCursorQuery,
+  toPaginationMeta,
+} from '../utils/cursorPagination.js';
 
 export const webhookRouter = Router();
 
@@ -101,4 +107,63 @@ webhookRouter.get('/health', (_req: Request, res: Response) => {
             deadLetter: counts.deadLetter
         }
     });
+});
+
+/**
+ * Cursor-paginated delivery records (standard pagination model).
+ *
+ * Query:
+ * - `cursor` — opaque cursor from a previous page (omit / empty for first page)
+ * - `limit`  — page size (1–100, default 25)
+ * - `status` — optional filter: `delivered` | `failed` | `dead_letter`
+ *
+ * Sort: `updatedAt DESC`, composite id (`drawId::url`) ASC as tie-break.
+ */
+webhookRouter.get('/deliveries', (req: Request, res: Response) => {
+    try {
+        const { cursor, limit } = parseCursorQuery(req.query as Record<string, unknown>);
+        const statusFilter =
+            typeof req.query.status === 'string' && req.query.status.length > 0
+                ? req.query.status
+                : undefined;
+
+        if (
+            statusFilter !== undefined &&
+            statusFilter !== 'delivered' &&
+            statusFilter !== 'failed' &&
+            statusFilter !== 'dead_letter'
+        ) {
+            return res.status(400).json({
+                data: null,
+                error: "Invalid 'status'. Must be one of: delivered, failed, dead_letter.",
+            });
+        }
+
+        const store = getWebhookDeliveryStateStore();
+        let records = store.list();
+        if (statusFilter) {
+            records = records.filter((r) => r.status === statusFilter);
+        }
+
+        const page = paginateArray(records, {
+            cursor,
+            limit,
+            order: 'desc',
+            getKey: (r) => ({
+                t: Date.parse(r.updatedAt),
+                i: `${r.drawId}::${r.url}`,
+            }),
+        });
+
+        return res.status(200).json({
+            data: {
+                items: page.items,
+                pagination: toPaginationMeta(page),
+            },
+            error: null,
+        });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Bad request';
+        return res.status(400).json({ data: null, error: message });
+    }
 });

--- a/src/schemas/credit.schema.ts
+++ b/src/schemas/credit.schema.ts
@@ -32,6 +32,8 @@ export type CreateCreditLineBody = z.infer<typeof createCreditLineSchema>;
 export const creditLinesQuerySchema = z.object({
   offset: nonNegativeIntString.optional(),
   limit: positiveIntString.max(100).optional(),
+  /** When present (even empty), enables the standard cursor pagination mode. */
+  cursor: z.string().optional(),
 }).strict();
 
 export type CreditLinesQuery = z.infer<typeof creditLinesQuerySchema>;
@@ -62,6 +64,8 @@ export const transactionHistoryQuerySchema = z.object({
   to: isoDateTime.optional(),
   page: positiveIntString.optional(),
   limit: positiveIntString.max(100).optional(),
+  /** When present (even empty), enables the standard cursor pagination mode. */
+  cursor: z.string().optional(),
 }).strict();
 
 export type TransactionHistoryQuery = z.infer<typeof transactionHistoryQuerySchema>;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -17,3 +17,12 @@ export type {
   RepayBody,
   TransactionHistoryQuery,
 } from './credit.schema.js';
+
+export {
+  cursorPaginationQuerySchema,
+  offsetPaginationQuerySchema,
+} from './pagination.schema.js';
+export type {
+  CursorPaginationQuery,
+  OffsetPaginationQuery,
+} from './pagination.schema.js';

--- a/src/schemas/pagination.schema.ts
+++ b/src/schemas/pagination.schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared Zod schemas for cursor-based list query parameters.
+ */
+import { z } from 'zod';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MIN_PAGE_SIZE } from '../utils/constants.js';
+
+/** Coerced positive int in the shared page-size bounds. */
+const limitField = z.coerce
+  .number()
+  .int()
+  .min(MIN_PAGE_SIZE)
+  .max(MAX_PAGE_SIZE)
+  .optional()
+  .default(DEFAULT_PAGE_SIZE);
+
+/**
+ * Standard cursor pagination query.
+ *
+ * - `cursor` may be omitted (offset-mode endpoints) or present as empty string
+ *   (first page of cursor mode — Express parses `?cursor` as `""`).
+ * - `limit` defaults to {@link DEFAULT_PAGE_SIZE}.
+ */
+export const cursorPaginationQuerySchema = z
+  .object({
+    cursor: z.string().optional(),
+    limit: limitField,
+  })
+  .strict();
+
+export type CursorPaginationQuery = z.infer<typeof cursorPaginationQuerySchema>;
+
+/** Offset/limit query kept for backward-compatible list endpoints. */
+export const offsetPaginationQuerySchema = z
+  .object({
+    offset: z.coerce.number().int().min(0).optional().default(0),
+    limit: limitField,
+  })
+  .strict();
+
+export type OffsetPaginationQuery = z.infer<typeof offsetPaginationQuerySchema>;

--- a/src/services/CreditLineService.ts
+++ b/src/services/CreditLineService.ts
@@ -2,6 +2,7 @@ import { type CreditLine, type CreateCreditLineRequest, type UpdateCreditLineReq
 import type { CreditLineRepository, CursorPaginationResult } from '../repositories/interfaces/CreditLineRepository.js';
 import type { EventBus } from './events/eventBus.js';
 import { nowIso } from './events/domainEvents.js';
+import { clampLimit } from '../utils/cursorPagination.js';
 
 /**
  * Domain service for credit-line CRUD plus the `draw` / `repay` operations.
@@ -110,14 +111,13 @@ export class CreditLineService {
    *
    * @see `docs/cursor-pagination.md`
    */
-  async getAllCreditLinesWithCursor(cursor?: string, limit?: number): Promise<CursorPaginationResult> {
-    if (limit !== undefined && limit <= 0) {
-      throw new Error('Limit must be greater than 0');
-    }
-    if (limit !== undefined && limit > 100) {
-      throw new Error('Limit cannot exceed 100');
-    }
-    return await this.creditLineRepository.findAllWithCursor(cursor, limit);
+  async getAllCreditLinesWithCursor(
+    cursor?: string,
+    limit?: number,
+  ): Promise<CursorPaginationResult<CreditLine>> {
+    // Shared clamp keeps limit error messages identical across list endpoints.
+    const safeLimit = clampLimit(limit, { defaultLimit: 100 });
+    return await this.creditLineRepository.findAllWithCursor(cursor, safeLimit);
   }
 
   /**

--- a/src/services/__tests__/dashboardSummaryService.test.ts
+++ b/src/services/__tests__/dashboardSummaryService.test.ts
@@ -80,7 +80,7 @@ describe('DashboardSummaryService caching', () => {
   });
 
   it('recomputes immediately after invalidate()', async () => {
-    let now = 0;
+    const now = 0;
     const { repo, findAll } = repoOf([line({})]);
     const service = new DashboardSummaryService(repo, 30_000, () => now);
 

--- a/src/services/apiKeyStore.ts
+++ b/src/services/apiKeyStore.ts
@@ -21,6 +21,7 @@
  * same.
  */
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { paginateArray, type CursorPage } from '../utils/cursorPagination.js';
 
 export type ApiKeyStatus = 'active' | 'revoked';
 
@@ -122,6 +123,20 @@ export class ApiKeyStore {
   }
 
   /**
+   * Cursor-paginated key metadata (createdAt ASC, id ASC).
+   * Opaque cursors; never includes secrets.
+   */
+  listWithCursor(cursor?: string, limit?: number): CursorPage<ApiKeyMetadata> {
+    const items = this.list();
+    return paginateArray(items, {
+      cursor,
+      limit,
+      order: 'asc',
+      getKey: (m) => ({ t: Date.parse(m.createdAt), i: m.id }),
+    });
+  }
+
+  /**
    * Constant-time verification that `presented` maps to a currently valid key.
    * Valid = active, or revoked but still within the grace window.
    */
@@ -142,6 +157,23 @@ export class ApiKeyStore {
   /** Copy of the audit log (newest last). Never contains secret material. */
   auditLog(): ApiKeyAuditEntry[] {
     return [...this.audit];
+  }
+
+  /**
+   * Cursor-paginated audit log (newest first: `at` DESC, `keyId` ASC).
+   * Composite id key uses `${at}|${keyId}|${action}` so entries with the same
+   * timestamp remain uniquely addressable without leaking secrets.
+   */
+  auditLogWithCursor(cursor?: string, limit?: number): CursorPage<ApiKeyAuditEntry> {
+    return paginateArray(this.audit, {
+      cursor,
+      limit,
+      order: 'desc',
+      getKey: (entry) => ({
+        t: Date.parse(entry.at),
+        i: `${entry.keyId}:${entry.action}:${entry.at}`,
+      }),
+    });
   }
 
   private isUsable(record: ApiKeyRecord, nowMs: number): boolean {

--- a/src/services/creditService.ts
+++ b/src/services/creditService.ts
@@ -20,6 +20,7 @@ import { randomUUID } from 'node:crypto';
 import { creditLines, type CreditLineStatus as StoredCreditLineStatus } from '../models/creditLineStore.js';
 import { TransactionType } from '../models/Transaction.js';
 import type { DrawBody, RepayBody } from '../schemas/index.js';
+import { paginateArray, type CursorPage } from '../utils/cursorPagination.js';
 
 export { TransactionType };
 
@@ -245,11 +246,7 @@ export function closeCreditLine(id: string): CreditLine {
   return line;
 }
 
-export function getTransactions(
-  id: string,
-  filters: TransactionFilters = {},
-  pagination: PaginationOptions = { page: 1, limit: 20 },
-): PaginatedTransactions {
+function filterTransactions(id: string, filters: TransactionFilters): Transaction[] {
   if (!_store.has(id)) throw new CreditLineNotFoundError(id);
 
   let txs = [...(_transactionStore.get(id) ?? [])];
@@ -266,8 +263,22 @@ export function getTransactions(
     txs = txs.filter((tx) => new Date(tx.timestamp).getTime() <= to);
   }
 
-  txs.reverse();
-  txs.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  return txs;
+}
+
+export function getTransactions(
+  id: string,
+  filters: TransactionFilters = {},
+  pagination: PaginationOptions = { page: 1, limit: 20 },
+): PaginatedTransactions {
+  const txs = filterTransactions(id, filters);
+
+  // Newest first (legacy page/limit ordering).
+  txs.sort((a, b) => {
+    const ts = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+    if (ts !== 0) return ts;
+    return a.id.localeCompare(b.id);
+  });
 
   const total = txs.length;
   const { page, limit } = pagination;
@@ -276,6 +287,25 @@ export function getTransactions(
   const transactions = txs.slice(offset, offset + limit);
 
   return { transactions, total, page, limit, totalPages };
+}
+
+/**
+ * Cursor-paginated transaction history (standard model).
+ * Sort: `timestamp DESC`, `id ASC` tie-break. Cursors are opaque.
+ */
+export function getTransactionsWithCursor(
+  id: string,
+  filters: TransactionFilters = {},
+  options: { cursor?: string; limit?: number } = {},
+): CursorPage<Transaction> {
+  const txs = filterTransactions(id, filters);
+  return paginateArray(txs, {
+    cursor: options.cursor,
+    limit: options.limit,
+    defaultLimit: 20,
+    order: 'desc',
+    getKey: (tx) => ({ t: new Date(tx.timestamp).getTime(), i: tx.id }),
+  });
 }
 
 export interface SorobanClient {

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -19,6 +19,7 @@ import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
 import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
 import { redactLogArgs } from "../utils/logRedact.js";
+import { logger as log } from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -200,11 +201,7 @@ async function retryWithBackoff<T>(
             lastError = error as Error;
             
             if (attempt <= maxRetries) {
-                log.warn("webhook:delivery:retry", {
-                    attempt,
-                    retryInMs: delay,
-                    error: lastError,
-                });
+                log.warn({ attempt, retryInMs: delay, error: lastError }, "webhook:delivery:retry");
                 await new Promise(resolve => setTimeout(resolve, delay));
                 delay = Math.floor(delay * backoffMultiplier);
             }
@@ -241,7 +238,7 @@ function parseDrawConfirmedEvent(event: HorizonEvent): WebhookPayload | null {
             }
         };
     } catch (error) {
-        log.error("webhook:event-parse:failed", { error });
+        log.error({ error }, "webhook:event-parse:failed");
         return null;
     }
 }
@@ -257,13 +254,9 @@ export function getWebhookConfig(): WebhookConfig | null {
 export function initializeWebhooks(): void {
     try {
         activeConfig = resolveWebhookConfig();
-        log.info("webhook:initialized", {
-            urls: activeConfig.urls.length,
-            maxRetries: activeConfig.maxRetries,
-            timeoutMs: activeConfig.timeoutMs
-        });
+        log.info({ urls: activeConfig.urls.length, maxRetries: activeConfig.maxRetries, timeoutMs: activeConfig.timeoutMs }, "webhook:initialized");
     } catch (error) {
-        log.error("webhook:initialize:failed", { error });
+        log.error({ error }, "webhook:initialize:failed");
         activeConfig = null;
     }
 }
@@ -278,20 +271,14 @@ export async function sendDrawConfirmationWebhook(
 
     const payload = parseDrawConfirmedEvent(event);
     if (!payload) {
-        log.info("webhook:delivery:skipped-non-draw-event", {
-            ledger: event.ledger,
-            contractId: event.contractId,
-        });
+        log.info({ ledger: event.ledger, contractId: event.contractId }, "webhook:delivery:skipped-non-draw-event");
         return [];
     }
 
     const payloadString = JSON.stringify(payload);
     const signature = generateSignature(payloadString, activeConfig.secret);
 
-    log.info("webhook:delivery:start", {
-        drawId: payload.data.drawId,
-        deliveryCount: activeConfig.urls.length,
-    });
+    log.info({ drawId: payload.data.drawId, deliveryCount: activeConfig.urls.length }, "webhook:delivery:start");
 
     const store = getWebhookDeliveryStateStore();
 
@@ -355,10 +342,7 @@ export async function sendDrawConfirmationWebhook(
     const successCount = results.filter(r => r.success).length;
     const failureCount = results.length - successCount;
     
-    log.info("webhook:delivery:complete", {
-        successful: successCount,
-        failed: failureCount,
-    });
+    log.info({ successful: successCount, failed: failureCount }, "webhook:delivery:complete");
 
     return results;
 }

--- a/src/services/webhookDeliveryState.ts
+++ b/src/services/webhookDeliveryState.ts
@@ -39,6 +39,8 @@ export interface WebhookDeliveryStateStore {
     record(record: Omit<DeliveryRecord, "updatedAt">): void;
     /** Read-only snapshot of permanently failed (dead-letter) deliveries. */
     deadLetters(): DeliveryRecord[];
+    /** Read-only snapshot of every tracked delivery (newest last insertion order). */
+    list(): DeliveryRecord[];
     /** Counts by status plus the total tracked deliveries. */
     counts(): {
         total: number;
@@ -70,6 +72,10 @@ class InMemoryWebhookDeliveryStateStore implements WebhookDeliveryStateStore {
         return [...this.records.values()].filter(
             (r) => r.status === "dead_letter"
         );
+    }
+
+    list(): DeliveryRecord[] {
+        return [...this.records.values()];
     }
 
     counts(): {

--- a/src/utils/__tests__/cursorPagination.test.ts
+++ b/src/utils/__tests__/cursorPagination.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encodeCursor,
+  decodeCursor,
+  clampLimit,
+  paginateArray,
+  buildPageFromOverfetch,
+  toPaginationMeta,
+  parseCursorQuery,
+  compareCursorKeysAsc,
+  InvalidCursorError,
+  CURSOR_VERSION,
+} from '../cursorPagination.js';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../constants.js';
+
+interface Row {
+  id: string;
+  createdAt: Date;
+  label: string;
+}
+
+function row(id: string, ms: number, label = id): Row {
+  return { id, createdAt: new Date(ms), label };
+}
+
+const getKey = (r: Row) => ({ t: r.createdAt.getTime(), i: r.id });
+
+describe('encodeCursor / decodeCursor', () => {
+  it('round-trips a cursor key opaquely', () => {
+    const key = { t: 1_700_000_000_000, i: 'abc-123' };
+    const cursor = encodeCursor(key);
+    expect(cursor).not.toContain('|');
+    expect(cursor).not.toContain(key.i);
+    expect(decodeCursor(cursor)).toEqual(key);
+  });
+
+  it('embeds the current cursor version', () => {
+    const cursor = encodeCursor({ t: 1, i: 'x' });
+    const raw = Buffer.from(cursor, 'base64url').toString('utf8');
+    expect(JSON.parse(raw).v).toBe(CURSOR_VERSION);
+  });
+
+  it('decodes legacy base64(timestamp|id) cursors', () => {
+    const legacy = Buffer.from('1700000000000|legacy-id', 'utf8').toString('base64');
+    expect(decodeCursor(legacy)).toEqual({ t: 1_700_000_000_000, i: 'legacy-id' });
+  });
+
+  it('returns null for empty / missing cursors', () => {
+    expect(decodeCursor(undefined)).toBeNull();
+    expect(decodeCursor(null)).toBeNull();
+    expect(decodeCursor('')).toBeNull();
+  });
+
+  it('returns null for malformed cursors in non-strict mode', () => {
+    expect(decodeCursor('not-a-cursor')).toBeNull();
+    expect(decodeCursor('!!!')).toBeNull();
+  });
+
+  it('throws InvalidCursorError in strict mode', () => {
+    expect(() => decodeCursor('not-a-cursor', { strict: true })).toThrow(InvalidCursorError);
+  });
+});
+
+describe('clampLimit', () => {
+  it('defaults when undefined', () => {
+    expect(clampLimit(undefined)).toBe(DEFAULT_PAGE_SIZE);
+  });
+
+  it('accepts bounds', () => {
+    expect(clampLimit(1)).toBe(1);
+    expect(clampLimit(MAX_PAGE_SIZE)).toBe(MAX_PAGE_SIZE);
+  });
+
+  it('rejects zero and oversized limits with credit-line-compatible messages', () => {
+    expect(() => clampLimit(0)).toThrow('Limit must be greater than 0');
+    expect(() => clampLimit(MAX_PAGE_SIZE + 1)).toThrow(`Limit cannot exceed ${MAX_PAGE_SIZE}`);
+  });
+});
+
+describe('paginateArray', () => {
+  const items = [
+    row('a', 1000),
+    row('b', 2000),
+    row('c', 3000),
+    row('d', 4000),
+    row('e', 5000),
+  ];
+
+  it('returns the first page and a nextCursor when more remain', () => {
+    const page = paginateArray(items, { limit: 2, getKey, order: 'asc' });
+    expect(page.items.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).toBeTruthy();
+    expect(page.limit).toBe(2);
+  });
+
+  it('continues from nextCursor without overlap', () => {
+    const first = paginateArray(items, { limit: 2, getKey });
+    const second = paginateArray(items, { cursor: first.nextCursor, limit: 2, getKey });
+    expect(second.items.map((r) => r.id)).toEqual(['c', 'd']);
+    const firstIds = new Set(first.items.map((r) => r.id));
+    for (const r of second.items) expect(firstIds.has(r.id)).toBe(false);
+  });
+
+  it('returns hasMore=false and null cursor on the last page', () => {
+    const first = paginateArray(items, { limit: 3, getKey });
+    const second = paginateArray(items, { cursor: first.nextCursor, limit: 3, getKey });
+    expect(second.items.map((r) => r.id)).toEqual(['d', 'e']);
+    expect(second.hasMore).toBe(false);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it('handles empty collections', () => {
+    const page = paginateArray([], { limit: 10, getKey });
+    expect(page.items).toEqual([]);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('starts from the beginning on invalid cursor (non-strict)', () => {
+    const page = paginateArray(items, { cursor: 'bogus', limit: 2, getKey });
+    expect(page.items.map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('throws on invalid cursor when strictCursor is set', () => {
+    expect(() =>
+      paginateArray(items, { cursor: 'bogus', limit: 2, getKey, strictCursor: true }),
+    ).toThrow(InvalidCursorError);
+  });
+
+  it('supports DESC order for newest-first lists', () => {
+    const page = paginateArray(items, { limit: 2, getKey, order: 'desc' });
+    expect(page.items.map((r) => r.id)).toEqual(['e', 'd']);
+    const second = paginateArray(items, {
+      cursor: page.nextCursor,
+      limit: 2,
+      getKey,
+      order: 'desc',
+    });
+    expect(second.items.map((r) => r.id)).toEqual(['c', 'b']);
+  });
+
+  it('is stable when timestamps collide', () => {
+    const sameTs = [row('z', 1000), row('m', 1000), row('a', 1000)];
+    const page = paginateArray(sameTs, { limit: 2, getKey, order: 'asc' });
+    // id ASC tie-break: a, m then z
+    expect(page.items.map((r) => r.id)).toEqual(['a', 'm']);
+    const rest = paginateArray(sameTs, { cursor: page.nextCursor, limit: 2, getKey });
+    expect(rest.items.map((r) => r.id)).toEqual(['z']);
+  });
+});
+
+describe('buildPageFromOverfetch', () => {
+  it('slices limit+1 rows into a page', () => {
+    const rows = [row('a', 1), row('b', 2), row('c', 3)];
+    const page = buildPageFromOverfetch(rows, 2, getKey);
+    expect(page.items).toHaveLength(2);
+    expect(page.hasMore).toBe(true);
+    expect(decodeCursor(page.nextCursor)).toEqual(getKey(rows[1]));
+  });
+});
+
+describe('toPaginationMeta / parseCursorQuery', () => {
+  it('projects meta fields', () => {
+    expect(
+      toPaginationMeta({ limit: 10, nextCursor: 'c', hasMore: true }),
+    ).toEqual({ limit: 10, nextCursor: 'c', hasMore: true });
+  });
+
+  it('detects cursor mode from query presence', () => {
+    expect(parseCursorQuery({ cursor: '', limit: '5' })).toMatchObject({
+      cursorMode: true,
+      cursor: undefined,
+      limit: 5,
+    });
+    expect(parseCursorQuery({ limit: '5' }).cursorMode).toBe(false);
+  });
+});
+
+describe('compareCursorKeysAsc', () => {
+  it('orders by t then i', () => {
+    expect(compareCursorKeysAsc({ t: 1, i: 'a' }, { t: 2, i: 'a' })).toBeLessThan(0);
+    expect(compareCursorKeysAsc({ t: 1, i: 'a' }, { t: 1, i: 'b' })).toBeLessThan(0);
+  });
+});

--- a/src/utils/cursorPagination.ts
+++ b/src/utils/cursorPagination.ts
@@ -1,0 +1,326 @@
+/**
+ * Shared cursor-based pagination helpers.
+ *
+ * Standard model for every list endpoint:
+ * - Opaque cursors (base64url JSON; clients must treat them as black boxes)
+ * - Deterministic sort key: `(timestamp ms, id)` with stable ASC or DESC order
+ * - Response shape: `{ items, nextCursor, hasMore, limit }`
+ *
+ * Repositories may implement the same key comparison in SQL; encode/decode
+ * and in-memory page building live here so routes never invent their own
+ * cursor format.
+ *
+ * @see docs/cursor-pagination.md
+ */
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MIN_PAGE_SIZE,
+} from './constants.js';
+
+/** Version tag embedded in every minted cursor. Bump only on breaking format changes. */
+export const CURSOR_VERSION = 1 as const;
+
+/**
+ * Sort key material encoded into a cursor.
+ * `t` is the primary sort column (usually createdAt epoch-ms);
+ * `i` is a unique tie-breaker (usually the row id).
+ */
+export interface CursorKey {
+  readonly t: number;
+  readonly i: string;
+}
+
+/** Standard cursor-page payload returned by repositories and services. */
+export interface CursorPage<T> {
+  readonly items: T[];
+  readonly nextCursor: string | null;
+  readonly hasMore: boolean;
+  readonly limit: number;
+}
+
+/** Pagination meta block attached to HTTP list responses. */
+export interface CursorPaginationMeta {
+  readonly limit: number;
+  readonly nextCursor: string | null;
+  readonly hasMore: boolean;
+}
+
+/** Alias kept for repository interfaces that historically used this name. */
+export type CursorPaginationResult<T = unknown> = Omit<CursorPage<T>, 'limit'> & {
+  limit?: number;
+};
+
+export type CursorSortOrder = 'asc' | 'desc';
+
+/**
+ * Thrown when a client-supplied cursor cannot be decoded.
+ * Routes map this to HTTP 400 when strict mode is requested.
+ */
+export class InvalidCursorError extends Error {
+  public readonly code = 'invalid_cursor';
+
+  constructor(message = 'Invalid cursor') {
+    super(message);
+    this.name = 'InvalidCursorError';
+  }
+}
+
+/**
+ * Clamp / default a page `limit` to the shared bounds.
+ *
+ * @throws {Error} when `limit` is present but non-finite, &lt; min, or &gt; max
+ */
+export function clampLimit(
+  limit?: number,
+  options: {
+    defaultLimit?: number;
+    min?: number;
+    max?: number;
+  } = {},
+): number {
+  const defaultLimit = options.defaultLimit ?? DEFAULT_PAGE_SIZE;
+  const min = options.min ?? MIN_PAGE_SIZE;
+  const max = options.max ?? MAX_PAGE_SIZE;
+
+  if (limit === undefined || limit === null || (typeof limit === 'number' && Number.isNaN(limit))) {
+    return defaultLimit;
+  }
+  if (!Number.isFinite(limit) || !Number.isInteger(limit)) {
+    throw new Error(`Limit must be an integer between ${min} and ${max}`);
+  }
+  if (limit < min) {
+    throw new Error(min === 1 ? 'Limit must be greater than 0' : `Limit must be at least ${min}`);
+  }
+  if (limit > max) {
+    throw new Error(`Limit cannot exceed ${max}`);
+  }
+  return limit;
+}
+
+/** Encode a cursor key as an opaque base64url string. */
+export function encodeCursor(key: CursorKey): string {
+  if (!Number.isFinite(key.t) || typeof key.i !== 'string' || key.i.length === 0) {
+    throw new Error('Cannot encode cursor: invalid key');
+  }
+  const payload = JSON.stringify({ v: CURSOR_VERSION, t: key.t, i: key.i });
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+/**
+ * Decode an opaque cursor.
+ *
+ * Accepts the current base64url JSON format and the legacy
+ * `base64(timestamp|id)` format used by early credit-line pagination so
+ * in-flight clients are not broken mid-rollout.
+ *
+ * @param cursor - raw query value
+ * @param options.strict - when true, throw {@link InvalidCursorError} on bad input;
+ *   when false (default), return `null` so callers can fall back to page 1
+ */
+export function decodeCursor(
+  cursor: string | undefined | null,
+  options: { strict?: boolean } = {},
+): CursorKey | null {
+  const strict = options.strict === true;
+
+  if (cursor === undefined || cursor === null || cursor === '') {
+    return null;
+  }
+  if (typeof cursor !== 'string') {
+    if (strict) throw new InvalidCursorError('Cursor must be a string');
+    return null;
+  }
+
+  try {
+    const raw = Buffer.from(cursor, 'base64url').toString('utf8');
+
+    // Preferred format: versioned JSON.
+    if (raw.startsWith('{')) {
+      const parsed = JSON.parse(raw) as { v?: unknown; t?: unknown; i?: unknown };
+      if (parsed.v !== CURSOR_VERSION) {
+        if (strict) throw new InvalidCursorError('Unsupported cursor version');
+        return null;
+      }
+      if (typeof parsed.t !== 'number' || !Number.isFinite(parsed.t) || typeof parsed.i !== 'string' || !parsed.i) {
+        if (strict) throw new InvalidCursorError('Malformed cursor payload');
+        return null;
+      }
+      return { t: parsed.t, i: parsed.i };
+    }
+
+    // Legacy format: "timestamp|id" (standard base64, not url-safe).
+    const legacyRaw = Buffer.from(cursor, 'base64').toString('utf8');
+    const pipe = legacyRaw.indexOf('|');
+    if (pipe > 0) {
+      const t = Number(legacyRaw.slice(0, pipe));
+      const i = legacyRaw.slice(pipe + 1);
+      if (Number.isFinite(t) && i.length > 0) {
+        return { t, i };
+      }
+    }
+  } catch (err) {
+    if (err instanceof InvalidCursorError) throw err;
+    if (strict) throw new InvalidCursorError('Malformed cursor');
+    return null;
+  }
+
+  if (strict) throw new InvalidCursorError('Malformed cursor');
+  return null;
+}
+
+/** Compare two cursor keys for ASC ordering (t, then i). */
+export function compareCursorKeysAsc(a: CursorKey, b: CursorKey): number {
+  if (a.t !== b.t) return a.t - b.t;
+  return a.i.localeCompare(b.i);
+}
+
+/** Compare two cursor keys for DESC ordering (t, then i ascending as stable tie-break). */
+export function compareCursorKeysDesc(a: CursorKey, b: CursorKey): number {
+  if (a.t !== b.t) return b.t - a.t;
+  return a.i.localeCompare(b.i);
+}
+
+/**
+ * True when `item` sorts strictly after `cursor` in the given order
+ * (i.e. belongs on a subsequent page).
+ */
+export function isAfterCursor(
+  item: CursorKey,
+  cursor: CursorKey,
+  order: CursorSortOrder = 'asc',
+): boolean {
+  if (order === 'asc') {
+    return compareCursorKeysAsc(item, cursor) > 0;
+  }
+  // DESC: "after" means smaller timestamp (older) or equal t with greater id
+  if (item.t !== cursor.t) return item.t < cursor.t;
+  return item.i.localeCompare(cursor.i) > 0;
+}
+
+/**
+ * Build a page from a fully sorted array already filtered to the page window.
+ * Callers that fetched `limit + 1` rows should pass that oversize slice here.
+ */
+export function buildPageFromOverfetch<T>(
+  overfetched: T[],
+  limit: number,
+  getKey: (item: T) => CursorKey,
+): CursorPage<T> {
+  const hasMore = overfetched.length > limit;
+  const items = hasMore ? overfetched.slice(0, limit) : overfetched;
+  const last = items[items.length - 1];
+  const nextCursor =
+    hasMore && last !== undefined ? encodeCursor(getKey(last)) : null;
+  return { items, nextCursor, hasMore, limit };
+}
+
+/**
+ * In-memory cursor pagination over a pre-sorted array (or an unsorted array
+ * when `sort` is provided). Used by in-memory repositories and list endpoints
+ * that hold the full collection in process.
+ */
+export function paginateArray<T>(
+  items: readonly T[],
+  options: {
+    cursor?: string | null;
+    limit?: number;
+    getKey: (item: T) => CursorKey;
+    order?: CursorSortOrder;
+    /** When true, invalid cursors throw; otherwise start from the beginning. */
+    strictCursor?: boolean;
+    defaultLimit?: number;
+  },
+): CursorPage<T> {
+  const order = options.order ?? 'asc';
+  const limit = clampLimit(options.limit, { defaultLimit: options.defaultLimit });
+  const getKey = options.getKey;
+
+  const sorted = [...items].sort((a, b) =>
+    order === 'asc' ? compareCursorKeysAsc(getKey(a), getKey(b)) : compareCursorKeysDesc(getKey(a), getKey(b)),
+  );
+
+  const decoded = decodeCursor(options.cursor, { strict: options.strictCursor === true });
+
+  let startIndex = 0;
+  if (decoded) {
+    // Prefer the classic "resume after the exact key" scan so pages never
+    // re-emit the cursor item even if timestamps collide.
+    const exact = sorted.findIndex((item) => {
+      const k = getKey(item);
+      return k.t === decoded.t && k.i === decoded.i;
+    });
+    if (exact >= 0) {
+      startIndex = exact + 1;
+    } else {
+      startIndex = sorted.findIndex((item) => isAfterCursor(getKey(item), decoded, order));
+      if (startIndex < 0) startIndex = sorted.length;
+    }
+  }
+
+  const window = sorted.slice(startIndex, startIndex + limit + 1);
+  return buildPageFromOverfetch(window, limit, getKey);
+}
+
+/** Build the standard HTTP pagination meta block from a {@link CursorPage}. */
+export function toPaginationMeta(page: Pick<CursorPage<unknown>, 'limit' | 'nextCursor' | 'hasMore'>): CursorPaginationMeta {
+  return {
+    limit: page.limit,
+    nextCursor: page.nextCursor,
+    hasMore: page.hasMore,
+  };
+}
+
+/**
+ * Parse `cursor` / `limit` from a loose query object (Express `req.query`).
+ * Empty-string cursor means "first page, cursor mode engaged".
+ */
+export function parseCursorQuery(
+  query: Record<string, unknown>,
+  options: { defaultLimit?: number } = {},
+): { cursor: string | undefined; limit: number; cursorMode: boolean } {
+  const cursorMode = Object.prototype.hasOwnProperty.call(query, 'cursor');
+  const rawCursor = query.cursor;
+  const cursor =
+    typeof rawCursor === 'string' && rawCursor.length > 0 ? rawCursor : undefined;
+
+  let rawLimit: number | undefined;
+  if (query.limit !== undefined && query.limit !== '') {
+    rawLimit = typeof query.limit === 'number' ? query.limit : Number.parseInt(String(query.limit), 10);
+  }
+
+  const limit = clampLimit(rawLimit, {
+    defaultLimit: options.defaultLimit ?? DEFAULT_PAGE_SIZE,
+  });
+
+  return { cursor, limit, cursorMode };
+}
+
+/**
+ * SQL helper: bind parameters for an ASC `(created_at, id)` seek.
+ * Returns `{ clause, values }` where `clause` is empty when there is no cursor.
+ *
+ * Example:
+ * ```sql
+ * WHERE (created_at > $2 OR (created_at = $2 AND id > $3))
+ * ORDER BY created_at ASC, id ASC
+ * LIMIT $1
+ * ```
+ */
+export function sqlSeekAsc(
+  cursor: CursorKey | null,
+  limit: number,
+  startIndex = 1,
+): { limitParam: number; clause: string; values: unknown[] } {
+  const limitParam = startIndex;
+  if (!cursor) {
+    return { limitParam, clause: '', values: [limit + 1] };
+  }
+  const tParam = startIndex + 1;
+  const iParam = startIndex + 2;
+  return {
+    limitParam,
+    clause: `(created_at > $${tParam} OR (created_at = $${tParam} AND id > $${iParam}))`,
+    values: [limit + 1, new Date(cursor.t), cursor.i],
+  };
+}

--- a/tests/schemas/index.exports.test.ts
+++ b/tests/schemas/index.exports.test.ts
@@ -7,6 +7,8 @@ import {
   riskEvaluateSchema,
   riskHistoryQuerySchema,
   transactionHistoryQuerySchema,
+  cursorPaginationQuerySchema,
+  offsetPaginationQuerySchema,
 } from '../../src/schemas/index.js';
 
 describe('schemas index exports', () => {
@@ -21,5 +23,10 @@ describe('schemas index exports', () => {
   it('re-exports risk schemas', () => {
     expect(riskEvaluateSchema).toBeDefined();
     expect(riskHistoryQuerySchema).toBeDefined();
+  });
+
+  it('re-exports pagination schemas', () => {
+    expect(cursorPaginationQuerySchema).toBeDefined();
+    expect(offsetPaginationQuerySchema).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Implements a single **cursor-based pagination standard** across list endpoints for credit lines, transactions, audits, and webhooks.

Closes #188

### Changes
- **Shared helpers** (`src/utils/cursorPagination.ts`): opaque base64url cursors (`{v,t,i}`), `clampLimit`, `paginateArray` / `buildPageFromOverfetch`, `parseCursorQuery`, SQL seek helper
- **Schemas** (`src/schemas/pagination.schema.ts`) for reusable cursor/offset query validation
- **Credit lines**: refactored in-memory + Postgres repos and service to use shared encode/decode (legacy `base64(ts|id)` still accepted on decode)
- **Transactions**: `GET /api/credit/lines/:id/transactions?cursor` returns `{ transactions, pagination: { limit, nextCursor, hasMore } }`; page/limit legacy retained
- **Audits / API keys**: `GET /api/admin/api-keys?cursor` and `.../audit?cursor` paginate; unpaginated responses kept when `cursor` is omitted
- **Webhooks**: new `GET /api/webhooks/deliveries` with cursor pagination + optional `status` filter
- **Docs + OpenAPI**: `docs/cursor-pagination.md`, `docs/API.md`, `docs/utils.md`, `docs/webhook-subscribers.md`, `src/openapi.yaml`
- **Tests**: unit tests for helpers + integration tests for all four surfaces

### Response contract (cursor mode)
```json
{
  pagination: {
    limit: 25,
    nextCursor: <opaque>,
    hasMore: true
  }
}
```

Cursors are opaque; clients must pass `nextCursor` back verbatim. Sort keys are deterministic (timestamp + id tie-break).

### Test plan
- [x] `vitest` unit tests for `cursorPagination`
- [x] Route integration tests (credit lines, transactions, api-keys, webhook deliveries)
- [x] Existing credit-line cursor tests still pass
- [x] `npm run validate:spec`
- [ ] Manual smoke: first page → next page → empty/hasMore=false; invalid limit → 400