### PR TITLE
feat(risk): anomaly detection hooks for rapid draw/repay patterns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,3 +114,31 @@ API_KEYS=change-me-before-any-real-traffic
 
 # Days before immutable `events` audit rows are purged. Default: 365
 # DATA_RETENTION_EVENTS_DAYS=365
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — Anomaly detection (rapid draw/repay risk signals)
+# See docs/ANOMALY_DETECTION.md
+# -----------------------------------------------------------------------------
+
+# Master switch for draw/repay anomaly hooks. Default: true
+# ANOMALY_DETECTION_ENABLED=true
+
+# rapid_successive_draws — medium severity (default: 3 draws / 300s)
+# ANOMALY_RAPID_DRAWS_MIN_COUNT=3
+# ANOMALY_RAPID_DRAWS_WINDOW_SECONDS=300
+
+# draw_burst — high severity (default: 5 draws / 60s)
+# ANOMALY_DRAW_BURST_MIN_COUNT=5
+# ANOMALY_DRAW_BURST_WINDOW_SECONDS=60
+
+# unusual_repay_pattern — high severity wash-cycle detection
+# ANOMALY_REPAY_PATTERN_MIN_CYCLES=2
+# ANOMALY_REPAY_PAIR_WINDOW_SECONDS=120
+# ANOMALY_REPAY_PATTERN_WINDOW_SECONDS=600
+# ANOMALY_REPAY_AMOUNT_TOLERANCE_RATIO=0.1
+
+# Suppress duplicate signals for the same rule/line (seconds). Default: 300
+# ANOMALY_SIGNAL_COOLDOWN_SECONDS=300
+
+# Cap in-memory activity events retained per credit line. Default: 50
+# ANOMALY_MAX_ACTIVITY_EVENTS_PER_LINE=50

