### PR TITLE
feat(db): enforce transactional boundaries for credit mutations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,6 +95,7 @@ flowchart TB
 
 - **Bootstrap** ([`src/index.ts`](../src/index.ts)) constructs the Express app, registers CORS, body parser, content-type guard, request logger, route mounts, and the global error handler — in that order.
 - **DI Container** ([`src/container/Container.ts`](../src/container/Container.ts)) is a lazy singleton. On first `getInstance()` it selects a repository implementation based on `DATABASE_URL` + `NODE_ENV`, constructs the service layer, instantiates the Soroban client and reconciliation pipeline, and registers the default in-process `jobQueue`.
+- **Transaction boundaries** for multi-write credit mutations (`create` / `draw` / `repay`) live in the service layer via `TransactionRunner` (`src/db/transaction.ts`). See [transactions.md](./transactions.md) for the strategy, guarantees, and failure-injection tests.
 - **Graceful shutdown** is bounded by `SHUTDOWN_TIMEOUT_MS` (default 30 s) and stops in this order: HTTP server → reconciliation worker → job queue → DB pool.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ This directory holds the long-form documentation for the Creditra backend. The t
 |---|---|
 | [`data-model.md`](./data-model.md) | Per-table column reference. |
 | [`REPOSITORY_ARCHITECTURE.md`](./REPOSITORY_ARCHITECTURE.md) | Repository / DIP layout. |
+| [`transactions.md`](./transactions.md) | DB transaction boundaries for atomic credit mutations (draw / repay / create). |
 | [`schema-validation.md`](./schema-validation.md) | Boot-time schema validator. |
 | [`cursor-pagination.md`](./cursor-pagination.md) | Cursor pagination contract. |
 | [`error-envelope.md`](./error-envelope.md) | `{ data, error }` envelope reference. |

--- a/docs/REPOSITORY_ARCHITECTURE.md
+++ b/docs/REPOSITORY_ARCHITECTURE.md
@@ -45,7 +45,7 @@ replaces the previous behavior of always returning the full limit.
 
 ### 4. Services (`src/services/`)
 Business logic layer that uses repositories:
-- `CreditLineService.ts` - Credit line management and validation
+- `CreditLineService.ts` - Credit line management and validation; multi-write mutations (`create` / `draw` / `repay`) run inside a `TransactionRunner` so ledger + balance writes commit or roll back together (see [transactions.md](./transactions.md))
 - `RiskEvaluationService.ts` - Risk assessment and caching logic
 
 ### 5. Dependency Injection (`src/container/`)

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,0 +1,141 @@
+# Database transaction strategy
+
+This document describes how the Creditra backend enforces **atomic multi-write
+credit mutations** so a mid-flow failure cannot leave the off-chain mirror
+desynced from ledger rows (or from what API clients observe).
+
+> Related: [ARCHITECTURE.md](./ARCHITECTURE.md), [REPOSITORY_ARCHITECTURE.md](./REPOSITORY_ARCHITECTURE.md), [data-model.md](./data-model.md).
+
+---
+
+## Why transactions
+
+Credit mutations often touch **more than one persistence step**:
+
+| Mutation | Writes |
+|---|---|
+| `createCreditLine` | Ensure `borrowers` row + insert `credit_lines` (Postgres path) |
+| `draw` | Insert `transactions` (`borrow`) + update credit-line utilization / re-read |
+| `repay` | Insert `transactions` (`repay`) + update credit-line utilization / re-read |
+
+Without a transaction boundary, a crash or query error after the first write
+and before the second produces **partial state**: e.g. a ledger row without a
+matching balance change, or a borrower without a credit line. That desyncs
+reconciliation, available-credit calculations, and client views.
+
+---
+
+## Boundary placement
+
+Transactions are opened at the **service layer**, not in HTTP routes and not
+as nested BEGIN inside every repository method.
+
+```
+Route  →  CreditLineService.draw/repay/create  →  TransactionRunner
+                │                                       │
+                │  BEGIN                                │
+                ├─► TransactionRepository.create        │
+                ├─► CreditLineRepository.update/create  │
+                │  COMMIT / ROLLBACK                    │
+                ▼
+         domain events (after commit only)
+```
+
+### Helper API
+
+| Symbol | Location | Role |
+|---|---|---|
+| `withTransaction(client, work)` | `src/db/transaction.ts` | `BEGIN` → `work()` → `COMMIT`, or `ROLLBACK` on throw |
+| `TransactionRunner` | same | Injectable function type used by services |
+| `createDbTransactionRunner(client)` | same | Postgres-backed runner |
+| `passthroughTransactionRunner` | same | No-op runner for in-memory / pure unit tests |
+
+When `client` is `undefined`, `withTransaction` runs `work` without SQL control
+statements. True multi-connection atomicity requires a live `DbClient`.
+
+### Wiring
+
+`Container.rebuildServices()` passes:
+
+- `transactionRepository` — shared with draw/repay ledger writes
+- `runInTransaction` — `createDbTransactionRunner(dbClient)` when `DATABASE_URL`
+  is active and `NODE_ENV !== 'test'`, otherwise passthrough
+
+Repositories that share the same `DbClient` connection participate in the open
+transaction automatically (same session for `BEGIN`/`COMMIT`).
+
+---
+
+## Guarantees and non-guarantees
+
+### Guaranteed (Postgres production path)
+
+- Draw/repay either persist **both** the ledger row and the balance touch, or
+  **neither**.
+- Create runs repository multi-statement work inside one transaction so a
+  failure after `ensureBorrower` does not leave an orphaned borrower without
+  rolling back when the insert fails (same session).
+- Domain events `credit.draw_confirmed` / `credit.repay_confirmed` /
+  `credit.opened` are emitted **after** a successful commit. Subscribers never
+  observe rolled-back state via those events.
+- `credit.draw_requested` may fire before the write txn (intent signal); it is
+  not a durability guarantee.
+
+### Not guaranteed
+
+- **In-memory repositories** use the passthrough runner: there is no SQL
+  rollback. Atomicity tests for in-memory use an explicit draft/commit harness
+  (see tests) to simulate the production contract.
+- **Nested transactions** on one connection are not supported (no SAVEPOINT).
+  Do not call `withTransaction` from inside another `withTransaction` on the
+  same client.
+- **On-chain / Soroban** submission is outside this boundary. Chain confirmation
+  remains eventually consistent via the indexer / reconciliation pipeline.
+- Single-statement updates (e.g. patch credit limit only) do not open a txn;
+  PostgreSQL already treats one statement as atomic.
+
+---
+
+## Failure-injection tests
+
+Regression coverage lives in:
+
+- `src/db/transaction.test.ts` — control flow (`BEGIN`/`COMMIT`/`ROLLBACK`),
+  injected failure on Nth data query, rollback error swallowed in favour of
+  the original failure.
+- `src/services/__tests__/CreditLineService.transactions.test.ts` — draw/repay
+  multi-write atomicity, mid-flow ledger failure, mid-flow balance-update
+  failure, no `*_confirmed` event after rollback, SQL control statements via
+  `createDbTransactionRunner`.
+
+Pattern used by service tests:
+
+1. Inject a `TransactionRunner` that stages mutations in draft maps.
+2. Throw on the second write.
+3. Assert durable maps are unchanged (simulated rollback).
+
+---
+
+## Adding a new atomic mutation
+
+1. Keep pure validation **outside** the runner (fail fast without `BEGIN`).
+2. Put every multi-write step **inside** `this.runInTransaction(async () => { ... })`.
+3. Emit success-side domain events **after** the runner returns.
+4. Add a failure-injection test that throws after the first write and asserts
+   no durable partial state.
+5. Prefer reusing the shared `DbClient` already held by repositories rather
+   than opening a second connection (which would not see the open txn).
+
+---
+
+## Operational notes
+
+- The current Postgres wiring uses a single `pg.Client` per process (see
+  `getConnection()`). All transactional work must run on that client. If the
+  stack moves to a `Pool`, acquire one client for the whole
+  `withTransaction` scope and pass it into repositories for that request.
+- Keep transactions **short**: no HTTP calls, no Soroban RPC, no webhook
+  delivery inside `runInTransaction`.
+- Prefer idempotent ledger writes (or unique constraints) for retries at the
+  HTTP edge; transactions alone do not make non-idempotent handlers safe under
+  double-submit.

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -20,6 +20,11 @@ import { type CreditLineRepository } from "../repositories/interfaces/CreditLine
 import { type RiskEvaluationRepository } from "../repositories/interfaces/RiskEvaluationRepository.js";
 import { type TransactionRepository } from "../repositories/interfaces/TransactionRepository.js";
 import { getConnection, type DbClient } from "../db/client.js";