--- a/docs/ANOMALY_DETECTION.md
+++ b/docs/ANOMALY_DETECTION.md
@@ -1,0 +1,212 @@
+# Anomaly Detection — Rapid Draw / Repay Risk Signals
+
+Lightweight, **rules-based** anomaly detection that watches credit lifecycle
+activity for suspicious draw and repay patterns. When a rule fires, the backend
+persists an explainable **risk signal** for operator review. Signals are
+**advisory only** — they never block draws or repays.
+
+Issue: [#198](https://github.com/Creditra/Creditra-Backend/issues/198)
+
+---
+
+## 1. Goals
+
+| Goal | How |
+|------|-----|
+| Detect rapid successive draws | Sliding window count on `credit.draw_confirmed` |
+| Detect draw bursts | Shorter/higher-frequency window |
+| Detect unusual repay patterns | Repeated draw→repay wash cycles |
+| Be explainable | Every signal stores the rule thresholds + evidence |
+| Be reviewable | Admin list/get endpoints under `/api/risk/admin/signals` |
+| Stay out of the money path | Event-bus subscriber; failures isolated |
+
+---
+
+## 2. Pipeline
+
+```
+CreditLineService.draw / .repay
+        │
+        ▼
+EventBus  ── credit.draw_confirmed / credit.repay_confirmed
+        │
+        ▼
+anomalySubscriber  ──►  AnomalyDetectionService.observe()
+        │
+        ├─ in-memory activity buffer (per credit line)
+        ├─ evaluate rules against configured thresholds
+        └─ RiskSignalRepository.create()  (correlationId attached)
+                │
+                ▼
+        risk_signals table  /  InMemoryRiskSignalRepository
+                │
+                ▼
+        GET /api/risk/admin/signals  (API key)
+```
+
+---
+
+## 3. Rules and default thresholds
+
+All thresholds are env-overridable (see §5). Defaults:
+
+### 3.1 `rapid_successive_draws` (medium)
+
+| Parameter | Default | Env |
+|-----------|---------|-----|
+| `minCount` | **3** draws | `ANOMALY_RAPID_DRAWS_MIN_COUNT` |
+| `windowSeconds` | **300** (5 min) | `ANOMALY_RAPID_DRAWS_WINDOW_SECONDS` |
+
+**Fires when** ≥ `minCount` confirmed draws land on the **same credit line**
+inside the trailing window ending at the latest draw.
+
+**Rationale:** Legitimate usage rarely stacks three draws inside five minutes;
+automation or account-takeover probes often do.
+
+### 3.2 `draw_burst` (high)
+
+| Parameter | Default | Env |
+|-----------|---------|-----|
+| `minCount` | **5** draws | `ANOMALY_DRAW_BURST_MIN_COUNT` |
+| `windowSeconds` | **60** | `ANOMALY_DRAW_BURST_WINDOW_SECONDS` |
+
+**Fires when** ≥ `minCount` draws hit the same line inside a one-minute burst.
+
+**Rationale:** High-frequency short bursts are a stronger abuse signal than
+merely “rapid successive” activity.
+
+### 3.3 `unusual_repay_pattern` (high)
+
+| Parameter | Default | Env |
+|-----------|---------|-----|
+| `minCycles` | **2** | `ANOMALY_REPAY_PATTERN_MIN_CYCLES` |
+| `pairWindowSeconds` | **120** | `ANOMALY_REPAY_PAIR_WINDOW_SECONDS` |
+| `patternWindowSeconds` | **600** | `ANOMALY_REPAY_PATTERN_WINDOW_SECONDS` |
+| `amountToleranceRatio` | **0.1** (10%) | `ANOMALY_REPAY_AMOUNT_TOLERANCE_RATIO` |
+
+**Fires when** at least `minCycles` draw→repay pairs occur where:
+
+1. Each repay arrives within `pairWindowSeconds` of its matched draw.
+2. `|draw − repay| / |draw| ≤ amountToleranceRatio`.
+3. The whole pattern fits inside `patternWindowSeconds`.
+
+**Rationale:** Fast, amount-matched draw/repay loops look like wash activity or
+limit probing rather than ordinary utilization.
+
+### 3.4 Cooldown
+
+| Parameter | Default | Env |
+|-----------|---------|-----|
+| `signalCooldownSeconds` | **300** | `ANOMALY_SIGNAL_COOLDOWN_SECONDS` |
+
+Suppresses re-emitting the **same rule** for the **same credit line** while the
+window is still “hot,” so operators are not flooded with duplicates.
+
+---
+
+## 4. Stored signal shape
+
+Table: `risk_signals` (`migrations/006_risk_signals.sql`).
+
+| Field | Purpose |
+|-------|---------|
+| `signal_type` | `rapid_successive_draws` \| `draw_burst` \| `unusual_repay_pattern` |
+| `rule_id` | Stable id, e.g. `rule.draw_burst` |
+| `severity` | `low` \| `medium` \| `high` |
+| `wallet_address` / `credit_line_id` | Subject of the signal |
+| `correlation_id` | Ties the signal to the evaluation that produced it |
+| `thresholds` | JSON snapshot of the thresholds used (explainability) |
+| `evidence` | Counts, amounts, timestamps that fired the rule |
+| `status` | `open` (default) \| `acknowledged` \| `dismissed` |
+| `created_at` | Server time |
+
+---
+
+## 5. Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `ANOMALY_DETECTION_ENABLED` | `true` | Master switch |
+| `ANOMALY_RAPID_DRAWS_MIN_COUNT` | `3` | See §3.1 |
+| `ANOMALY_RAPID_DRAWS_WINDOW_SECONDS` | `300` | See §3.1 |
+| `ANOMALY_DRAW_BURST_MIN_COUNT` | `5` | See §3.2 |
+| `ANOMALY_DRAW_BURST_WINDOW_SECONDS` | `60` | See §3.2 |
+| `ANOMALY_REPAY_PATTERN_MIN_CYCLES` | `2` | See §3.3 |
+| `ANOMALY_REPAY_PAIR_WINDOW_SECONDS` | `120` | See §3.3 |
+| `ANOMALY_REPAY_PATTERN_WINDOW_SECONDS` | `600` | See §3.3 |
+| `ANOMALY_REPAY_AMOUNT_TOLERANCE_RATIO` | `0.1` | See §3.3 |
+| `ANOMALY_SIGNAL_COOLDOWN_SECONDS` | `300` | See §3.4 |
+| `ANOMALY_MAX_ACTIVITY_EVENTS_PER_LINE` | `50` | Cap on in-memory buffer |
+
+Loader: [`src/config/anomalyDetection.ts`](../src/config/anomalyDetection.ts).
+
+---
+
+## 6. Admin API
+
+Auth: `X-API-Key` (same as other risk admin routes).
+
+### `GET /api/risk/admin/signals`
+
+Query (all optional, strict schema):
+
+- `walletAddress` — valid Stellar address
+- `creditLineId` — UUID
+- `signalType` — enum of the three types
+- `status` — `open` \| `acknowledged` \| `dismissed`
+- `correlationId`
+- `offset`, `limit` (max 100)
+
+Response envelope:
+
+```json
+{
+  "data": {
+    "signals": [ /* RiskSignal[] newest first */ ],
+    "total": 12,
+    "offset": 0,
+    "limit": 50
+  },
+  "error": null
+}
+```
+
+### `GET /api/risk/admin/signals/:id`
+
+Returns one signal or `404`.
+
+---
+
+## 7. Security notes
+
+- Detection is **read-only w.r.t. credit state**; it cannot mutate utilization.
+- Admin list endpoints require a valid API key; keys are never logged.
+- Evidence stores amounts and timestamps only — no secrets.
+- Multi-instance deployments each keep a local activity buffer; signals still
+  land in shared Postgres. For cross-replica window accuracy, prefer a single
+  writer or a future shared buffer (out of scope for #198).
+
+---
+
+## 8. Tests
+
+| Suite | Coverage |
+|-------|----------|
+| `src/services/__tests__/anomalyDetectionService.test.ts` | Rule triggers / non-triggers, cooldown, config |
+| `src/services/events/__tests__/anomalySubscriber.test.ts` | Event-bus hooks |
+| `src/repositories/memory/__tests__/InMemoryRiskSignalRepository.test.ts` | Persistence |
+| `src/routes/__tests__/risk.test.ts` | Admin list/get auth + happy path |
+
+---
+
+## 9. Code map
+
+| Path | Role |
+|------|------|
+| `src/config/anomalyDetection.ts` | Thresholds / env loader |
+| `src/models/RiskSignal.ts` | Domain model |
+| `src/services/anomalyDetectionService.ts` | Rules + buffer |
+| `src/services/events/anomalySubscriber.ts` | EventBus hooks |
+| `src/repositories/**/RiskSignal*` | Persistence |
+| `migrations/006_risk_signals.sql` | Schema |
+| `src/routes/risk.ts` | Admin endpoints |

--- a/docs/API.md
+++ b/docs/API.md
@@ -227,6 +227,22 @@ Implemented in [`src/routes/risk.ts`](../src/routes/risk.ts), backed by `RiskEva
 - **Query:** `offset`, `limit` (validated by `riskHistoryQuerySchema`).
 - **Response 200:** `{ data: { evaluations: RiskEvaluation[] }, error: null }`.
 
+#### `GET /api/risk/admin/signals` *(API-key auth)*
+
+List anomaly risk signals (rapid draws, draw bursts, unusual repay patterns)
+for operator review. Signals are advisory only — see
+[`ANOMALY_DETECTION.md`](./ANOMALY_DETECTION.md) for rules and thresholds.
+
+- **Auth:** `X-API-Key`.
+- **Query** (`riskSignalsQuerySchema`, all optional): `walletAddress`,
+  `creditLineId`, `signalType`, `status`, `correlationId`, `offset`, `limit`.
+- **Response 200:** `{ data: { signals, total, offset, limit }, error: null }`.
+
+#### `GET /api/risk/admin/signals/:id` *(API-key auth)*
+
+- **Auth:** `X-API-Key`.
+- **404:** `Risk signal not found`.
+
 #### `POST /api/risk/admin/recalibrate` *(API-key auth)*
 
 Hook for triggering a recalibration of the risk model.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This directory holds the long-form documentation for the Creditra backend. The t
 | Document | Subsystem |
 |---|---|
 | [`SIGNALS_INGEST.md`](./SIGNALS_INGEST.md) | The behavioral-signal pipeline — Creditra's differentiator. |
+| [`ANOMALY_DETECTION.md`](./ANOMALY_DETECTION.md) | Rules-based rapid draw/repay anomaly hooks and risk signals. |
 | [`INDEXER.md`](./INDEXER.md) | Stellar Horizon listener, cursor model, gap recovery, reconciliation runbook. |
 | [`SECURITY.md`](./SECURITY.md) | Threat model and in-tree mitigations. |
 | [`DATA_RETENTION.md`](./DATA_RETENTION.md) | Retention windows, anonymization, and deletion tooling for logs, audit events, and wallet-linked data. |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -9,6 +9,7 @@ The model supports:
 - **Borrowers** — Identities (e.g. wallet addresses) that can hold credit lines and receive risk evaluations.
 - **Credit lines** — Per-borrower credit facilities with limits, currency, and status.
 - **Risk evaluations** — Historical risk scores and suggested limits/rates for borrowers.
+- **Risk signals** — Rules-based anomaly detection outputs (rapid draws, draw bursts, unusual repay patterns) for operator review.
 - **Transactions** — Draws and repayments against credit lines.
 - **Events** — Immutable audit and domain events (e.g. from Horizon) for idempotency and replay.
 

--- a/migrations/006_risk_signals.sql
+++ b/migrations/006_risk_signals.sql
@@ -1,0 +1,47 @@
+-- Risk signals: rules-based anomaly detection outputs for operator review.
+-- See docs/ANOMALY_DETECTION.md and docs/data-model.md.
+
+CREATE TABLE IF NOT EXISTS risk_signals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  signal_type TEXT NOT NULL,
+  rule_id TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  wallet_address TEXT NOT NULL,
+  credit_line_id UUID,
+  correlation_id TEXT NOT NULL,
+  thresholds JSONB NOT NULL DEFAULT '{}'::jsonb,
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status TEXT NOT NULL DEFAULT 'open',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT risk_signals_severity_check
+    CHECK (severity IN ('low', 'medium', 'high')),
+  CONSTRAINT risk_signals_status_check
+    CHECK (status IN ('open', 'acknowledged', 'dismissed'))
+);
+
+CREATE INDEX IF NOT EXISTS risk_signals_wallet_address_idx
+  ON risk_signals (wallet_address);
+
+CREATE INDEX IF NOT EXISTS risk_signals_credit_line_id_idx
+  ON risk_signals (credit_line_id);
+
+CREATE INDEX IF NOT EXISTS risk_signals_created_at_idx
+  ON risk_signals (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS risk_signals_signal_type_idx
+  ON risk_signals (signal_type);
+
+CREATE INDEX IF NOT EXISTS risk_signals_correlation_id_idx
+  ON risk_signals (correlation_id);
+
+CREATE INDEX IF NOT EXISTS risk_signals_status_created_at_idx
+  ON risk_signals (status, created_at DESC);
+
+COMMENT ON TABLE risk_signals IS
+  'Anomaly detection risk signals (rapid draws, draw bursts, unusual repay patterns); advisory only';
+COMMENT ON COLUMN risk_signals.correlation_id IS
+  'Links signal to the activity evaluation that produced it (for audit/trace)';
+COMMENT ON COLUMN risk_signals.thresholds IS
+  'Explainable snapshot of rule thresholds at evaluation time';
+COMMENT ON COLUMN risk_signals.evidence IS
+  'Activity window / amounts / counts that caused the rule to fire';

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import cors from 'cors';
 import { creditRouter } from './routes/credit.js';
 import { riskRouter } from './routes/risk.js';
 import { apiKeysRouter } from './routes/apiKeys.js';
+import { recordRequest, metricsRouter } from './routes/metrics.js';
+import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
+import { maintenanceRouter } from './routes/maintenance.js';
 
 export function createApp() {
   const app = express();

--- a/src/config/anomalyDetection.ts
+++ b/src/config/anomalyDetection.ts
@@ -1,0 +1,157 @@
+/**
+ * Anomaly detection configuration for rapid draw/repay risk signals.
+ *
+ * All thresholds are explainable and env-overridable. Defaults are conservative
+ * enough for tests and local dev while still flagging clearly suspicious bursts.
+ *
+ * See `docs/ANOMALY_DETECTION.md` for rule semantics and rationale.
+ */
+
+export interface AnomalyDetectionConfig {
+  /** Master switch. When false, the subscriber is a no-op. */
+  enabled: boolean;
+
+  /**
+   * rapid_successive_draws — medium severity.
+   * Fires when `minCount` draws occur on the same credit line within `windowSeconds`.
+   */
+  rapidSuccessiveDraws: {
+    minCount: number;
+    windowSeconds: number;
+  };
+
+  /**
+   * draw_burst — high severity.
+   * Fires when `minCount` draws occur on the same credit line within a short
+   * `windowSeconds` burst window (stricter than rapid successive draws).
+   */
+  drawBurst: {
+    minCount: number;
+    windowSeconds: number;
+  };
+
+  /**
+   * unusual_repay_pattern — high severity.
+   * Fires when at least `minCycles` draw→repay pairs occur where each repay
+   * lands within `pairWindowSeconds` of its draw, amounts are within
+   * `amountToleranceRatio` of each other, and the whole pattern fits inside
+   * `patternWindowSeconds`.
+   */
+  unusualRepayPattern: {
+    minCycles: number;
+    pairWindowSeconds: number;
+    patternWindowSeconds: number;
+    /** Absolute relative difference |draw-repay|/draw allowed (e.g. 0.1 = 10%). */
+    amountToleranceRatio: number;
+  };
+
+  /**
+   * Per (creditLineId, ruleId) cooldown in seconds. Suppresses duplicate
+   * signals for the same rule/line while the suspicious window is still open.
+   */
+  signalCooldownSeconds: number;
+
+  /** Max in-memory activity events retained per credit line. */
+  maxActivityEventsPerLine: number;
+}
+
+export const DEFAULT_ANOMALY_DETECTION_CONFIG: AnomalyDetectionConfig = {
+  enabled: true,
+  rapidSuccessiveDraws: {
+    minCount: 3,
+    windowSeconds: 300,
+  },
+  drawBurst: {
+    minCount: 5,
+    windowSeconds: 60,
+  },
+  unusualRepayPattern: {
+    minCycles: 2,
+    pairWindowSeconds: 120,
+    patternWindowSeconds: 600,
+    amountToleranceRatio: 0.1,
+  },
+  signalCooldownSeconds: 300,
+  maxActivityEventsPerLine: 50,
+};
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return n;
+}
+
+function parseNonNegativeRatio(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return n;
+}
+
+function parseBool(raw: string | undefined, fallback: boolean): boolean {
+  if (raw === undefined || raw === '') return fallback;
+  const v = raw.trim().toLowerCase();
+  if (v === 'true' || v === '1' || v === 'yes') return true;
+  if (v === 'false' || v === '0' || v === 'no') return false;
+  return fallback;
+}
+
+/**
+ * Load anomaly detection config from environment variables.
+ * Unknown or invalid values fall back to {@link DEFAULT_ANOMALY_DETECTION_CONFIG}.
+ */
+export function loadAnomalyDetectionConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): AnomalyDetectionConfig {
+  const d = DEFAULT_ANOMALY_DETECTION_CONFIG;
+  return {
+    enabled: parseBool(env.ANOMALY_DETECTION_ENABLED, d.enabled),
+    rapidSuccessiveDraws: {
+      minCount: parsePositiveInt(
+        env.ANOMALY_RAPID_DRAWS_MIN_COUNT,
+        d.rapidSuccessiveDraws.minCount,
+      ),
+      windowSeconds: parsePositiveInt(
+        env.ANOMALY_RAPID_DRAWS_WINDOW_SECONDS,
+        d.rapidSuccessiveDraws.windowSeconds,
+      ),
+    },
+    drawBurst: {
+      minCount: parsePositiveInt(
+        env.ANOMALY_DRAW_BURST_MIN_COUNT,
+        d.drawBurst.minCount,
+      ),
+      windowSeconds: parsePositiveInt(
+        env.ANOMALY_DRAW_BURST_WINDOW_SECONDS,
+        d.drawBurst.windowSeconds,
+      ),
+    },
+    unusualRepayPattern: {
+      minCycles: parsePositiveInt(
+        env.ANOMALY_REPAY_PATTERN_MIN_CYCLES,
+        d.unusualRepayPattern.minCycles,
+      ),
+      pairWindowSeconds: parsePositiveInt(
+        env.ANOMALY_REPAY_PAIR_WINDOW_SECONDS,
+        d.unusualRepayPattern.pairWindowSeconds,
+      ),
+      patternWindowSeconds: parsePositiveInt(
+        env.ANOMALY_REPAY_PATTERN_WINDOW_SECONDS,
+        d.unusualRepayPattern.patternWindowSeconds,
+      ),
+      amountToleranceRatio: parseNonNegativeRatio(
+        env.ANOMALY_REPAY_AMOUNT_TOLERANCE_RATIO,
+        d.unusualRepayPattern.amountToleranceRatio,
+      ),
+    },
+    signalCooldownSeconds: parsePositiveInt(
+      env.ANOMALY_SIGNAL_COOLDOWN_SECONDS,
+      d.signalCooldownSeconds,
+    ),
+    maxActivityEventsPerLine: parsePositiveInt(
+      env.ANOMALY_MAX_ACTIVITY_EVENTS_PER_LINE,
+      d.maxActivityEventsPerLine,
+    ),
+  };
+}

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -18,16 +18,20 @@
  */
 import { type CreditLineRepository } from "../repositories/interfaces/CreditLineRepository.js";
 import { type RiskEvaluationRepository } from "../repositories/interfaces/RiskEvaluationRepository.js";
+import { type RiskSignalRepository } from "../repositories/interfaces/RiskSignalRepository.js";
 import { type TransactionRepository } from "../repositories/interfaces/TransactionRepository.js";
 import { getConnection, type DbClient } from "../db/client.js";
 import { InMemoryCreditLineRepository } from "../repositories/memory/InMemoryCreditLineRepository.js";
 import { InMemoryRiskEvaluationRepository } from "../repositories/memory/InMemoryRiskEvaluationRepository.js";
+import { InMemoryRiskSignalRepository } from "../repositories/memory/InMemoryRiskSignalRepository.js";
 import { InMemoryTransactionRepository } from "../repositories/memory/InMemoryTransactionRepository.js";
 import { PostgresCreditLineRepository } from "../repositories/postgres/PostgresCreditLineRepository.js";
 import { PostgresRiskEvaluationRepository } from "../repositories/postgres/PostgresRiskEvaluationRepository.js";
+import { PostgresRiskSignalRepository } from "../repositories/postgres/PostgresRiskSignalRepository.js";
 import { PostgresTransactionRepository } from "../repositories/postgres/PostgresTransactionRepository.js";
 import { CreditLineService } from "../services/CreditLineService.js";
 import { RiskEvaluationService } from "../services/RiskEvaluationService.js";
+import { AnomalyDetectionService } from "../services/anomalyDetectionService.js";
 import { createRiskProvider } from "../services/providers/providerFactory.js";
 import { ReconciliationService, type SorobanRpcClient } from "../services/reconciliationService.js";
 import { ReconciliationWorker } from "../services/reconciliationWorker.js";
@@ -35,9 +39,11 @@ import { createSorobanClient, resolveSorobanConfig } from "../services/sorobanCl
 import { defaultJobQueue } from "../services/jobQueue.js";
 import { defaultEventBus } from "../services/events/eventBus.js";
 import { registerAuditSubscriber } from "../services/events/auditSubscriber.js";
+import { registerAnomalySubscriber } from "../services/events/anomalySubscriber.js";
 import { DataRetentionService } from "../services/dataRetentionService.js";
 import { DataRetentionWorker } from "../services/dataRetentionWorker.js";
 import { DashboardSummaryService } from "../services/dashboardSummaryService.js";
+import { loadAnomalyDetectionConfig } from "../config/anomalyDetection.js";
 
 export class Container {
   private static instance: Container;
@@ -49,18 +55,22 @@ export class Container {
   private _creditLineRepository!: CreditLineRepository;
   private _riskEvaluationRepository!: RiskEvaluationRepository;
   private _transactionRepository!: TransactionRepository;
+  private _riskSignalRepository!: RiskSignalRepository;
 
   // Services
   private _creditLineService!: CreditLineService;
   private _riskEvaluationService!: RiskEvaluationService;
+  private _anomalyDetectionService!: AnomalyDetectionService;
   private _reconciliationService!: ReconciliationService;
   private _reconciliationWorker!: ReconciliationWorker;
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
+  private _anomalyUnsubscribe?: () => void;
 
   private constructor() {
     // Initialize repositories based on environment
@@ -79,6 +89,16 @@ export class Container {
     this._riskEvaluationService = new RiskEvaluationService(
       this._riskEvaluationRepository,
       createRiskProvider(),
+    );
+    this._anomalyDetectionService = new AnomalyDetectionService(
+      this._riskSignalRepository,
+      loadAnomalyDetectionConfig(),
+    );
+    // Re-bind anomaly subscriber so it always targets the current service instance.
+    this._anomalyUnsubscribe?.();
+    this._anomalyUnsubscribe = registerAnomalySubscriber(
+      this._eventBus,
+      this._anomalyDetectionService,
     );
     this._reconciliationService = new ReconciliationService(
       this._creditLineRepository,
@@ -113,11 +133,13 @@ export class Container {
       this._creditLineRepository = new PostgresCreditLineRepository(this._dbClient);
       this._riskEvaluationRepository = new PostgresRiskEvaluationRepository(this._dbClient);
       this._transactionRepository = new PostgresTransactionRepository(this._dbClient);
+      this._riskSignalRepository = new PostgresRiskSignalRepository(this._dbClient);
     } else {
       // Use in-memory repositories (for development/testing)
       this._creditLineRepository = new InMemoryCreditLineRepository();
       this._riskEvaluationRepository = new InMemoryRiskEvaluationRepository();
       this._transactionRepository = new InMemoryTransactionRepository();
+      this._riskSignalRepository = new InMemoryRiskSignalRepository();
     }
   }
 
@@ -141,6 +163,10 @@ export class Container {
     return this._transactionRepository;
   }
 
+  get riskSignalRepository(): RiskSignalRepository {
+    return this._riskSignalRepository;
+  }
+
   // Service getters
   get creditLineService(): CreditLineService {
     return this._creditLineService;
@@ -148,6 +174,10 @@ export class Container {
 
   get riskEvaluationService(): RiskEvaluationService {
     return this._riskEvaluationService;
+  }
+
+  get anomalyDetectionService(): AnomalyDetectionService {
+    return this._anomalyDetectionService;
   }
 
   get reconciliationService(): ReconciliationService {
@@ -168,11 +198,16 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
   // Method to replace repositories (useful for testing or switching to DB implementations)
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;
     riskEvaluationRepository?: RiskEvaluationRepository;
     transactionRepository?: TransactionRepository;
+    riskSignalRepository?: RiskSignalRepository;
   }): void {
     let shouldRebuildServices = false;
 
@@ -188,6 +223,11 @@ export class Container {
 
     if (repositories.transactionRepository) {
       this._transactionRepository = repositories.transactionRepository;
+    }
+
+    if (repositories.riskSignalRepository) {
+      this._riskSignalRepository = repositories.riskSignalRepository;
+      shouldRebuildServices = true;
     }
 
     if (shouldRebuildServices) {

--- a/src/container/__tests__/Container.contract.test.ts
+++ b/src/container/__tests__/Container.contract.test.ts
@@ -18,6 +18,7 @@ import { Container } from '../Container.js';
 import { validateEnv } from '../../config/env.js';
 import { CreditLineService } from '../../services/CreditLineService.js';
 import { RiskEvaluationService } from '../../services/RiskEvaluationService.js';
+import { AnomalyDetectionService } from '../../services/anomalyDetectionService.js';
 import { ReconciliationService } from '../../services/reconciliationService.js';
 import { ReconciliationWorker } from '../../services/reconciliationWorker.js';
 
@@ -31,6 +32,7 @@ const SERVICE_RESOLVERS: ReadonlyArray<{
 }> = [
   { name: 'creditLineService', ctor: CreditLineService },
   { name: 'riskEvaluationService', ctor: RiskEvaluationService },
+  { name: 'anomalyDetectionService', ctor: AnomalyDetectionService },
   { name: 'reconciliationService', ctor: ReconciliationService },
   { name: 'reconciliationWorker', ctor: ReconciliationWorker },
 ];
@@ -39,6 +41,7 @@ const REPOSITORY_RESOLVERS: ReadonlyArray<keyof Container> = [
   'creditLineRepository',
   'riskEvaluationRepository',
   'transactionRepository',
+  'riskSignalRepository',
 ];
 
 describe('Container DI contract', () => {
@@ -64,7 +67,7 @@ describe('Container DI contract', () => {
     });
 
     it.each(REPOSITORY_RESOLVERS)('resolves repository %s', (name) => {
-      const repo = container[name] as Record<string, unknown>;
+      const repo = container[name] as unknown as Record<string, unknown>;
       expect(repo, `${String(name)} must resolve`).toBeDefined();
       // A repository is a contract object: it must expose callable methods.
       expect(typeof repo).toBe('object');

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -16,6 +16,7 @@ export const EXPECTED_TABLES = [
   'risk_evaluations',
   'transactions',
   'events',
+  'risk_signals',
 ] as const;
 
 /**

--- a/src/db/validate-schema.test.ts
+++ b/src/db/validate-schema.test.ts
@@ -26,6 +26,7 @@ describe('missingTables', () => {
         { table_name: 'risk_evaluations' },
         { table_name: 'transactions' },
         { table_name: 'events' },
+        { table_name: 'risk_signals' },
       ],
     });
     const missing = await missingTables(client);
@@ -188,6 +189,7 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'risk_signals' },
           ],
         };
       }
@@ -210,6 +212,13 @@ describe('validateSchema', () => {
             { column_name: 'amount' },
             { column_name: 'event_type' },
             { column_name: 'created_at' },
+            { column_name: 'signal_type' },
+            { column_name: 'rule_id' },
+            { column_name: 'severity' },
+            { column_name: 'correlation_id' },
+            { column_name: 'thresholds' },
+            { column_name: 'evidence' },
+            { column_name: 'status' },
           ],
         };
       }
@@ -223,6 +232,8 @@ describe('validateSchema', () => {
             { indexname: 'risk_evaluations_borrower_id_idx' },
             { indexname: 'transactions_credit_line_id_idx' },
             { indexname: 'events_idempotency_key_key' },
+            { indexname: 'risk_signals_wallet_address_idx' },
+            { indexname: 'risk_signals_created_at_idx' },
           ],
         };
       }
@@ -263,6 +274,7 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'risk_signals' },
           ],
         };
       }
@@ -279,6 +291,8 @@ describe('validateSchema', () => {
             { indexname: 'risk_evaluations_borrower_id_idx' },
             { indexname: 'transactions_credit_line_id_idx' },
             { indexname: 'events_idempotency_key_key' },
+            { indexname: 'risk_signals_wallet_address_idx' },
+            { indexname: 'risk_signals_created_at_idx' },
           ],
         };
       }
@@ -309,6 +323,7 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'risk_signals' },
           ],
         };
       }
@@ -330,6 +345,13 @@ describe('validateSchema', () => {
             { column_name: 'amount' },
             { column_name: 'event_type' },
             { column_name: 'created_at' },
+            { column_name: 'signal_type' },
+            { column_name: 'rule_id' },
+            { column_name: 'severity' },
+            { column_name: 'correlation_id' },
+            { column_name: 'thresholds' },
+            { column_name: 'evidence' },
+            { column_name: 'status' },
           ],
         };
       }
@@ -364,6 +386,7 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'risk_signals' },
           ],
         };
       }
@@ -376,6 +399,8 @@ describe('validateSchema', () => {
             { indexname: 'risk_evaluations_borrower_id_idx' },
             { indexname: 'transactions_credit_line_id_idx' },
             { indexname: 'events_idempotency_key_key' },
+            { indexname: 'risk_signals_wallet_address_idx' },
+            { indexname: 'risk_signals_created_at_idx' },
           ],
         };
       }
@@ -405,6 +430,7 @@ describe('validateSchema', () => {
             { table_name: 'risk_evaluations' },
             { table_name: 'transactions' },
             { table_name: 'events' },
+            { table_name: 'risk_signals' },
           ],
         };
       }
@@ -426,6 +452,13 @@ describe('validateSchema', () => {
             { column_name: 'amount' },
             { column_name: 'event_type' },
             { column_name: 'created_at' },
+            { column_name: 'signal_type' },
+            { column_name: 'rule_id' },
+            { column_name: 'severity' },
+            { column_name: 'correlation_id' },
+            { column_name: 'thresholds' },
+            { column_name: 'evidence' },
+            { column_name: 'status' },
           ],
         };
       }

--- a/src/db/validate-schema.ts
+++ b/src/db/validate-schema.ts
@@ -28,6 +28,18 @@ const REQUIRED_COLUMNS: Record<string, string[]> = {
   risk_evaluations: ['id', 'borrower_id', 'risk_score', 'suggested_limit', 'interest_rate_bps', 'evaluated_at'],
   transactions: ['id', 'credit_line_id', 'type', 'amount', 'currency', 'created_at'],
   events: ['id', 'event_type', 'created_at'],
+  risk_signals: [
+    'id',
+    'signal_type',
+    'rule_id',
+    'severity',
+    'wallet_address',
+    'correlation_id',
+    'thresholds',
+    'evidence',
+    'status',
+    'created_at',
+  ],
 };
 
 /**
@@ -40,6 +52,7 @@ const REQUIRED_INDEXES: Record<string, string[]> = {
   risk_evaluations: ['risk_evaluations_borrower_id_idx'],
   transactions: ['transactions_credit_line_id_idx'],
   events: ['events_idempotency_key_key'],
+  risk_signals: ['risk_signals_wallet_address_idx', 'risk_signals_created_at_idx'],
 };
 
 /**

--- a/src/models/RiskSignal.ts
+++ b/src/models/RiskSignal.ts
@@ -1,0 +1,51 @@
+/**
+ * Persisted risk signal produced by the rules-based anomaly detection pipeline.
+ *
+ * Signals are advisory: they never block draws/repays. Operators review them
+ * via the admin list endpoint. Thresholds and evidence are stored so every
+ * signal is explainable at audit time.
+ */
+
+export type RiskSignalType =
+  | 'rapid_successive_draws'
+  | 'draw_burst'
+  | 'unusual_repay_pattern';
+
+export type RiskSignalSeverity = 'low' | 'medium' | 'high';
+
+export type RiskSignalStatus = 'open' | 'acknowledged' | 'dismissed';
+
+/** Stable rule identifiers (documented in docs/ANOMALY_DETECTION.md). */
+export type RiskSignalRuleId =
+  | 'rule.rapid_successive_draws'
+  | 'rule.draw_burst'
+  | 'rule.unusual_repay_pattern';
+
+export interface RiskSignal {
+  id: string;
+  signalType: RiskSignalType;
+  ruleId: RiskSignalRuleId;
+  severity: RiskSignalSeverity;
+  walletAddress: string;
+  creditLineId: string;
+  /** Correlates the signal to the activity evaluation that produced it. */
+  correlationId: string;
+  /** Snapshot of rule thresholds at evaluation time (explainability). */
+  thresholds: Record<string, number | string | boolean>;
+  /** Concrete activity that triggered the rule. */
+  evidence: Record<string, unknown>;
+  status: RiskSignalStatus;
+  createdAt: Date;
+}
+
+export interface CreateRiskSignalInput {
+  signalType: RiskSignalType;
+  ruleId: RiskSignalRuleId;
+  severity: RiskSignalSeverity;
+  walletAddress: string;
+  creditLineId: string;
+  correlationId: string;
+  thresholds: Record<string, number | string | boolean>;
+  evidence: Record<string, unknown>;
+  status?: RiskSignalStatus;
+}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -339,6 +339,74 @@ components:
           items:
             $ref: "#/components/schemas/RiskEvaluation"
 
+    RiskSignal:
+      type: object
+      description: |
+        Anomaly detection risk signal (advisory). Thresholds and evidence make
+        the decision explainable. See docs/ANOMALY_DETECTION.md.
+      required:
+        - id
+        - signalType
+        - ruleId
+        - severity
+        - walletAddress
+        - creditLineId
+        - correlationId
+        - thresholds
+        - evidence
+        - status
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        signalType:
+          type: string
+          enum: [rapid_successive_draws, draw_burst, unusual_repay_pattern]
+        ruleId:
+          type: string
+          example: rule.rapid_successive_draws
+        severity:
+          type: string
+          enum: [low, medium, high]
+        walletAddress:
+          type: string
+        creditLineId:
+          type: string
+          format: uuid
+        correlationId:
+          type: string
+          description: Links signal to the activity evaluation that produced it
+        thresholds:
+          type: object
+          additionalProperties: true
+          description: Snapshot of rule thresholds at evaluation time
+        evidence:
+          type: object
+          additionalProperties: true
+          description: Activity counts/amounts/timestamps that fired the rule
+        status:
+          type: string
+          enum: [open, acknowledged, dismissed]
+        createdAt:
+          type: string
+          format: date-time
+
+    RiskSignalListResponse:
+      type: object
+      required: [signals, total, offset, limit]
+      properties:
+        signals:
+          type: array
+          items:
+            $ref: "#/components/schemas/RiskSignal"
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
     # ── Webhook Schemas ───────────────────────────────────────────────────────
 
     WebhookConfigResponse:
@@ -1292,3 +1360,101 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+  /api/risk/admin/signals:
+    get:
+      tags: [Risk]
+      operationId: listRiskSignals
+      summary: List anomaly risk signals (admin)
+      description: |
+        Returns rules-based anomaly risk signals for operator review
+        (rapid successive draws, draw bursts, unusual repay patterns).
+        Requires API key. See docs/ANOMALY_DETECTION.md.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: walletAddress
+          in: query
+          schema:
+            type: string
+        - name: creditLineId
+          in: query
+          schema:
+            type: string
+            format: uuid
+        - name: signalType
+          in: query
+          schema:
+            type: string
+            enum: [rapid_successive_draws, draw_burst, unusual_repay_pattern]
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, acknowledged, dismissed]
+        - name: correlationId
+          in: query
+          schema:
+            type: string
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Risk signal list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/RiskSignalListResponse"
+                  error:
+                    type: string
+                    nullable: true
+        "401":
+          description: Missing API key
+        "403":
+          description: Invalid API key
+
+  /api/risk/admin/signals/{id}:
+    get:
+      tags: [Risk]
+      operationId: getRiskSignalById
+      summary: Get anomaly risk signal by id (admin)
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Risk signal
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/RiskSignal"
+                  error:
+                    type: string
+                    nullable: true
+        "404":
+          description: Risk signal not found
+        "401":
+          description: Missing API key
+        "403":
+          description: Invalid API key

--- a/src/repositories/interfaces/RiskSignalRepository.ts
+++ b/src/repositories/interfaces/RiskSignalRepository.ts
@@ -1,0 +1,33 @@
+import type {
+  CreateRiskSignalInput,
+  RiskSignal,
+  RiskSignalStatus,
+  RiskSignalType,
+} from '../../models/RiskSignal.js';
+
+export interface RiskSignalListFilters {
+  walletAddress?: string;
+  creditLineId?: string;
+  signalType?: RiskSignalType;
+  status?: RiskSignalStatus;
+  correlationId?: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface RiskSignalRepository {
+  /** Persist a newly detected signal. */
+  create(input: CreateRiskSignalInput): Promise<RiskSignal>;
+
+  /** Fetch by primary key. */
+  findById(id: string): Promise<RiskSignal | null>;
+
+  /**
+   * List signals newest-first with optional filters.
+   * `limit` is clamped by the service layer (default 50, max 100).
+   */
+  findMany(filters?: RiskSignalListFilters): Promise<RiskSignal[]>;
+
+  /** Total matching rows for pagination metadata. */
+  count(filters?: Omit<RiskSignalListFilters, 'offset' | 'limit'>): Promise<number>;
+}

--- a/src/repositories/memory/InMemoryRiskSignalRepository.ts
+++ b/src/repositories/memory/InMemoryRiskSignalRepository.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'crypto';
+import type {
+  CreateRiskSignalInput,
+  RiskSignal,
+} from '../../models/RiskSignal.js';
+import type {
+  RiskSignalListFilters,
+  RiskSignalRepository,
+} from '../interfaces/RiskSignalRepository.js';
+
+export class InMemoryRiskSignalRepository implements RiskSignalRepository {
+  private readonly signals = new Map<string, RiskSignal>();
+
+  async create(input: CreateRiskSignalInput): Promise<RiskSignal> {
+    const signal: RiskSignal = {
+      id: randomUUID(),
+      signalType: input.signalType,
+      ruleId: input.ruleId,
+      severity: input.severity,
+      walletAddress: input.walletAddress,
+      creditLineId: input.creditLineId,
+      correlationId: input.correlationId,
+      thresholds: { ...input.thresholds },
+      evidence: { ...input.evidence },
+      status: input.status ?? 'open',
+      createdAt: new Date(),
+    };
+    this.signals.set(signal.id, signal);
+    return signal;
+  }
+
+  async findById(id: string): Promise<RiskSignal | null> {
+    return this.signals.get(id) ?? null;
+  }
+
+  async findMany(filters: RiskSignalListFilters = {}): Promise<RiskSignal[]> {
+    const offset = filters.offset ?? 0;
+    const limit = filters.limit ?? 50;
+    return this.filter(filters)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(offset, offset + limit);
+  }
+
+  async count(
+    filters: Omit<RiskSignalListFilters, 'offset' | 'limit'> = {},
+  ): Promise<number> {
+    return this.filter(filters).length;
+  }
+
+  /** Test helper. */
+  clear(): void {
+    this.signals.clear();
+  }
+
+  private filter(
+    filters: Omit<RiskSignalListFilters, 'offset' | 'limit'>,
+  ): RiskSignal[] {
+    return Array.from(this.signals.values()).filter((s) => {
+      if (filters.walletAddress && s.walletAddress !== filters.walletAddress) {
+        return false;
+      }
+      if (filters.creditLineId && s.creditLineId !== filters.creditLineId) {
+        return false;
+      }
+      if (filters.signalType && s.signalType !== filters.signalType) {
+        return false;
+      }
+      if (filters.status && s.status !== filters.status) {
+        return false;
+      }
+      if (filters.correlationId && s.correlationId !== filters.correlationId) {
+        return false;
+      }
+      return true;
+    });
+  }
+}

--- a/src/repositories/memory/__tests__/InMemoryRiskSignalRepository.test.ts
+++ b/src/repositories/memory/__tests__/InMemoryRiskSignalRepository.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryRiskSignalRepository } from '../InMemoryRiskSignalRepository.js';
+
+describe('InMemoryRiskSignalRepository', () => {
+  let repo: InMemoryRiskSignalRepository;
+
+  beforeEach(() => {
+    repo = new InMemoryRiskSignalRepository();
+  });
+
+  it('creates and retrieves a signal by id', async () => {
+    const created = await repo.create({
+      signalType: 'rapid_successive_draws',
+      ruleId: 'rule.rapid_successive_draws',
+      severity: 'medium',
+      walletAddress: 'GTEST',
+      creditLineId: 'line-1',
+      correlationId: 'corr-1',
+      thresholds: { minCount: 3 },
+      evidence: { drawCount: 3 },
+    });
+
+    expect(created.id).toBeTruthy();
+    const found = await repo.findById(created.id);
+    expect(found).not.toBeNull();
+    expect(found?.correlationId).toBe('corr-1');
+    expect(found?.status).toBe('open');
+  });
+
+  it('filters by signal type and wallet', async () => {
+    await repo.create({
+      signalType: 'draw_burst',
+      ruleId: 'rule.draw_burst',
+      severity: 'high',
+      walletAddress: 'W1',
+      creditLineId: 'L1',
+      correlationId: 'c1',
+      thresholds: {},
+      evidence: {},
+    });
+    await repo.create({
+      signalType: 'rapid_successive_draws',
+      ruleId: 'rule.rapid_successive_draws',
+      severity: 'medium',
+      walletAddress: 'W2',
+      creditLineId: 'L2',
+      correlationId: 'c2',
+      thresholds: {},
+      evidence: {},
+    });
+
+    const bursts = await repo.findMany({ signalType: 'draw_burst' });
+    expect(bursts).toHaveLength(1);
+    expect(bursts[0].walletAddress).toBe('W1');
+
+    const w2 = await repo.findMany({ walletAddress: 'W2' });
+    expect(w2).toHaveLength(1);
+    expect(await repo.count({ walletAddress: 'W2' })).toBe(1);
+  });
+});

--- a/src/repositories/postgres/PostgresRiskSignalRepository.ts
+++ b/src/repositories/postgres/PostgresRiskSignalRepository.ts
@@ -1,0 +1,170 @@
+import type {
+  CreateRiskSignalInput,
+  RiskSignal,
+  RiskSignalRuleId,
+  RiskSignalSeverity,
+  RiskSignalStatus,
+  RiskSignalType,
+} from '../../models/RiskSignal.js';
+import type { DbClient } from '../../db/client.js';
+import type {
+  RiskSignalListFilters,
+  RiskSignalRepository,
+} from '../interfaces/RiskSignalRepository.js';
+
+interface RiskSignalRow {
+  id: string;
+  signal_type: string;
+  rule_id: string;
+  severity: string;
+  wallet_address: string;
+  credit_line_id: string | null;
+  correlation_id: string;
+  thresholds: Record<string, number | string | boolean> | string;
+  evidence: Record<string, unknown> | string;
+  status: string;
+  created_at: Date;
+}
+
+/**
+ * Postgres-backed RiskSignalRepository for the `risk_signals` table
+ * (see `migrations/006_risk_signals.sql`).
+ */
+export class PostgresRiskSignalRepository implements RiskSignalRepository {
+  constructor(private readonly client: DbClient) {}
+
+  async create(input: CreateRiskSignalInput): Promise<RiskSignal> {
+    const result = await this.client.query(
+      `INSERT INTO risk_signals
+         (signal_type, rule_id, severity, wallet_address, credit_line_id,
+          correlation_id, thresholds, evidence, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9)
+       RETURNING id, signal_type, rule_id, severity, wallet_address, credit_line_id,
+                 correlation_id, thresholds, evidence, status, created_at`,
+      [
+        input.signalType,
+        input.ruleId,
+        input.severity,
+        input.walletAddress,
+        input.creditLineId,
+        input.correlationId,
+        JSON.stringify(input.thresholds ?? {}),
+        JSON.stringify(input.evidence ?? {}),
+        input.status ?? 'open',
+      ],
+    );
+    return this.toModel(result.rows[0] as RiskSignalRow);
+  }
+
+  async findById(id: string): Promise<RiskSignal | null> {
+    const result = await this.client.query(
+      `SELECT id, signal_type, rule_id, severity, wallet_address, credit_line_id,
+              correlation_id, thresholds, evidence, status, created_at
+       FROM risk_signals
+       WHERE id = $1`,
+      [id],
+    );
+    if (result.rows.length === 0) return null;
+    return this.toModel(result.rows[0] as RiskSignalRow);
+  }
+
+  async findMany(filters: RiskSignalListFilters = {}): Promise<RiskSignal[]> {
+    const { clause, values, nextIndex } = this.buildWhere(filters);
+    const limit = filters.limit ?? 50;
+    const offset = filters.offset ?? 0;
+    values.push(limit, offset);
+    const result = await this.client.query(
+      `SELECT id, signal_type, rule_id, severity, wallet_address, credit_line_id,
+              correlation_id, thresholds, evidence, status, created_at
+       FROM risk_signals
+       ${clause}
+       ORDER BY created_at DESC
+       LIMIT $${nextIndex} OFFSET $${nextIndex + 1}`,
+      values,
+    );
+    return (result.rows as RiskSignalRow[]).map((row) => this.toModel(row));
+  }
+
+  async count(
+    filters: Omit<RiskSignalListFilters, 'offset' | 'limit'> = {},
+  ): Promise<number> {
+    const { clause, values } = this.buildWhere(filters);
+    const result = await this.client.query(
+      `SELECT COUNT(*)::text AS count FROM risk_signals ${clause}`,
+      values,
+    );
+    const row = result.rows[0] as { count: string };
+    return Number.parseInt(row.count, 10);
+  }
+
+  private buildWhere(
+    filters: Omit<RiskSignalListFilters, 'offset' | 'limit'>,
+  ): { clause: string; values: unknown[]; nextIndex: number } {
+    const parts: string[] = [];
+    const values: unknown[] = [];
+    let i = 1;
+
+    if (filters.walletAddress) {
+      parts.push(`wallet_address = $${i++}`);
+      values.push(filters.walletAddress);
+    }
+    if (filters.creditLineId) {
+      parts.push(`credit_line_id = $${i++}`);
+      values.push(filters.creditLineId);
+    }
+    if (filters.signalType) {
+      parts.push(`signal_type = $${i++}`);
+      values.push(filters.signalType);
+    }
+    if (filters.status) {
+      parts.push(`status = $${i++}`);
+      values.push(filters.status);
+    }
+    if (filters.correlationId) {
+      parts.push(`correlation_id = $${i++}`);
+      values.push(filters.correlationId);
+    }
+
+    return {
+      clause: parts.length > 0 ? `WHERE ${parts.join(' AND ')}` : '',
+      values,
+      nextIndex: i,
+    };
+  }
+
+  private toModel(row: RiskSignalRow): RiskSignal {
+    return {
+      id: row.id,
+      signalType: row.signal_type as RiskSignalType,
+      ruleId: row.rule_id as RiskSignalRuleId,
+      severity: row.severity as RiskSignalSeverity,
+      walletAddress: row.wallet_address,
+      creditLineId: row.credit_line_id ?? '',
+      correlationId: row.correlation_id,
+      thresholds: this.parseJsonObject(row.thresholds) as Record<
+        string,
+        number | string | boolean
+      >,
+      evidence: this.parseJsonObject(row.evidence),
+      status: row.status as RiskSignalStatus,
+      createdAt: new Date(row.created_at),
+    };
+  }
+
+  private parseJsonObject(
+    value: Record<string, unknown> | string,
+  ): Record<string, unknown> {
+    if (typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value) as unknown;
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>;
+        }
+      } catch {
+        return {};
+      }
+      return {};
+    }
+    return value ?? {};
+  }
+}

--- a/src/routes/__tests__/metrics.test.ts
+++ b/src/routes/__tests__/metrics.test.ts
@@ -23,9 +23,8 @@ async function invokeRoute(args: InvokeArgs): Promise<{ status: number; body: un
     throw new Error(`Route not found: ${args.method.toUpperCase()} ${args.path}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handlers: Array<(req: Request, res: Response, next: NextFunction) => unknown> =
-    layer.route.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
+    layer.route!.stack.map((s: any) => s.handle); // eslint-disable-line @typescript-eslint/no-explicit-any
 
   let statusCode = 200;
   let responseBody: unknown = null;

--- a/src/routes/__tests__/risk.test.ts
+++ b/src/routes/__tests__/risk.test.ts
@@ -379,4 +379,86 @@ describe('Risk Routes', () => {
       });
     });
   });
+
+  describe('GET /admin/signals', () => {
+    afterEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (typeof (container.riskSignalRepository as any).clear === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (container.riskSignalRepository as any).clear();
+      }
+      container.anomalyDetectionService.clearState();
+    });
+
+    it('requires API key', async () => {
+      const response = await invokeRoute({
+        method: 'get',
+        path: '/admin/signals',
+      });
+      expect(response.status).toBe(401);
+    });
+
+    it('lists signals for operators', async () => {
+      await container.riskSignalRepository.create({
+        signalType: 'rapid_successive_draws',
+        ruleId: 'rule.rapid_successive_draws',
+        severity: 'medium',
+        walletAddress: 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S2',
+        creditLineId: '33333333-3333-3333-3333-333333333333',
+        correlationId: 'route-corr-1',
+        thresholds: { minCount: 3, windowSeconds: 300 },
+        evidence: { drawCount: 3 },
+      });
+
+      const response = await invokeRoute({
+        method: 'get',
+        path: '/admin/signals',
+        headers: { 'x-api-key': validApiKey },
+        query: { limit: 10 },
+      });
+
+      expect(response.status).toBe(200);
+      const body = response.body as {
+        data: { signals: Array<{ correlationId: string }>; total: number };
+        error: null;
+      };
+      expect(body.error).toBeNull();
+      expect(body.data.total).toBeGreaterThanOrEqual(1);
+      expect(body.data.signals.some((s) => s.correlationId === 'route-corr-1')).toBe(true);
+    });
+
+    it('returns a single signal by id', async () => {
+      const created = await container.riskSignalRepository.create({
+        signalType: 'draw_burst',
+        ruleId: 'rule.draw_burst',
+        severity: 'high',
+        walletAddress: 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S2',
+        creditLineId: '44444444-4444-4444-4444-444444444444',
+        correlationId: 'route-corr-2',
+        thresholds: { minCount: 5 },
+        evidence: { drawCount: 5 },
+      });
+
+      const response = await invokeRoute({
+        method: 'get',
+        path: '/admin/signals/:id',
+        params: { id: created.id },
+        headers: { 'x-api-key': validApiKey },
+      });
+
+      expect(response.status).toBe(200);
+      expect((response.body as { data: { id: string } }).data.id).toBe(created.id);
+    });
+
+    it('returns 404 for missing signal', async () => {
+      const response = await invokeRoute({
+        method: 'get',
+        path: '/admin/signals/:id',
+        params: { id: '00000000-0000-0000-0000-000000000000' },
+        headers: { 'x-api-key': validApiKey },
+      });
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ data: null, error: 'Risk signal not found' });
+    });
+  });
 });