+import {
+  createDbTransactionRunner,
+  passthroughTransactionRunner,
+  type TransactionRunner,
+} from "../db/transaction.js";
 import { InMemoryCreditLineRepository } from "../repositories/memory/InMemoryCreditLineRepository.js";
 import { InMemoryRiskEvaluationRepository } from "../repositories/memory/InMemoryRiskEvaluationRepository.js";
 import { InMemoryTransactionRepository } from "../repositories/memory/InMemoryTransactionRepository.js";
@@ -58,6 +63,8 @@ export class Container {
   private _sorobanClient!: SorobanRpcClient;
   private _dataRetentionService?: DataRetentionService;
   private _dataRetentionWorker?: DataRetentionWorker;
+  private _dashboardSummaryService!: DashboardSummaryService;
+  private _runInTransaction: TransactionRunner = passthroughTransactionRunner;
 
   // In-process domain event bus (credit lifecycle).
   private readonly _eventBus = defaultEventBus;
@@ -75,7 +82,20 @@ export class Container {
   }
 
   private rebuildServices(): void {
-    this._creditLineService = new CreditLineService(this._creditLineRepository, this._eventBus);
+    // Prefer a real BEGIN/COMMIT boundary when Postgres is wired; otherwise
+    // passthrough so unit tests and in-memory mode keep working without a DB.
+    this._runInTransaction = this._dbClient
+      ? createDbTransactionRunner(this._dbClient)
+      : passthroughTransactionRunner;
+
+    this._creditLineService = new CreditLineService(
+      this._creditLineRepository,
+      this._eventBus,
+      {
+        transactionRepository: this._transactionRepository,
+        runInTransaction: this._runInTransaction,
+      },
+    );
     this._riskEvaluationService = new RiskEvaluationService(
       this._riskEvaluationRepository,
       createRiskProvider(),
@@ -168,6 +188,10 @@ export class Container {
     return this._dataRetentionWorker;
   }
 
+  get dashboardSummaryService(): DashboardSummaryService {
+    return this._dashboardSummaryService;
+  }
+
   // Method to replace repositories (useful for testing or switching to DB implementations)
   public setRepositories(repositories: {
     creditLineRepository?: CreditLineRepository;
@@ -188,6 +212,9 @@ export class Container {
 
     if (repositories.transactionRepository) {
       this._transactionRepository = repositories.transactionRepository;
+      // CreditLineService pairs ledger writes with draw/repay — rebuild so the
+      // service holds the latest TransactionRepository reference.
+      shouldRebuildServices = true;
     }
 
     if (shouldRebuildServices) {

--- a/src/db/transaction.test.ts
+++ b/src/db/transaction.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { DbClient } from './client.js';
+import {
+  withTransaction,
+  createDbTransactionRunner,
+  passthroughTransactionRunner,
+} from './transaction.js';
+
+function createRecordingClient(options?: {
+  /** Fail when this SQL fragment is seen (case-insensitive). */
+  failOn?: string | RegExp;
+  /** Fail on the Nth non-control query (1-based). Control = BEGIN/COMMIT/ROLLBACK. */
+  failOnDataQuery?: number;
+}): DbClient & { statements: string[] } {
+  const statements: string[] = [];
+  let dataQueryCount = 0;
+
+  const client: DbClient & { statements: string[] } = {
+    statements,
+    async query(text: string) {
+      statements.push(text);
+      const normalized = text.trim().toUpperCase();
+      const isControl =
+        normalized === 'BEGIN' ||
+        normalized === 'COMMIT' ||
+        normalized === 'ROLLBACK';
+
+      if (!isControl) {
+        dataQueryCount += 1;
+        if (
+          options?.failOnDataQuery !== undefined &&
+          dataQueryCount === options.failOnDataQuery
+        ) {
+          throw new Error(`injected failure on data query #${dataQueryCount}`);
+        }
+      }
+
+      if (options?.failOn) {
+        const pattern =
+          typeof options.failOn === 'string'
+            ? new RegExp(options.failOn, 'i')
+            : options.failOn;
+        if (pattern.test(text)) {
+          throw new Error(`injected failure on: ${text}`);
+        }
+      }
+
+      return { rows: [] };
+    },
+    async end() {
+      /* no-op */
+    },
+  };
+
+  return client;
+}
+
+describe('withTransaction', () => {
+  it('runs work without control statements when client is undefined', async () => {
+    const result = await withTransaction(undefined, async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('commits after successful work', async () => {
+    const client = createRecordingClient();
+    const result = await withTransaction(client, async () => {
+      await client.query('INSERT INTO t VALUES (1)');
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(client.statements).toEqual([
+      'BEGIN',
+      'INSERT INTO t VALUES (1)',
+      'COMMIT',
+    ]);
+  });
+
+  it('rolls back and rethrows when work fails', async () => {
+    const client = createRecordingClient();
+
+    await expect(
+      withTransaction(client, async () => {
+        await client.query('INSERT INTO t VALUES (1)');
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(client.statements).toEqual([
+      'BEGIN',
+      'INSERT INTO t VALUES (1)',
+      'ROLLBACK',
+    ]);
+    expect(client.statements).not.toContain('COMMIT');
+  });
+
+  it('rolls back when a mid-flow data query fails (failure injection)', async () => {
+    const client = createRecordingClient({ failOnDataQuery: 2 });
+
+    await expect(
+      withTransaction(client, async () => {
+        await client.query('UPDATE credit_lines SET status = $1');
+        await client.query('INSERT INTO transactions ...'); // fails here
+        return 'unreachable';
+      }),
+    ).rejects.toThrow('injected failure on data query #2');
+
+    expect(client.statements[0]).toBe('BEGIN');
+    expect(client.statements.at(-1)).toBe('ROLLBACK');
+    expect(client.statements).not.toContain('COMMIT');
+  });
+
+  it('prefers the original error if ROLLBACK itself fails', async () => {
+    const statements: string[] = [];
+    const client: DbClient = {
+      async query(text: string) {
+        statements.push(text);
+        const n = text.trim().toUpperCase();
+        if (n === 'ROLLBACK') {
+          throw new Error('rollback failed');
+        }
+        return { rows: [] };
+      },
+      async end() {
+        /* no-op */
+      },
+    };
+
+    await expect(
+      withTransaction(client, async () => {
+        throw new Error('work failed');
+      }),
+    ).rejects.toThrow('work failed');
+
+    expect(statements).toEqual(['BEGIN', 'ROLLBACK']);
+  });
+});
+
+describe('createDbTransactionRunner', () => {
+  it('delegates to withTransaction on the given client', async () => {
+    const client = createRecordingClient();
+    const run = createDbTransactionRunner(client);
+    const value = await run(async () => {
+      await client.query('SELECT 1');
+      return 7;
+    });
+    expect(value).toBe(7);
+    expect(client.statements).toEqual(['BEGIN', 'SELECT 1', 'COMMIT']);
+  });
+});
+
+describe('passthroughTransactionRunner', () => {
+  it('executes work without a database client', async () => {
+    const spy = vi.fn(async () => 'done');
+    await expect(passthroughTransactionRunner(spy)).resolves.toBe('done');
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/db/transaction.ts
+++ b/src/db/transaction.ts
@@ -1,0 +1,65 @@
+import type { DbClient } from './client.js';
+
+/**
+ * Run `work` inside a PostgreSQL transaction on `client`.
+ *
+ * Lifecycle:
+ * 1. `BEGIN`
+ * 2. await `work()`
+ * 3. `COMMIT` on success, or `ROLLBACK` on any thrown error (re-thrown)
+ *
+ * When `client` is `undefined` (in-memory / test wiring without Postgres),
+ * `work` runs without BEGIN/COMMIT — there is no multi-connection ledger to
+ * keep consistent. Callers that need true atomicity must supply a real
+ * `DbClient` (see `docs/transactions.md`).
+ *
+ * Nested usage on the same connection is **not** supported (plain BEGIN, no
+ * SAVEPOINT). Service methods that already call `withTransaction` must not
+ * nest another transaction on the same client.
+ *
+ * @example
+ * ```ts
+ * await withTransaction(db, async () => {
+ *   await creditLines.update(id, { utilized });
+ *   await transactions.create({ creditLineId: id, type: 'borrow', amount });
+ * });
+ * ```
+ */
+export async function withTransaction<T>(
+  client: DbClient | undefined,
+  work: () => Promise<T>,
+): Promise<T> {
+  if (!client) {
+    return work();
+  }
+
+  await client.query('BEGIN');
+  try {
+    const result = await work();
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch {
+      // Prefer the original failure over a secondary rollback error.
+    }
+    throw error;
+  }
+}
+
+/**
+ * Injectable transaction boundary used by domain services.
+ *
+ * Production wires {@link createDbTransactionRunner}; tests inject a no-op
+ * or a failure-injecting runner without needing a live Postgres connection.
+ */
+export type TransactionRunner = <T>(work: () => Promise<T>) => Promise<T>;
+
+/** No-op runner: executes work immediately (in-memory repositories / unit tests). */
+export const passthroughTransactionRunner: TransactionRunner = async (work) => work();
+
+/** Build a runner that wraps work in `BEGIN`/`COMMIT`/`ROLLBACK` on `client`. */
+export function createDbTransactionRunner(client: DbClient): TransactionRunner {
+  return <T>(work: () => Promise<T>) => withTransaction(client, work);
+}

--- a/src/services/CreditLineService.ts
+++ b/src/services/CreditLineService.ts
@@ -1,7 +1,25 @@
 import { type CreditLine, type CreateCreditLineRequest, type UpdateCreditLineRequest, CreditLineStatus } from '../models/CreditLine.js';
 import type { CreditLineRepository, CursorPaginationResult } from '../repositories/interfaces/CreditLineRepository.js';
+import type { TransactionRepository } from '../repositories/interfaces/TransactionRepository.js';
+import { TransactionType } from '../models/Transaction.js';
+import {
+  passthroughTransactionRunner,
+  type TransactionRunner,
+} from '../db/transaction.js';
 import type { EventBus } from './events/eventBus.js';
 import { nowIso } from './events/domainEvents.js';
+
+/**
+ * Optional dependencies that enable atomic multi-table credit mutations.
+ *
+ * - `transactionRepository` — ledger writes paired with draw/repay
+ * - `runInTransaction` — BEGIN/COMMIT/ROLLBACK boundary (Postgres) or passthrough
+ *   (in-memory). See `docs/transactions.md`.
+ */
+export interface CreditLineServiceDeps {
+  transactionRepository?: TransactionRepository;
+  runInTransaction?: TransactionRunner;
+}
 
 /**
  * Domain service for credit-line CRUD plus the `draw` / `repay` operations.
@@ -16,24 +34,38 @@ import { nowIso } from './events/domainEvents.js';
  * - `interestRateBps` is clamped to the basis-points range `0..10000`
  * - Pagination `limit` is clamped to `1..100`; `offset` must be `≥ 0`
  *
+ * **Transaction boundaries.** Mutating methods that touch more than one
+ * persistence step (`createCreditLine`, `draw`, `repay`) run inside
+ * {@link TransactionRunner} so a mid-flow failure rolls back every write.
+ * Domain events are emitted *after* the transaction commits so subscribers
+ * never observe state that was rolled back.
+ *
  * Errors are thrown as plain {@link Error} with human-readable messages so
  * the route layer can map them to the `{ data, error }` response envelope.
  *
- * See `docs/ARCHITECTURE.md` §2 (request lifecycle) and `docs/API.md` for
- * the surfaces that call into this service.
+ * See `docs/ARCHITECTURE.md` §2 (request lifecycle), `docs/transactions.md`,
+ * and `docs/API.md` for the surfaces that call into this service.
  */
 export class CreditLineService {
+  private readonly transactionRepository?: TransactionRepository;
+  private readonly runInTransaction: TransactionRunner;
+
   /**
    * @param creditLineRepository persistence for credit lines
    * @param eventBus optional in-process bus; when supplied, lifecycle changes
    *   (open / draw / repay) publish domain events for decoupled subscribers
    *   (audit, webhooks, notifications). Emission is fire-and-forget and never
    *   blocks or fails the core operation.
+   * @param deps optional ledger + transaction-boundary wiring
    */
   constructor(
     private creditLineRepository: CreditLineRepository,
     private readonly eventBus?: EventBus,
-  ) {}
+    deps: CreditLineServiceDeps = {},
+  ) {
+    this.transactionRepository = deps.transactionRepository;
+    this.runInTransaction = deps.runInTransaction ?? passthroughTransactionRunner;
+  }
 
   /** Publish a domain event without letting subscriber failures affect callers. */
   private emit(event: Parameters<EventBus['publish']>[0]): void {
@@ -45,15 +77,19 @@ export class CreditLineService {
    * Create a new credit line for `walletAddress` with an explicit credit limit
    * and (optional) interest rate.
    *
+   * Runs inside a transaction so multi-statement repository paths
+   * (e.g. ensure-borrower + insert credit line on Postgres) cannot leave a
+   * partial row set if a later statement fails.
+   *
    * @throws if `walletAddress` is empty, `creditLimit` ≤ 0, or
    * `interestRateBps` is outside `0..10000`.
    */
   async createCreditLine(request: CreateCreditLineRequest): Promise<CreditLine> {
-    // Validate request
+    // Validate request (pure; outside the transaction)
     if (!request.walletAddress) {
       throw new Error('Wallet address is required');
     }
-    
+
     if (!request.creditLimit || parseFloat(request.creditLimit) <= 0) {
       throw new Error('Credit limit must be greater than 0');
     }
@@ -62,7 +98,9 @@ export class CreditLineService {
       throw new Error('Interest rate must be between 0 and 10000 basis points');
     }
 
-    const created = await this.creditLineRepository.create(request);
+    const created = await this.runInTransaction(async () => {
+      return this.creditLineRepository.create(request);
+    });
 
     this.emit({
       type: 'credit.opened',
@@ -132,7 +170,7 @@ export class CreditLineService {
       throw new Error('Credit limit must be greater than 0');
     }
 
-    if (request.interestRateBps !== undefined && 
+    if (request.interestRateBps !== undefined &&
         (request.interestRateBps < 0 || request.interestRateBps > 10000)) {
       throw new Error('Interest rate must be between 0 and 10000 basis points');
     }
@@ -159,11 +197,16 @@ export class CreditLineService {
    * - line `status` must be {@link CreditLineStatus.ACTIVE}
    * - `utilized + amount` must not exceed `creditLimit`
    *
-   * On success the persisted `utilized` field is incremented atomically by
-   * the repository. The on-chain transaction is submitted separately by the
-   * caller's wallet or integration; confirmation flows back through the indexer.
+   * **Atomicity.** The balance update and the ledger row (`transactions` type
+   * `borrow`) commit together. If either write fails, both roll back so the
+   * off-chain mirror cannot desync from the ledger clients read.
+   *
+   * The on-chain transaction is submitted separately by the caller's wallet
+   * or integration; confirmation flows back through the indexer.
    */
   async draw(id: string, borrowerId: string, amount: string): Promise<CreditLine> {
+    // Pre-flight read + pure validation outside the write transaction so we
+    // do not open a DB txn for cheap authorization failures.
     const line = await this.creditLineRepository.findById(id);
     if (!line) {
       throw new Error('Credit line not found');
@@ -181,6 +224,10 @@ export class CreditLineService {
     const limitNum = parseFloat(line.creditLimit);
     const utilizedNum = parseFloat(line.utilized || '0');
 
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
+      throw new Error('Draw amount must be greater than 0');
+    }
+
     if (utilizedNum + amountNum > limitNum) {
       throw new Error('Credit limit exceeded');
     }
@@ -192,9 +239,27 @@ export class CreditLineService {
       payload: { walletAddress: line.walletAddress, amount },
     });
 
-    const updated = await this.creditLineRepository.update(id, {
-      utilized: (utilizedNum + amountNum).toString(),
-    }) as CreditLine;
+    const newUtilized = (utilizedNum + amountNum).toString();
+
+    const updated = await this.runInTransaction(async () => {
+      // Ledger first so Postgres available-credit (SUM of borrows/repays) is
+      // consistent before we re-read the line after the balance touch.
+      if (this.transactionRepository) {
+        await this.transactionRepository.create({
+          creditLineId: id,
+          amount,
+          type: TransactionType.BORROW,
+        });
+      }
+
+      const next = await this.creditLineRepository.update(id, {
+        utilized: newUtilized,
+      });
+      if (!next) {
+        throw new Error('Credit line not found');
+      }
+      return next;
+    });
 
     this.emit({
       type: 'credit.draw_confirmed',
@@ -211,6 +276,9 @@ export class CreditLineService {
    * balance. The utilized amount is floored at `0` so a stray overpayment
    * can never produce negative utilization on the persisted row.
    *
+   * **Atomicity.** Balance update and ledger row (`transactions` type
+   * `repay`) commit in one transaction — same guarantees as {@link draw}.
+   *
    * Like {@link draw}, this method only manipulates the off-chain mirror of
    * state. The on-chain repay transaction is broadcast separately and
    * confirmed by the indexer.
@@ -222,11 +290,30 @@ export class CreditLineService {
     }
 
     const amountNum = parseFloat(amount);
-    const utilizedNum = parseFloat(line.utilized || '0');
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
+      throw new Error('Repay amount must be greater than 0');
+    }
 
-    const updated = await this.creditLineRepository.update(id, {
-      utilized: Math.max(0, utilizedNum - amountNum).toString(),
-    }) as CreditLine;
+    const utilizedNum = parseFloat(line.utilized || '0');
+    const newUtilized = Math.max(0, utilizedNum - amountNum).toString();
+
+    const updated = await this.runInTransaction(async () => {
+      if (this.transactionRepository) {
+        await this.transactionRepository.create({
+          creditLineId: id,
+          amount,
+          type: TransactionType.REPAY,
+        });
+      }
+
+      const next = await this.creditLineRepository.update(id, {
+        utilized: newUtilized,
+      });
+      if (!next) {
+        throw new Error('Credit line not found');
+      }
+      return next;
+    });
 
     this.emit({
       type: 'credit.repay_confirmed',

--- a/src/services/__tests__/CreditLineService.transactions.test.ts
+++ b/src/services/__tests__/CreditLineService.transactions.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Transaction-boundary tests for credit mutations.
+ *
+ * Verifies that draw / repay / create run inside the injected TransactionRunner
+ * and that a mid-flow failure aborts the whole unit of work (no partial
+ * credit-line update + orphan ledger row).
+ *
+ * @see docs/transactions.md
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CreditLineService } from '../CreditLineService.js';
+import type { CreditLineRepository } from '../../repositories/interfaces/CreditLineRepository.js';
+import type { TransactionRepository } from '../../repositories/interfaces/TransactionRepository.js';
+import {
+  type CreditLine,
+  CreditLineStatus,
+} from '../../models/CreditLine.js';
+import {
+  TransactionType,
+  TransactionStatus,
+  type Transaction,
+  type CreateTransactionRequest,
+} from '../../models/Transaction.js';
+import type { TransactionRunner } from '../../db/transaction.js';
+import type { DbClient } from '../../db/client.js';
+import { createDbTransactionRunner } from '../../db/transaction.js';
+
+const WALLET = 'GBAHQCUPC7G2B4D2F2I2K2M2O2Q2S2U2W2Y2A2C2E2G2I2K2M2O2Q2S1';
+
+function baseLine(overrides: Partial<CreditLine> = {}): CreditLine {
+  return {
+    id: 'cl-1',
+    walletAddress: WALLET,
+    creditLimit: '1000',
+    availableCredit: '1000',
+    utilized: '0',
+    interestRateBps: 500,
+    status: CreditLineStatus.ACTIVE,
+    version: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('CreditLineService transaction boundaries', () => {
+  let creditLines: CreditLineRepository;
+  let transactions: TransactionRepository;
+  let ledger: CreateTransactionRequest[];
+  let utilizedStore: Map<string, string>;
+  let lines: Map<string, CreditLine>;
+
+  beforeEach(() => {
+    ledger = [];
+    utilizedStore = new Map();
+    lines = new Map([['cl-1', baseLine()]]);
+
+    creditLines = {
+      create: vi.fn(async (req) => {
+        const line = baseLine({
+          id: 'cl-new',
+          walletAddress: req.walletAddress,
+          creditLimit: req.creditLimit,
+          availableCredit: req.creditLimit,
+          interestRateBps: req.interestRateBps,
+        });
+        lines.set(line.id, line);
+        return line;
+      }),
+      findById: vi.fn(async (id) => {
+        const line = lines.get(id);
+        if (!line) return null;
+        const utilized = utilizedStore.get(id) ?? line.utilized;
+        const limit = parseFloat(line.creditLimit);
+        const util = parseFloat(utilized);
+        return {
+          ...line,
+          utilized,
+          availableCredit: (limit - util).toString(),
+        };
+      }),
+      findByWalletAddress: vi.fn(async () => []),
+      findAll: vi.fn(async () => []),
+      findAllWithCursor: vi.fn(async () => ({
+        items: [],
+        nextCursor: null,
+        hasMore: false,
+      })),
+      update: vi.fn(async (id, request) => {
+        const existing = lines.get(id);
+        if (!existing) return null;
+        if (request.utilized !== undefined) {
+          utilizedStore.set(id, request.utilized);
+        }
+        const utilized = utilizedStore.get(id) ?? existing.utilized;
+        const limit = parseFloat(
+          request.creditLimit ?? existing.creditLimit,
+        );
+        const updated: CreditLine = {
+          ...existing,
+          ...request,
+          utilized,
+          availableCredit: (limit - parseFloat(utilized)).toString(),
+          updatedAt: new Date(),
+        };
+        lines.set(id, updated);
+        return updated;
+      }),
+      delete: vi.fn(async () => false),
+      exists: vi.fn(async () => true),
+      count: vi.fn(async () => lines.size),
+    };
+
+    transactions = {
+      create: vi.fn(async (request: CreateTransactionRequest) => {
+        ledger.push(request);
+        const tx: Transaction = {
+          id: `tx-${ledger.length}`,
+          creditLineId: request.creditLineId,
+          walletAddress: WALLET,
+          amount: request.amount,
+          type: request.type,
+          status: TransactionStatus.PENDING,
+          blockchainTxHash: request.blockchainTxHash,
+          createdAt: new Date(),
+        };
+        return tx;
+      }),
+      findById: vi.fn(async () => null),
+      findByCreditLineId: vi.fn(async () => []),
+      findByWalletAddress: vi.fn(async () => []),
+      updateStatus: vi.fn(async () => null),
+      findAll: vi.fn(async () => []),
+      count: vi.fn(async () => ledger.length),
+      findByStatus: vi.fn(async () => []),
+    };
+  });
+
+  it('draw updates utilized and records a borrow ledger row inside the runner', async () => {
+    const runOrder: string[] = [];
+    const runInTransaction: TransactionRunner = async (work) => {
+      runOrder.push('begin');
+      try {
+        const result = await work();
+        runOrder.push('commit');
+        return result;
+      } catch (e) {
+        runOrder.push('rollback');
+        throw e;
+      }
+    };
+
+    const service = new CreditLineService(creditLines, undefined, {
+      transactionRepository: transactions,
+      runInTransaction,
+    });
+
+    const updated = await service.draw('cl-1', WALLET, '250');
+
+    expect(updated.utilized).toBe('250');
+    expect(ledger).toEqual([
+      {
+        creditLineId: 'cl-1',
+        amount: '250',
+        type: TransactionType.BORROW,
+      },
+    ]);
+    expect(runOrder).toEqual(['begin', 'commit']);
+    expect(transactions.create).toHaveBeenCalledOnce();
+    expect(creditLines.update).toHaveBeenCalledOnce();
+  });
+
+  it('repay records a repay ledger row and reduces utilized atomically', async () => {
+    lines.set('cl-1', baseLine({ utilized: '400', availableCredit: '600' }));
+    utilizedStore.set('cl-1', '400');
+
+    const service = new CreditLineService(creditLines, undefined, {
+      transactionRepository: transactions,
+      runInTransaction: async (work) => work(),
+    });
+
+    const updated = await service.repay('cl-1', WALLET, '150');
+
+    expect(updated.utilized).toBe('250');
+    expect(ledger).toEqual([
+      {
+        creditLineId: 'cl-1',
+        amount: '150',
+        type: TransactionType.REPAY,
+      },
+    ]);
+  });
+
+  it('rolls back credit-line update when ledger write fails mid-flow', async () => {
+    // Simulate a transactional store: apply mutations to a draft, only
+    // promote on successful commit. Failure leaves the durable maps untouched.
+    let draftUtilized: Map<string, string> | null = null;
+    let draftLedger: CreateTransactionRequest[] | null = null;
+
+    const runInTransaction: TransactionRunner = async (work) => {
+      draftUtilized = new Map(utilizedStore);
+      draftLedger = [...ledger];
+      try {
+        const result = await work();
+        // commit
+        utilizedStore = draftUtilized!;
+        ledger = draftLedger!;
+        draftUtilized = null;
+        draftLedger = null;
+        return result;
+      } catch (error) {
+        // rollback — discard drafts
+        draftUtilized = null;
+        draftLedger = null;
+        throw error;
+      }
+    };
+
+    creditLines.update = vi.fn(async (id, request) => {
+      if (!draftUtilized) {
+        throw new Error('update outside transaction');
+      }
+      if (request.utilized !== undefined) {
+        draftUtilized.set(id, request.utilized);
+      }
+      const existing = lines.get(id)!;
+      const utilized = draftUtilized.get(id) ?? existing.utilized;
+      return {
+        ...existing,
+        utilized,
+        availableCredit: (
+          parseFloat(existing.creditLimit) - parseFloat(utilized)
+        ).toString(),
+      };
+    });
+
+    transactions.create = vi.fn(async (request) => {
+      if (!draftLedger) {
+        throw new Error('create outside transaction');
+      }
+      // Fail after the would-be ledger append would have been staged —
+      // inject failure *instead* of recording so commit never runs.
+      throw new Error('ledger write failed');
+      draftLedger.push(request);
+    });
+
+    const service = new CreditLineService(creditLines, undefined, {
+      transactionRepository: transactions,
+      runInTransaction,
+    });
+
+    await expect(service.draw('cl-1', WALLET, '100')).rejects.toThrow(
+      'ledger write failed',
+    );
+
+    // Durable state unchanged
+    expect(utilizedStore.size).toBe(0);
+    expect(ledger).toEqual([]);
+    const still = await creditLines.findById('cl-1');
+    expect(still?.utilized).toBe('0');
+  });
+
+  it('rolls back ledger row when credit-line update fails mid-flow', async () => {
+    let draftUtilized: Map<string, string> | null = null;
+    let draftLedger: CreateTransactionRequest[] | null = null;
+
+    const runInTransaction: TransactionRunner = async (work) => {
+      draftUtilized = new Map(utilizedStore);
+      draftLedger = [...ledger];
+      try {
+        const result = await work();
+        utilizedStore = draftUtilized!;
+        ledger = draftLedger!;
+        draftUtilized = null;
+        draftLedger = null;
+        return result;
+      } catch (error) {
+        draftUtilized = null;
+        draftLedger = null;
+        throw error;
+      }
+    };
+
+    transactions.create = vi.fn(async (request) => {
+      draftLedger!.push(request);
+      return {
+        id: 'tx-tmp',
+        creditLineId: request.creditLineId,
+        walletAddress: WALLET,
+        amount: request.amount,
+        type: request.type,
+        status: TransactionStatus.PENDING,
+        createdAt: new Date(),
+      };
+    });
+
+    creditLines.update = vi.fn(async () => {
+      throw new Error('balance update failed');
+    });
+
+    const service = new CreditLineService(creditLines, undefined, {
+      transactionRepository: transactions,
+      runInTransaction,
+    });
+
+    await expect(service.draw('cl-1', WALLET, '100')).rejects.toThrow(
+      'balance update failed',
+    );
+
+    expect(ledger).toEqual([]);
+    expect(utilizedStore.size).toBe(0);
+  });
+
+  it('createCreditLine runs repository.create inside the transaction runner', async () => {
+    const calls: string[] = [];
+    const runInTransaction: TransactionRunner = async (work) => {
+      calls.push('begin');
+      const result = await work();
+      calls.push('commit');
+      return result;
+    };
+
+    const service = new CreditLineService(creditLines, undefined, {
+      runInTransaction,
+    });
+
+    await service.createCreditLine({
+      walletAddress: WALLET,
+      creditLimit: '500',
+      interestRateBps: 100,
+    });
+
+    expect(calls).toEqual(['begin', 'commit']);
+    expect(creditLines.create).toHaveBeenCalledOnce();
+  });
+
+  it('does not emit draw_confirmed when the mutation rolls back', async () => {
+    const published: string[] = [];
+    const eventBus = {
+      publish: vi.fn(async (event: { type: string }) => {
+        published.push(event.type);
+      }),
+      subscribe: vi.fn(),
+    };
+
+    const runInTransaction: TransactionRunner = async (work) => {
+      try {
+        return await work();
+      } catch (e) {
+        throw e;
+      }
+    };
+
+    transactions.create = vi.fn(async () => {
+      throw new Error('db down');
+    });
+
+    const service = new CreditLineService(creditLines, eventBus as never, {
+      transactionRepository: transactions,
+      runInTransaction,
+    });
+
+    await expect(service.draw('cl-1', WALLET, '50')).rejects.toThrow('db down');
+
+    // requested is pre-txn (observability); confirmed must not fire after rollback
+    expect(published).toContain('credit.draw_requested');
+    expect(published).not.toContain('credit.draw_confirmed');
+  });
+});
+
+describe('CreditLineService + createDbTransactionRunner (SQL control flow)', () => {
+  it('issues BEGIN … COMMIT around a successful multi-write draw', async () => {
+    const statements: string[] = [];
+    const client: DbClient = {
+      async query(text: string) {
+        statements.push(text.trim().toUpperCase().split(/\s+/)[0] ?? text);
+        return { rows: [{ id: 'x' }] };
+      },
+      async end() {
+        /* no-op */
+      },
+    };
+
+    const line = baseLine();
+    const creditLines: CreditLineRepository = {
+      create: vi.fn(),
+      findById: vi.fn(async () => line),
+      findByWalletAddress: vi.fn(),
+      findAll: vi.fn(),
+      findAllWithCursor: vi.fn(),
+      update: vi.fn(async (_id, req) => ({
+        ...line,
+        utilized: req.utilized ?? line.utilized,
+        availableCredit: (
+          parseFloat(line.creditLimit) -
+          parseFloat(req.utilized ?? line.utilized)
+        ).toString(),
+      })),
+      delete: vi.fn(),
+      exists: vi.fn(),
+      count: vi.fn(),
+    };
+
+    const transactions: TransactionRepository = {
+      create: vi.fn(async (req) => ({
+        id: 'tx-1',
+        creditLineId: req.creditLineId,
+        walletAddress: WALLET,
+        amount: req.amount,
+        type: req.type,
+        status: TransactionStatus.PENDING,
+        createdAt: new Date(),
+      })),
+      findById: vi.fn(),
+      findByCreditLineId: vi.fn(),
+      findByWalletAddress: vi.fn(),
+      updateStatus: vi.fn(),
+      findAll: vi.fn(),
+      count: vi.fn(),
+      findByStatus: vi.fn(),
+    };
+
+    // Runner drives real BEGIN/COMMIT on the recording client; repos themselves
+    // are mocked and do not talk to SQL — we only assert control statements.
+    const runInTransaction = createDbTransactionRunner(client);
+    const service = new CreditLineService(creditLines, undefined, {
+      transactionRepository: transactions,
+      runInTransaction,
+    });
+
+    await service.draw('cl-1', WALLET, '10');
+
+    expect(statements[0]).toBe('BEGIN');
+    expect(statements.at(-1)).toBe('COMMIT');
+    expect(statements).not.toContain('ROLLBACK');
+  });
+
+  it('issues BEGIN … ROLLBACK when a mid-flow write throws', async () => {
+    const statements: string[] = [];
+    const client: DbClient = {
+      async query(text: string) {
+        statements.push(text.trim().toUpperCase().split(/\s+/)[0] ?? text);
+        return { rows: [] };
+      },
+      async end() {
+        /* no-op */
+      },
+    };
+
+    const line = baseLine();
+    const creditLines: CreditLineRepository = {
+      create: vi.fn(),
+      findById: vi.fn(async () => line),
+      findByWalletAddress: vi.fn(),
+      findAll: vi.fn(),
+      findAllWithCursor: vi.fn(),
+      update: vi.fn(async () => {
+        throw new Error('injected mid-flow failure');
+      }),
+      delete: vi.fn(),
+      exists: vi.fn(),
+      count: vi.fn(),
+    };
+
+    const transactions: TransactionRepository = {
+      create: vi.fn(async (req) => ({
+        id: 'tx-1',
+        creditLineId: req.creditLineId,
+        walletAddress: WALLET,
+        amount: req.amount,
+        type: req.type,
+        status: TransactionStatus.PENDING,
+        createdAt: new Date(),
+      })),
+      findById: vi.fn(),
+      findByCreditLineId: vi.fn(),
+      findByWalletAddress: vi.fn(),
+      updateStatus: vi.fn(),
+      findAll: vi.fn(),
+      count: vi.fn(),
+      findByStatus: vi.fn(),
+    };
+
+    const service = new CreditLineService(creditLines, undefined, {
+      transactionRepository: transactions,
+      runInTransaction: createDbTransactionRunner(client),
+    });
+
+    await expect(service.draw('cl-1', WALLET, '10')).rejects.toThrow(
+      'injected mid-flow failure',
+    );
+
+    expect(statements[0]).toBe('BEGIN');
+    expect(statements.at(-1)).toBe('ROLLBACK');
+    expect(statements).not.toContain('COMMIT');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #194.

Ensures multi-write credit mutations are atomic so a mid-flow failure cannot leave partial off-chain state (ledger vs balance desync).

### Changes
- **`src/db/transaction.ts`**: `withTransaction`, injectable `TransactionRunner`, `createDbTransactionRunner` / `passthroughTransactionRunner`
- **`CreditLineService`**: `createCreditLine`, `draw`, and `repay` run inside the runner; draw/repay also write paired ledger rows (`borrow` / `repay`) when a `TransactionRepository` is wired
- **`Container`**: wires transaction repository + DB-backed runner into the service; rebuilds on transaction-repo swap; restores missing `dashboardSummaryService` field/getter used by routes
- **Docs**: `docs/transactions.md` strategy; links from Architecture / Repository Architecture / docs index
- **Tests**: control-flow + failure-injection rollback coverage (`transaction.test.ts`, `CreditLineService.transactions.test.ts`)

### Transaction strategy (short)
- Boundaries at the **service** layer (not routes)
- Domain `*_confirmed` / `opened` events emit **after** commit only
- In-memory uses passthrough runner; Postgres uses `BEGIN`/`COMMIT`/`ROLLBACK` on the shared `DbClient`

## Test plan
- [x] `npx vitest --run src/db/transaction.test.ts src/services/__tests__/CreditLineService.transactions.test.ts src/services/__tests__/CreditLineService.test.ts src/container/__tests__/Container.test.ts`
- [x] Credit routes suite green
- [ ] CI full suite

## GrantFox
Payout wallet (Stellar): `GBVHELLD2JE235Y2NGTDT3MWI3T65ON6SY4N6FBHYVDAQ5FZC2CP5QXH`