--- a/src/routes/creditBulk.ts
+++ b/src/routes/creditBulk.ts
@@ -54,8 +54,13 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
 
       try {
-        const creditService = container.getCreditService();
-        const line = await creditService.createCreditLine(parsed.data as CreateCreditLineBody);
+        const creditService = container.creditLineService;
+        const body = parsed.data as CreateCreditLineBody;
+        const line = await creditService.createCreditLine({
+          walletAddress: body.walletAddress,
+          creditLimit: body.creditLimit ?? body.requestedLimit ?? '',
+          interestRateBps: body.interestRateBps ?? 0,
+        });
         results.push({ index: i + 1, status: 'created', id: line.id });
         created++;
       } catch (err) {
@@ -64,9 +69,9 @@ creditBulkRouter.post('/lines/bulk', async (req: Request, res: Response, next) =
       }
     }
 
-    return res.status(207).json(ok({ summary: { total: rows.length, created, failed, dry_run: isDryRun }, results }));
+    return ok(res, { summary: { total: rows.length, created, failed, dry_run: isDryRun } as Record<string, unknown>, results }, 207);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 });
 

--- a/src/routes/risk.ts
+++ b/src/routes/risk.ts
@@ -1,12 +1,14 @@
 /**
  * Risk-evaluation routes mounted at `/api/risk` by `src/index.ts`.
  *
- * Surface (see `docs/API.md` and `docs/SIGNALS_INGEST.md` for the pipeline):
+ * Surface (see `docs/API.md`, `docs/SIGNALS_INGEST.md`, `docs/ANOMALY_DETECTION.md`):
  * - POST `/evaluate`                          — body validated; returns
  *   the cached evaluation when fresh (<24h) unless `forceRefresh: true`.
  * - GET  `/evaluations/:id`                   — fetch by id (404 if missing).
  * - GET  `/wallet/:walletAddress/latest`      — most recent for wallet.
  * - GET  `/wallet/:walletAddress/history`     — paginated history.
+ * - GET  `/admin/signals`                     — list anomaly risk signals (API key).
+ * - GET  `/admin/signals/:id`                 — fetch one risk signal (API key).
  * - POST `/admin/recalibrate`                 — protected by `X-API-Key`.
  *
  * Wallet path params are passed through to the risk service so missing
@@ -22,8 +24,10 @@ import { Container } from '../container/Container.js';
 import {
   riskEvaluateSchema,
   riskHistoryQuerySchema,
+  riskSignalsQuerySchema,
   type RiskEvaluateBody,
   type RiskHistoryQuery,
+  type RiskSignalsQuery,
 } from '../schemas/index.js';
 
 export const riskRouter = Router();
@@ -95,6 +99,54 @@ riskRouter.get(
       ok(res, { evaluations });
     } catch {
       fail(res, 'Failed to fetch risk evaluation history', 500);
+    }
+  },
+);
+
+/**
+ * GET /api/risk/admin/signals
+ * List anomaly risk signals for operator review (API-key auth).
+ */
+riskRouter.get(
+  '/admin/signals',
+  requireApiKey,
+  validateQuery(riskSignalsQuerySchema),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const query = req.query as unknown as RiskSignalsQuery;
+      const result = await container.anomalyDetectionService.listSignals({
+        walletAddress: query.walletAddress,
+        creditLineId: query.creditLineId,
+        signalType: query.signalType,
+        status: query.status,
+        correlationId: query.correlationId,
+        offset: query.offset,
+        limit: query.limit,
+      });
+      ok(res, result);
+    } catch {
+      fail(res, 'Failed to list risk signals', 500);
+    }
+  },
+);
+
+/**
+ * GET /api/risk/admin/signals/:id
+ * Fetch a single anomaly risk signal by id (API-key auth).
+ */
+riskRouter.get(
+  '/admin/signals/:id',
+  requireApiKey,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const signal = await container.anomalyDetectionService.getSignal(req.params.id);
+      if (!signal) {
+        fail(res, 'Risk signal not found', 404);
+        return;
+      }
+      ok(res, signal);
+    } catch {
+      fail(res, 'Failed to fetch risk signal', 500);
     }
   },
 );

--- a/src/routes/simulation.ts
+++ b/src/routes/simulation.ts
@@ -31,7 +31,7 @@ simulationRouter.post(
 
       const { amount } = req.body as DrawBody;
       const drawAmount = Number(amount);
-      const availableCredit = Number(line.creditLimit) - Number(line.balance ?? 0);
+      const availableCredit = Number(line.creditLimit) - Number(line.utilized ?? 0);
       const valid = drawAmount > 0 && drawAmount <= availableCredit;
       const interestBps: number = (line as unknown as Record<string, unknown>)['interestRateBps'] as number ?? 0;
       const estimatedFee = Math.ceil(drawAmount * interestBps / INTEREST_RATE_DIVISOR);
@@ -46,13 +46,13 @@ simulationRouter.post(
         preview: {
           requestedAmount: drawAmount,
           estimatedFee,
-          newBalance: valid ? Number(line.balance ?? 0) + drawAmount : null,
+          newBalance: valid ? Number(line.utilized ?? 0) + drawAmount : null,
           remainingCredit: valid ? availableCredit - drawAmount : availableCredit,
         },
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );
@@ -67,7 +67,7 @@ simulationRouter.post(
 
       const { amount } = req.body as RepayBody;
       const repayAmount = Number(amount);
-      const currentBalance = Number(line.balance ?? 0);
+      const currentBalance = Number(line.utilized ?? 0);
       const effectiveRepay = Math.min(repayAmount, currentBalance);
       const valid = repayAmount > 0;
 
@@ -84,7 +84,7 @@ simulationRouter.post(
       });
     } catch (err) {
       if (err instanceof CreditLineNotFoundError) return fail(res, err.message, 404);
-      next(err);
+      return next(err);
     }
   },
 );

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,7 +1,15 @@
 export { walletAddressSchema } from './common.schema.js';
 export { walletAddressParamSchema } from './params.schema.js';
-export { riskEvaluateSchema, riskHistoryQuerySchema } from './risk.schema.js';
-export type { RiskEvaluateBody, RiskHistoryQuery } from './risk.schema.js';
+export {
+  riskEvaluateSchema,
+  riskHistoryQuerySchema,
+  riskSignalsQuerySchema,
+} from './risk.schema.js';
+export type {
+  RiskEvaluateBody,
+  RiskHistoryQuery,
+  RiskSignalsQuery,
+} from './risk.schema.js';
 
 export {
   createCreditLineSchema,

--- a/src/schemas/risk.schema.ts
+++ b/src/schemas/risk.schema.ts
@@ -16,3 +16,21 @@ export const riskHistoryQuerySchema = z.object({
 }).strict();
 
 export type RiskHistoryQuery = z.infer<typeof riskHistoryQuerySchema>;
+
+/** Admin list filters for anomaly risk signals (GET /api/risk/admin/signals). */
+export const riskSignalsQuerySchema = z.object({
+  walletAddress: z
+    .string()
+    .refine(isValidStellarAddress, 'walletAddress must be a valid Stellar address')
+    .optional(),
+  creditLineId: z.string().uuid().optional(),
+  signalType: z
+    .enum(['rapid_successive_draws', 'draw_burst', 'unusual_repay_pattern'])
+    .optional(),
+  status: z.enum(['open', 'acknowledged', 'dismissed']).optional(),
+  correlationId: z.string().min(1).max(128).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  limit: z.coerce.number().int().positive().max(100).optional(),
+}).strict();
+
+export type RiskSignalsQuery = z.infer<typeof riskSignalsQuerySchema>;

--- a/src/services/__tests__/anomalyDetectionService.test.ts
+++ b/src/services/__tests__/anomalyDetectionService.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  AnomalyDetectionService,
+  type ActivityEvent,
+} from '../anomalyDetectionService.js';
+import { InMemoryRiskSignalRepository } from '../../repositories/memory/InMemoryRiskSignalRepository.js';
+import {
+  DEFAULT_ANOMALY_DETECTION_CONFIG,
+  type AnomalyDetectionConfig,
+} from '../../config/anomalyDetection.js';
+import { loadAnomalyDetectionConfig } from '../../config/anomalyDetection.js';
+
+const WALLET = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+const LINE_ID = '11111111-1111-1111-1111-111111111111';
+
+function baseConfig(
+  overrides: Partial<AnomalyDetectionConfig> = {},
+): AnomalyDetectionConfig {
+  return {
+    ...DEFAULT_ANOMALY_DETECTION_CONFIG,
+    signalCooldownSeconds: 1, // short cooldown for tests that expect multi-fire
+    ...overrides,
+    rapidSuccessiveDraws: {
+      ...DEFAULT_ANOMALY_DETECTION_CONFIG.rapidSuccessiveDraws,
+      ...overrides.rapidSuccessiveDraws,
+    },
+    drawBurst: {
+      ...DEFAULT_ANOMALY_DETECTION_CONFIG.drawBurst,
+      ...overrides.drawBurst,
+    },
+    unusualRepayPattern: {
+      ...DEFAULT_ANOMALY_DETECTION_CONFIG.unusualRepayPattern,
+      ...overrides.unusualRepayPattern,
+    },
+  };
+}
+
+function draw(
+  atMs: number,
+  amount = '100',
+  extras: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  return {
+    kind: 'draw',
+    creditLineId: LINE_ID,
+    walletAddress: WALLET,
+    amount,
+    occurredAtMs: atMs,
+    ...extras,
+  };
+}
+
+function repay(
+  atMs: number,
+  amount = '100',
+  extras: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  return {
+    kind: 'repay',
+    creditLineId: LINE_ID,
+    walletAddress: WALLET,
+    amount,
+    occurredAtMs: atMs,
+    ...extras,
+  };
+}
+
+describe('AnomalyDetectionService', () => {
+  let repo: InMemoryRiskSignalRepository;
+  let service: AnomalyDetectionService;
+
+  beforeEach(() => {
+    repo = new InMemoryRiskSignalRepository();
+    service = new AnomalyDetectionService(repo, baseConfig());
+  });
+
+  describe('rapid_successive_draws', () => {
+    it('does not fire below minCount', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          rapidSuccessiveDraws: { minCount: 3, windowSeconds: 300 },
+          drawBurst: { minCount: 99, windowSeconds: 1 },
+        }),
+      );
+      const t0 = Date.now();
+      await service.observe(draw(t0));
+      const r = await service.observe(draw(t0 + 1_000));
+      expect(r.signals.filter((s) => s.signalType === 'rapid_successive_draws')).toHaveLength(0);
+    });
+
+    it('fires when minCount draws land inside the window', async () => {
+      const t0 = Date.now();
+      await service.observe(draw(t0, '10'));
+      await service.observe(draw(t0 + 30_000, '20'));
+      const result = await service.observe(draw(t0 + 60_000, '30'));
+
+      const rapid = result.signals.filter((s) => s.signalType === 'rapid_successive_draws');
+      expect(rapid).toHaveLength(1);
+      expect(rapid[0].severity).toBe('medium');
+      expect(rapid[0].ruleId).toBe('rule.rapid_successive_draws');
+      expect(rapid[0].correlationId).toBeTruthy();
+      expect(rapid[0].thresholds.minCount).toBe(3);
+      expect(rapid[0].evidence.drawCount).toBe(3);
+      expect(rapid[0].walletAddress).toBe(WALLET);
+      expect(rapid[0].creditLineId).toBe(LINE_ID);
+    });
+
+    it('does not fire when draws are spread beyond the window', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          rapidSuccessiveDraws: { minCount: 3, windowSeconds: 60 },
+          drawBurst: { minCount: 99, windowSeconds: 1 }, // disable burst for this case
+        }),
+      );
+      const t0 = Date.now();
+      await service.observe(draw(t0));
+      await service.observe(draw(t0 + 61_000));
+      const result = await service.observe(draw(t0 + 122_000));
+      expect(result.signals).toHaveLength(0);
+    });
+  });
+
+  describe('draw_burst', () => {
+    it('fires on high-frequency short-window draws', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          rapidSuccessiveDraws: { minCount: 99, windowSeconds: 1 }, // isolate burst
+          drawBurst: { minCount: 5, windowSeconds: 60 },
+        }),
+      );
+      const t0 = Date.now();
+      for (let i = 0; i < 4; i++) {
+        await service.observe(draw(t0 + i * 5_000, String(10 + i)));
+      }
+      const result = await service.observe(draw(t0 + 20_000, '50'));
+      const burst = result.signals.filter((s) => s.signalType === 'draw_burst');
+      expect(burst).toHaveLength(1);
+      expect(burst[0].severity).toBe('high');
+      expect(burst[0].evidence.drawCount).toBe(5);
+    });
+
+    it('does not fire with only four draws in the burst window', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          rapidSuccessiveDraws: { minCount: 99, windowSeconds: 1 },
+          drawBurst: { minCount: 5, windowSeconds: 60 },
+        }),
+      );
+      const t0 = Date.now();
+      for (let i = 0; i < 3; i++) {
+        await service.observe(draw(t0 + i * 5_000));
+      }
+      const result = await service.observe(draw(t0 + 15_000));
+      expect(result.signals).toHaveLength(0);
+    });
+  });
+
+  describe('unusual_repay_pattern', () => {
+    it('fires on repeated rapid draw→repay cycles of similar amount', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          rapidSuccessiveDraws: { minCount: 99, windowSeconds: 1 },
+          drawBurst: { minCount: 99, windowSeconds: 1 },
+          unusualRepayPattern: {
+            minCycles: 2,
+            pairWindowSeconds: 120,
+            patternWindowSeconds: 600,
+            amountToleranceRatio: 0.1,
+          },
+        }),
+      );
+      const t0 = Date.now();
+      await service.observe(draw(t0, '100'));
+      await service.observe(repay(t0 + 10_000, '100'));
+      await service.observe(draw(t0 + 20_000, '100'));
+      const result = await service.observe(repay(t0 + 30_000, '100'));
+
+      const pattern = result.signals.filter((s) => s.signalType === 'unusual_repay_pattern');
+      expect(pattern).toHaveLength(1);
+      expect(pattern[0].severity).toBe('high');
+      expect(pattern[0].evidence.cycleCount).toBe(2);
+      expect(pattern[0].thresholds.minCycles).toBe(2);
+    });
+
+    it('does not fire when repay amounts diverge beyond tolerance', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          rapidSuccessiveDraws: { minCount: 99, windowSeconds: 1 },
+          drawBurst: { minCount: 99, windowSeconds: 1 },
+        }),
+      );
+      const t0 = Date.now();
+      await service.observe(draw(t0, '100'));
+      await service.observe(repay(t0 + 10_000, '50')); // 50% off
+      await service.observe(draw(t0 + 20_000, '100'));
+      const result = await service.observe(repay(t0 + 30_000, '50'));
+      expect(result.signals).toHaveLength(0);
+    });
+
+    it('does not fire for a single draw→repay cycle', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          rapidSuccessiveDraws: { minCount: 99, windowSeconds: 1 },
+          drawBurst: { minCount: 99, windowSeconds: 1 },
+        }),
+      );
+      const t0 = Date.now();
+      await service.observe(draw(t0, '100'));
+      const result = await service.observe(repay(t0 + 10_000, '100'));
+      expect(result.signals).toHaveLength(0);
+    });
+  });
+
+  describe('cooldown and disabled mode', () => {
+    it('suppresses duplicate signals during cooldown', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({
+          signalCooldownSeconds: 3600,
+          rapidSuccessiveDraws: { minCount: 3, windowSeconds: 300 },
+          drawBurst: { minCount: 99, windowSeconds: 1 },
+        }),
+      );
+      const t0 = Date.now();
+      await service.observe(draw(t0));
+      await service.observe(draw(t0 + 1_000));
+      const first = await service.observe(draw(t0 + 2_000));
+      expect(first.signals).toHaveLength(1);
+
+      const second = await service.observe(draw(t0 + 3_000));
+      expect(second.signals).toHaveLength(0);
+    });
+
+    it('is a no-op when disabled', async () => {
+      service = new AnomalyDetectionService(
+        repo,
+        baseConfig({ enabled: false }),
+      );
+      const t0 = Date.now();
+      for (let i = 0; i < 5; i++) {
+        await service.observe(draw(t0 + i * 1_000));
+      }
+      const listed = await service.listSignals();
+      expect(listed.total).toBe(0);
+    });
+  });
+
+  describe('listSignals', () => {
+    it('returns persisted signals with pagination metadata', async () => {
+      const t0 = Date.now();
+      await service.observe(draw(t0));
+      await service.observe(draw(t0 + 1_000));
+      await service.observe(draw(t0 + 2_000));
+
+      const page = await service.listSignals({ limit: 10 });
+      expect(page.total).toBeGreaterThanOrEqual(1);
+      expect(page.signals.length).toBeGreaterThanOrEqual(1);
+      expect(page.limit).toBe(10);
+      expect(page.offset).toBe(0);
+    });
+
+    it('filters by correlationId', async () => {
+      const t0 = Date.now();
+      const corr = 'corr-test-123';
+      await service.observe(draw(t0, '1', { correlationId: corr }));
+      await service.observe(draw(t0 + 1_000, '1', { correlationId: corr }));
+      await service.observe(draw(t0 + 2_000, '1', { correlationId: corr }));
+
+      const page = await service.listSignals({ correlationId: corr });
+      expect(page.total).toBeGreaterThanOrEqual(1);
+      expect(page.signals.every((s) => s.correlationId === corr)).toBe(true);
+    });
+  });
+
+  describe('loadAnomalyDetectionConfig', () => {
+    it('applies env overrides', () => {
+      const cfg = loadAnomalyDetectionConfig({
+        ANOMALY_DETECTION_ENABLED: 'true',
+        ANOMALY_RAPID_DRAWS_MIN_COUNT: '4',
+        ANOMALY_RAPID_DRAWS_WINDOW_SECONDS: '120',
+        ANOMALY_DRAW_BURST_MIN_COUNT: '6',
+        ANOMALY_SIGNAL_COOLDOWN_SECONDS: '60',
+      } as NodeJS.ProcessEnv);
+      expect(cfg.rapidSuccessiveDraws.minCount).toBe(4);
+      expect(cfg.rapidSuccessiveDraws.windowSeconds).toBe(120);
+      expect(cfg.drawBurst.minCount).toBe(6);
+      expect(cfg.signalCooldownSeconds).toBe(60);
+    });
+
+    it('falls back on invalid values', () => {
+      const cfg = loadAnomalyDetectionConfig({
+        ANOMALY_RAPID_DRAWS_MIN_COUNT: 'not-a-number',
+      } as NodeJS.ProcessEnv);
+      expect(cfg.rapidSuccessiveDraws.minCount).toBe(
+        DEFAULT_ANOMALY_DETECTION_CONFIG.rapidSuccessiveDraws.minCount,
+      );
+    });
+  });
+});

--- a/src/services/anomalyDetectionService.ts
+++ b/src/services/anomalyDetectionService.ts
@@ -1,0 +1,408 @@
+/**
+ * Rules-based anomaly detection for rapid draw / repay patterns.
+ *
+ * Pipeline:
+ *  1. Activity (draw/repay) is recorded into a per-credit-line sliding buffer.
+ *  2. Explainable rules evaluate the buffer against configured thresholds.
+ *  3. Firing rules persist {@link RiskSignal} rows for operator review.
+ *
+ * Detection never blocks the credit path — failures here are isolated and
+ * logged. See `docs/ANOMALY_DETECTION.md`.
+ */
+
+import { randomUUID } from 'crypto';
+import type {
+  AnomalyDetectionConfig,
+} from '../config/anomalyDetection.js';
+import {
+  DEFAULT_ANOMALY_DETECTION_CONFIG,
+  loadAnomalyDetectionConfig,
+} from '../config/anomalyDetection.js';
+import type {
+  CreateRiskSignalInput,
+  RiskSignal,
+  RiskSignalRuleId,
+  RiskSignalSeverity,
+  RiskSignalType,
+} from '../models/RiskSignal.js';
+import type {
+  RiskSignalListFilters,
+  RiskSignalRepository,
+} from '../repositories/interfaces/RiskSignalRepository.js';
+
+export type ActivityKind = 'draw' | 'repay';
+
+export interface ActivityEvent {
+  kind: ActivityKind;
+  creditLineId: string;
+  walletAddress: string;
+  amount: string;
+  /** Epoch milliseconds. */
+  occurredAtMs: number;
+  /** Optional external correlation (e.g. request id); generated if omitted. */
+  correlationId?: string;
+}
+
+export interface FiredRule {
+  signalType: RiskSignalType;
+  ruleId: RiskSignalRuleId;
+  severity: RiskSignalSeverity;
+  thresholds: Record<string, number | string | boolean>;
+  evidence: Record<string, unknown>;
+}
+
+export interface EvaluateResult {
+  correlationId: string;
+  signals: RiskSignal[];
+  firedRules: FiredRule[];
+}
+
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 100;
+
+export class AnomalyDetectionService {
+  private readonly config: AnomalyDetectionConfig;
+  /** creditLineId → chronological activity (newest last). */
+  private readonly activity = new Map<string, ActivityEvent[]>();
+  /** `${creditLineId}:${ruleId}` → last fired epoch ms (cooldown). */
+  private readonly lastFired = new Map<string, number>();
+
+  constructor(
+    private readonly repository: RiskSignalRepository,
+    config: AnomalyDetectionConfig = loadAnomalyDetectionConfig(),
+  ) {
+    this.config = config;
+  }
+
+  getConfig(): AnomalyDetectionConfig {
+    return this.config;
+  }
+
+  /**
+   * Record a draw/repay activity event and evaluate all rules.
+   * Returns any newly persisted signals (may be empty).
+   */
+  async observe(event: ActivityEvent): Promise<EvaluateResult> {
+    const correlationId = event.correlationId ?? randomUUID();
+    if (!this.config.enabled) {
+      return { correlationId, signals: [], firedRules: [] };
+    }
+
+    const normalized: ActivityEvent = {
+      ...event,
+      correlationId,
+      amount: event.amount,
+    };
+    this.pushActivity(normalized);
+
+    const fired = this.evaluateRules(normalized.creditLineId, correlationId);
+    const signals: RiskSignal[] = [];
+
+    for (const rule of fired) {
+      if (this.isCoolingDown(normalized.creditLineId, rule.ruleId, normalized.occurredAtMs)) {
+        continue;
+      }
+
+      const input: CreateRiskSignalInput = {
+        signalType: rule.signalType,
+        ruleId: rule.ruleId,
+        severity: rule.severity,
+        walletAddress: normalized.walletAddress,
+        creditLineId: normalized.creditLineId,
+        correlationId,
+        thresholds: rule.thresholds,
+        evidence: rule.evidence,
+        status: 'open',
+      };
+
+      const saved = await this.repository.create(input);
+      this.lastFired.set(
+        cooldownKey(normalized.creditLineId, rule.ruleId),
+        normalized.occurredAtMs,
+      );
+      signals.push(saved);
+    }
+
+    return { correlationId, signals, firedRules: fired };
+  }
+
+  /** Evaluate rules without persisting (pure; used by unit tests). */
+  evaluateOnly(
+    creditLineId: string,
+    correlationId = randomUUID(),
+  ): FiredRule[] {
+    return this.evaluateRules(creditLineId, correlationId);
+  }
+
+  async listSignals(filters: RiskSignalListFilters = {}): Promise<{
+    signals: RiskSignal[];
+    total: number;
+    offset: number;
+    limit: number;
+  }> {
+    const offset = Math.max(0, filters.offset ?? 0);
+    let limit = filters.limit ?? DEFAULT_LIST_LIMIT;
+    if (limit <= 0) limit = DEFAULT_LIST_LIMIT;
+    if (limit > MAX_LIST_LIMIT) limit = MAX_LIST_LIMIT;
+
+    const query: RiskSignalListFilters = {
+      ...filters,
+      offset,
+      limit,
+    };
+    const [signals, total] = await Promise.all([
+      this.repository.findMany(query),
+      this.repository.count({
+        walletAddress: filters.walletAddress,
+        creditLineId: filters.creditLineId,
+        signalType: filters.signalType,
+        status: filters.status,
+        correlationId: filters.correlationId,
+      }),
+    ]);
+    return { signals, total, offset, limit };
+  }
+
+  async getSignal(id: string): Promise<RiskSignal | null> {
+    return this.repository.findById(id);
+  }
+
+  /** Test helper: inject activity without evaluation. */
+  seedActivity(events: ActivityEvent[]): void {
+    for (const event of events) {
+      this.pushActivity({
+        ...event,
+        correlationId: event.correlationId ?? randomUUID(),
+      });
+    }
+  }
+
+  /** Test helper. */
+  clearState(): void {
+    this.activity.clear();
+    this.lastFired.clear();
+  }
+
+  // ── Rules ────────────────────────────────────────────────────────────────
+
+  private evaluateRules(creditLineId: string, correlationId: string): FiredRule[] {
+    const events = this.activity.get(creditLineId) ?? [];
+    if (events.length === 0) return [];
+
+    const fired: FiredRule[] = [];
+    const rapid = this.ruleRapidSuccessiveDraws(events, correlationId);
+    if (rapid) fired.push(rapid);
+
+    const burst = this.ruleDrawBurst(events, correlationId);
+    if (burst) fired.push(burst);
+
+    const repay = this.ruleUnusualRepayPattern(events, correlationId);
+    if (repay) fired.push(repay);
+
+    return fired;
+  }
+
+  private ruleRapidSuccessiveDraws(
+    events: ActivityEvent[],
+    correlationId: string,
+  ): FiredRule | null {
+    const { minCount, windowSeconds } = this.config.rapidSuccessiveDraws;
+    const windowMs = windowSeconds * 1000;
+    const latest = events[events.length - 1];
+    if (!latest || latest.kind !== 'draw') return null;
+
+    const windowStart = latest.occurredAtMs - windowMs;
+    const draws = events.filter(
+      (e) => e.kind === 'draw' && e.occurredAtMs >= windowStart,
+    );
+    if (draws.length < minCount) return null;
+
+    return {
+      signalType: 'rapid_successive_draws',
+      ruleId: 'rule.rapid_successive_draws',
+      severity: 'medium',
+      thresholds: {
+        minCount,
+        windowSeconds,
+        rule: 'rapid_successive_draws',
+      },
+      evidence: {
+        correlationId,
+        drawCount: draws.length,
+        windowStartIso: new Date(windowStart).toISOString(),
+        windowEndIso: new Date(latest.occurredAtMs).toISOString(),
+        amounts: draws.map((d) => d.amount),
+        occurredAt: draws.map((d) => new Date(d.occurredAtMs).toISOString()),
+      },
+    };
+  }
+
+  private ruleDrawBurst(
+    events: ActivityEvent[],
+    correlationId: string,
+  ): FiredRule | null {
+    const { minCount, windowSeconds } = this.config.drawBurst;
+    const windowMs = windowSeconds * 1000;
+    const latest = events[events.length - 1];
+    if (!latest || latest.kind !== 'draw') return null;
+
+    const windowStart = latest.occurredAtMs - windowMs;
+    const draws = events.filter(
+      (e) => e.kind === 'draw' && e.occurredAtMs >= windowStart,
+    );
+    if (draws.length < minCount) return null;
+
+    return {
+      signalType: 'draw_burst',
+      ruleId: 'rule.draw_burst',
+      severity: 'high',
+      thresholds: {
+        minCount,
+        windowSeconds,
+        rule: 'draw_burst',
+      },
+      evidence: {
+        correlationId,
+        drawCount: draws.length,
+        windowStartIso: new Date(windowStart).toISOString(),
+        windowEndIso: new Date(latest.occurredAtMs).toISOString(),
+        amounts: draws.map((d) => d.amount),
+        occurredAt: draws.map((d) => new Date(d.occurredAtMs).toISOString()),
+      },
+    };
+  }
+
+  private ruleUnusualRepayPattern(
+    events: ActivityEvent[],
+    correlationId: string,
+  ): FiredRule | null {
+    const {
+      minCycles,
+      pairWindowSeconds,
+      patternWindowSeconds,
+      amountToleranceRatio,
+    } = this.config.unusualRepayPattern;
+
+    const latest = events[events.length - 1];
+    if (!latest || latest.kind !== 'repay') return null;
+
+    const patternMs = patternWindowSeconds * 1000;
+    const pairMs = pairWindowSeconds * 1000;
+    const windowStart = latest.occurredAtMs - patternMs;
+    const recent = events.filter((e) => e.occurredAtMs >= windowStart);
+
+    const cycles: Array<{
+      drawAmount: string;
+      repayAmount: string;
+      drawAt: string;
+      repayAt: string;
+      deltaSeconds: number;
+    }> = [];
+
+    // Greedy pair: each repay matches the most recent unpaired prior draw
+    // within pairWindowSeconds and amount tolerance.
+    const unpairedDraws: ActivityEvent[] = [];
+    for (const e of recent) {
+      if (e.kind === 'draw') {
+        unpairedDraws.push(e);
+        continue;
+      }
+      // repay
+      for (let i = unpairedDraws.length - 1; i >= 0; i--) {
+        const draw = unpairedDraws[i];
+        const delta = e.occurredAtMs - draw.occurredAtMs;
+        if (delta < 0 || delta > pairMs) continue;
+        if (!amountsWithinTolerance(draw.amount, e.amount, amountToleranceRatio)) {
+          continue;
+        }
+        cycles.push({
+          drawAmount: draw.amount,
+          repayAmount: e.amount,
+          drawAt: new Date(draw.occurredAtMs).toISOString(),
+          repayAt: new Date(e.occurredAtMs).toISOString(),
+          deltaSeconds: Math.round(delta / 1000),
+        });
+        unpairedDraws.splice(i, 1);
+        break;
+      }
+    }
+
+    if (cycles.length < minCycles) return null;
+
+    return {
+      signalType: 'unusual_repay_pattern',
+      ruleId: 'rule.unusual_repay_pattern',
+      severity: 'high',
+      thresholds: {
+        minCycles,
+        pairWindowSeconds,
+        patternWindowSeconds,
+        amountToleranceRatio,
+        rule: 'unusual_repay_pattern',
+      },
+      evidence: {
+        correlationId,
+        cycleCount: cycles.length,
+        cycles,
+        windowStartIso: new Date(windowStart).toISOString(),
+        windowEndIso: new Date(latest.occurredAtMs).toISOString(),
+      },
+    };
+  }
+
+  // ── Buffer helpers ───────────────────────────────────────────────────────
+
+  private pushActivity(event: ActivityEvent): void {
+    const list = this.activity.get(event.creditLineId) ?? [];
+    list.push(event);
+
+    // Drop events older than the widest configured window (plus small margin).
+    const maxWindowSec = Math.max(
+      this.config.rapidSuccessiveDraws.windowSeconds,
+      this.config.drawBurst.windowSeconds,
+      this.config.unusualRepayPattern.patternWindowSeconds,
+    );
+    const cutoff = event.occurredAtMs - maxWindowSec * 1000 * 2;
+    let trimmed = list.filter((e) => e.occurredAtMs >= cutoff);
+
+    const max = this.config.maxActivityEventsPerLine;
+    if (trimmed.length > max) {
+      trimmed = trimmed.slice(trimmed.length - max);
+    }
+
+    this.activity.set(event.creditLineId, trimmed);
+  }
+
+  private isCoolingDown(
+    creditLineId: string,
+    ruleId: RiskSignalRuleId,
+    nowMs: number,
+  ): boolean {
+    const last = this.lastFired.get(cooldownKey(creditLineId, ruleId));
+    if (last === undefined) return false;
+    return nowMs - last < this.config.signalCooldownSeconds * 1000;
+  }
+}
+
+function cooldownKey(creditLineId: string, ruleId: string): string {
+  return `${creditLineId}:${ruleId}`;
+}
+
+function amountsWithinTolerance(
+  drawAmount: string,
+  repayAmount: string,
+  toleranceRatio: number,
+): boolean {
+  const d = Number.parseFloat(drawAmount);
+  const r = Number.parseFloat(repayAmount);
+  if (!Number.isFinite(d) || !Number.isFinite(r) || d === 0) return false;
+  return Math.abs(d - r) / Math.abs(d) <= toleranceRatio;
+}
+
+/** Factory using default env config — handy for tests that only need pure rules. */
+export function createAnomalyDetectionService(
+  repository: RiskSignalRepository,
+  config: AnomalyDetectionConfig = DEFAULT_ANOMALY_DETECTION_CONFIG,
+): AnomalyDetectionService {
+  return new AnomalyDetectionService(repository, config);
+}

--- a/src/services/drawWebhookService.ts
+++ b/src/services/drawWebhookService.ts
@@ -19,6 +19,9 @@ import { createHmac } from "node:crypto";
 import type { HorizonEvent } from "./horizonListener.js";
 import { getWebhookDeliveryStateStore } from "./webhookDeliveryState.js";
 import { redactLogArgs } from "../utils/logRedact.js";
+import { createServiceLogger } from "../utils/serviceLogger.js";
+
+const log = createServiceLogger("DrawWebhook");
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/services/events/__tests__/anomalySubscriber.test.ts
+++ b/src/services/events/__tests__/anomalySubscriber.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventBus } from '../eventBus.js';
+import { registerAnomalySubscriber } from '../anomalySubscriber.js';
+import { AnomalyDetectionService } from '../../anomalyDetectionService.js';
+import { InMemoryRiskSignalRepository } from '../../../repositories/memory/InMemoryRiskSignalRepository.js';
+import { DEFAULT_ANOMALY_DETECTION_CONFIG } from '../../../config/anomalyDetection.js';
+import { nowIso } from '../domainEvents.js';
+
+const WALLET = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOUJ3LNLRK';
+const LINE_ID = '22222222-2222-2222-2222-222222222222';
+
+describe('registerAnomalySubscriber', () => {
+  let bus: EventBus;
+  let service: AnomalyDetectionService;
+  let repo: InMemoryRiskSignalRepository;
+
+  beforeEach(() => {
+    bus = new EventBus();
+    repo = new InMemoryRiskSignalRepository();
+    service = new AnomalyDetectionService(repo, {
+      ...DEFAULT_ANOMALY_DETECTION_CONFIG,
+      signalCooldownSeconds: 1,
+      rapidSuccessiveDraws: { minCount: 3, windowSeconds: 300 },
+      drawBurst: { minCount: 99, windowSeconds: 1 },
+      unusualRepayPattern: {
+        minCycles: 2,
+        pairWindowSeconds: 120,
+        patternWindowSeconds: 600,
+        amountToleranceRatio: 0.1,
+      },
+    });
+  });
+
+  it('records signals when draw_confirmed events form a rapid pattern', async () => {
+    const sink = vi.fn();
+    registerAnomalySubscriber(bus, service, sink);
+
+    const base = Date.now();
+    for (let i = 0; i < 3; i++) {
+      await bus.publish({
+        type: 'credit.draw_confirmed',
+        occurredAt: new Date(base + i * 1_000).toISOString(),
+        creditLineId: LINE_ID,
+        payload: { walletAddress: WALLET, amount: '25', utilized: String(25 * (i + 1)) },
+      });
+    }
+
+    const listed = await service.listSignals({ creditLineId: LINE_ID });
+    expect(listed.total).toBeGreaterThanOrEqual(1);
+    expect(sink).toHaveBeenCalled();
+    const lastCall = sink.mock.calls[sink.mock.calls.length - 1][0];
+    expect(lastCall.signalCount).toBeGreaterThanOrEqual(1);
+    expect(lastCall.correlationId).toBeTruthy();
+  });
+
+  it('ignores non-draw/repay lifecycle events', async () => {
+    const sink = vi.fn();
+    registerAnomalySubscriber(bus, service, sink);
+
+    await bus.publish({
+      type: 'credit.opened',
+      occurredAt: nowIso(),
+      creditLineId: LINE_ID,
+      payload: { walletAddress: WALLET, creditLimit: '1000' },
+    });
+
+    expect(sink).not.toHaveBeenCalled();
+    const listed = await service.listSignals();
+    expect(listed.total).toBe(0);
+  });
+
+  it('disposer removes subscriptions', async () => {
+    const dispose = registerAnomalySubscriber(bus, service);
+    dispose();
+
+    await bus.publish({
+      type: 'credit.draw_confirmed',
+      occurredAt: nowIso(),
+      creditLineId: LINE_ID,
+      payload: { walletAddress: WALLET, amount: '10', utilized: '10' },
+    });
+
+    const listed = await service.listSignals();
+    expect(listed.total).toBe(0);
+  });
+});

--- a/src/services/events/anomalySubscriber.ts
+++ b/src/services/events/anomalySubscriber.ts
@@ -1,0 +1,80 @@
+/**
+ * Anomaly-detection subscriber for credit lifecycle events.
+ *
+ * Hooks into draw/repay confirmations on the {@link EventBus} and feeds them
+ * into {@link AnomalyDetectionService}. Subscriber failures are isolated so
+ * the core credit path never fails because of risk-signal recording.
+ */
+import type { EventBus } from './eventBus.js';
+import type {
+  CreditDomainEvent,
+  DrawConfirmedEvent,
+  RepayConfirmedEvent,
+} from './domainEvents.js';
+import type { AnomalyDetectionService } from '../anomalyDetectionService.js';
+
+const WATCHED = ['credit.draw_confirmed', 'credit.repay_confirmed'] as const;
+
+export type AnomalySignalSink = (info: {
+  eventType: string;
+  creditLineId: string;
+  signalCount: number;
+  correlationId: string;
+}) => void;
+
+function defaultSink(info: {
+  eventType: string;
+  creditLineId: string;
+  signalCount: number;
+  correlationId: string;
+}): void {
+  if (info.signalCount > 0) {
+    console.log(
+      '[anomaly]',
+      JSON.stringify({
+        ...info,
+        message: 'risk signals recorded',
+      }),
+    );
+  }
+}
+
+/**
+ * Subscribe anomaly detection to draw/repay lifecycle events.
+ * Returns a disposer that removes all subscriptions.
+ */
+export function registerAnomalySubscriber(
+  bus: EventBus,
+  service: AnomalyDetectionService,
+  sink: AnomalySignalSink = defaultSink,
+): () => void {
+  const handler = async (event: CreditDomainEvent): Promise<void> => {
+    if (
+      event.type !== 'credit.draw_confirmed' &&
+      event.type !== 'credit.repay_confirmed'
+    ) {
+      return;
+    }
+
+    const kind = event.type === 'credit.draw_confirmed' ? 'draw' : 'repay';
+    const payload = (event as DrawConfirmedEvent | RepayConfirmedEvent).payload;
+    const occurredAtMs = Date.parse(event.occurredAt);
+    const result = await service.observe({
+      kind,
+      creditLineId: event.creditLineId,
+      walletAddress: payload.walletAddress,
+      amount: payload.amount,
+      occurredAtMs: Number.isFinite(occurredAtMs) ? occurredAtMs : Date.now(),
+    });
+
+    sink({
+      eventType: event.type,
+      creditLineId: event.creditLineId,
+      signalCount: result.signals.length,
+      correlationId: result.correlationId,
+    });
+  };
+
+  const disposers = WATCHED.map((type) => bus.subscribe(type, handler));
+  return () => disposers.forEach((dispose) => dispose());
+}


### PR DESCRIPTION
## Summary

Rules-based anomaly detection for rapid draw / repay patterns (risk signals). Closes #198.

- **Rules (explainable, env-overridable thresholds)** documented in `docs/ANOMALY_DETECTION.md`:
  - `rapid_successive_draws` (medium): N draws in a window (default 3 / 300s)
  - `draw_burst` (high): short high-frequency burst (default 5 / 60s)
  - `unusual_repay_pattern` (high): repeated draw→repay wash cycles
- **EventBus hooks** on `credit.draw_confirmed` / `credit.repay_confirmed` via `anomalySubscriber`
- **Persist** `risk_signals` with `correlation_id`, threshold snapshot, and evidence (migration `006_risk_signals.sql`)
- **Admin API** (`X-API-Key`):
  - `GET /api/risk/admin/signals`
  - `GET /api/risk/admin/signals/:id`
- In-memory + Postgres repositories; schema validation / OpenAPI / `.env.example` updated
- Includes baseline typecheck fixes (`app.ts` imports, `creditBulk`, `simulation`, `drawWebhookService` logger, dashboard summary getter) so `tsc --noEmit` is clean

Signals are **advisory only** — they never block draws/repays.

## Validation

- `npx tsc --noEmit` — clean
- `npm run validate:spec` — OpenAPI valid
- Focused tests: anomaly service, subscriber, risk signal repo, risk routes, validate-schema, Container contract — **75 passed**

## Test plan

- [ ] Apply migration `006_risk_signals.sql` on a local Postgres
- [ ] Perform 3+ rapid draws on one credit line; confirm a medium `rapid_successive_draws` signal
- [ ] Perform 5 draws in <60s; confirm high `draw_burst`
- [ ] Two quick draw→repay cycles of similar amount; confirm `unusual_repay_pattern`
- [ ] `GET /api/risk/admin/signals` with API key lists signals; without key → 401
- [ ] `ANOMALY_DETECTION_ENABLED=false` produces no new signals