### PR TITLE
feat(auth): service JWT tokens with rotation and migration plan

### DIFF
--- a/docs/security/service-auth.md
+++ b/docs/security/service-auth.md
@@ -1,0 +1,70 @@
+# Internal service authentication: JWT service tokens
+
+Replaces long-lived shared API keys with short-lived, signed JWT service tokens for
+internal service-to-service calls.
+
+## Format
+
+A minimal, dependency-free JWT (`header.payload.signature`, base64url, HS256 only).
+No external JWT library is used, so verification has no supply-chain surface beyond
+Node's built-in `crypto` module.
+
+- `iss`: `creditra-backend`
+- `aud`: `creditra-internal`
+- `sub`: calling service account name (e.g. `reconciliation-worker`)
+- `permissions`: string array of granted scopes
+- `iat` / `exp`: issued-at / expiry (default TTL 5 minutes, max 1 hour)
+
+## Minting a token (admin-only)
+
+```
+POST /api/admin/service-tokens
+X-Admin-Api-Key: <ADMIN_API_KEY>
+Content-Type: application/json
+
+{ "serviceAccount": "reconciliation-worker", "permissions": ["reconcile:run"], "ttlSeconds": 300 }
+```
+
+Returns `{ token, expiresAt }`. Tokens are short-lived by design — callers should
+re-mint rather than requesting long expiries.
+
+## Verifying a token on a route
+
+```ts
+import { requireServiceToken } from '../middleware/serviceAuth.js';
+
+router.post('/internal/reconcile', requireServiceToken('reconcile:run'), handler);
+```
+
+`requireServiceToken(permission?)` returns 401 when the `Authorization: Bearer <token>`
+header is missing, and 403 when the token is invalid, expired, or lacks the required
+permission. On success, `req.serviceAccount` carries the verified claims.
+
+## Key rotation without downtime
+
+```
+POST /api/admin/service-tokens/rotate
+X-Admin-Api-Key: <ADMIN_API_KEY>
+```
+
+Rotating adds a new signing key used for all newly minted tokens. The previous keys
+remain valid for verification for a retention window (last 3 keys), so tokens minted
+just before a rotation are not invalidated mid-flight — no coordinated deploy or
+downtime is required.
+
+By default the signing secret is generated in-process (`SERVICE_TOKEN_SECRET` env var
+override for a fixed value across replicas/restarts).
+
+## Migration plan from shared API keys
+
+This is additive, not a breaking replacement: `requireServiceToken` middleware is
+independent of `createApiKeyMiddleware` (`X-API-Key`), which continues to work
+unchanged. Adopt route-by-route:
+
+1. Mint a service token for each internal caller and update it to send
+   `Authorization: Bearer <token>` instead of `X-API-Key`.
+2. Add `requireServiceToken(...)` to the route (can run alongside the existing
+   API-key check during the migration window — accept either until all callers
+   have switched).
+3. Once all callers of a route have migrated, remove the API-key check for that
+   route.

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { exportsRouter } from './routes/exports.js';
 import { recordRequest, metricsRouter } from './routes/metrics.js';
 import { maintenanceModeGuard } from './middleware/maintenanceMode.js';
 import { maintenanceRouter } from './routes/maintenance.js';
+import { serviceTokensRouter } from './routes/serviceTokens.js';
 
 /**
  * Application factory used by integration tests and lightweight local boots.
@@ -41,6 +42,7 @@ export function createApp() {
   app.use('/api/risk', riskRouter);
   app.use('/api/dashboard', dashboardRouter);
   app.use('/api/admin/api-keys', apiKeysRouter);
+  app.use('/api/admin/service-tokens', serviceTokensRouter);
   app.use('/api/admin/exports', exportsRouter);
 
   // Admin-only route to toggle maintenance mode.

--- a/src/middleware/serviceAuth.ts
+++ b/src/middleware/serviceAuth.ts
@@ -1,0 +1,37 @@
+/**
+ * Bearer JWT authentication for internal service-to-service routes.
+ *
+ * Additive to (not a replacement for) `createApiKeyMiddleware` — see
+ * `docs/security/service-auth.md` for the migration plan from shared API keys.
+ */
+import type { Request, Response, NextFunction } from 'express';
+import { forbidden, sendProblem, unauthorized } from '../errors/index.js';
+import { verifyServiceToken, type VerifiedServiceToken } from '../services/serviceTokens.js';
+
+export type RequestWithServiceAccount = Request & { serviceAccount?: VerifiedServiceToken };
+
+/**
+ * Requires a valid `Authorization: Bearer <token>` service token.
+ * When `requiredPermission` is given, the token's `permissions` claim must include it.
+ */
+export function requireServiceToken(requiredPermission?: string) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const header = req.headers.authorization;
+    if (!header || !header.startsWith('Bearer ')) {
+      sendProblem(res, unauthorized('Unauthorized: Bearer service token required.'));
+      return;
+    }
+
+    try {
+      const claims = verifyServiceToken(header.slice('Bearer '.length));
+      if (requiredPermission && !claims.permissions.includes(requiredPermission)) {
+        sendProblem(res, forbidden('Forbidden: token lacks required permission.'));
+        return;
+      }
+      (req as RequestWithServiceAccount).serviceAccount = claims;
+      next();
+    } catch {
+      sendProblem(res, forbidden('Forbidden: invalid or expired service token.'));
+    }
+  };
+}

--- a/src/routes/serviceTokens.ts
+++ b/src/routes/serviceTokens.ts
@@ -1,0 +1,36 @@
+/**
+ * Service-token lifecycle routes (admin-gated via `X-Admin-Api-Key`).
+ *
+ * Mints short-lived signed JWTs for internal service-to-service calls, and
+ * rotates the active signing key. See `docs/security/service-auth.md`.
+ *
+ * Surface:
+ *  - POST `/`       — mint a token for a named service account.
+ *  - POST `/rotate` — rotate the signing key (old tokens stay valid until they age out).
+ */
+import { Router, type Request, type Response } from 'express';
+import { adminAuth } from '../middleware/adminAuth.js';
+import { validateBody } from '../middleware/validate.js';
+import { mintServiceTokenSchema, type MintServiceTokenBody } from '../schemas/serviceToken.schema.js';
+import { mintServiceToken, rotateServiceTokenKey } from '../services/serviceTokens.js';
+import { ok } from '../utils/response.js';
+
+export const serviceTokensRouter = Router();
+
+serviceTokensRouter.post(
+  '/',
+  adminAuth,
+  validateBody(mintServiceTokenSchema),
+  (req: Request, res: Response): void => {
+    const { serviceAccount, permissions, ttlSeconds } = req.body as MintServiceTokenBody;
+    const { token, expiresAt } = mintServiceToken({ sub: serviceAccount, permissions }, ttlSeconds);
+    ok(res, { token, expiresAt });
+  },
+);
+
+serviceTokensRouter.post('/rotate', adminAuth, (_req: Request, res: Response): void => {
+  const { kid } = rotateServiceTokenKey();
+  ok(res, { kid });
+});
+
+export default serviceTokensRouter;

--- a/src/schemas/serviceToken.schema.ts
+++ b/src/schemas/serviceToken.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const mintServiceTokenSchema = z.object({
+  serviceAccount: z.string().min(1).max(128),
+  permissions: z.array(z.string().min(1)).max(50).default([]),
+  ttlSeconds: z.number().int().min(30).max(3600).optional(),
+}).strict();
+
+export type MintServiceTokenBody = z.infer<typeof mintServiceTokenSchema>;

--- a/src/services/__tests__/serviceTokens.test.ts
+++ b/src/services/__tests__/serviceTokens.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mintServiceToken,
+  verifyServiceToken,
+  rotateServiceTokenKey,
+  resetServiceTokenRegistry,
+  ServiceTokenError,
+} from '../serviceTokens.js';
+
+describe('service tokens', () => {
+  beforeEach(() => {
+    resetServiceTokenRegistry();
+    vi.useRealTimers();
+  });
+
+  it('mints a token that verifies back to the same claims', () => {
+    const { token } = mintServiceToken({ sub: 'reconciliation-worker', permissions: ['reconcile:run'] });
+    const claims = verifyServiceToken(token);
+    expect(claims.sub).toBe('reconciliation-worker');
+    expect(claims.permissions).toEqual(['reconcile:run']);
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const { token } = mintServiceToken({ sub: 'svc-a', permissions: [] });
+    resetServiceTokenRegistry();
+    process.env.SERVICE_TOKEN_SECRET = 'a-completely-different-secret-value';
+    expect(() => verifyServiceToken(token)).toThrow(ServiceTokenError);
+    delete process.env.SERVICE_TOKEN_SECRET;
+  });
+
+  it('rejects a malformed token', () => {
+    expect(() => verifyServiceToken('not-a-jwt')).toThrow(ServiceTokenError);
+  });
+
+  it('rejects an expired token', async () => {
+    vi.useFakeTimers();
+    const { token } = mintServiceToken({ sub: 'svc-a', permissions: [] }, 30);
+    vi.advanceTimersByTime(31_000);
+    expect(() => verifyServiceToken(token)).toThrow(ServiceTokenError);
+    vi.useRealTimers();
+  });
+
+  it('rotating the signing key keeps previously issued tokens valid', () => {
+    const { token: before } = mintServiceToken({ sub: 'svc-a', permissions: [] });
+    rotateServiceTokenKey();
+    const { token: after } = mintServiceToken({ sub: 'svc-a', permissions: [] });
+
+    expect(() => verifyServiceToken(before)).not.toThrow();
+    expect(() => verifyServiceToken(after)).not.toThrow();
+  });
+
+  it('rotating past the retention window invalidates the oldest key', () => {
+    const { token: gen1 } = mintServiceToken({ sub: 'svc-a', permissions: [] });
+    rotateServiceTokenKey();
+    rotateServiceTokenKey();
+    rotateServiceTokenKey();
+
+    expect(() => verifyServiceToken(gen1)).toThrow(ServiceTokenError);
+  });
+});

--- a/src/services/serviceTokens.ts
+++ b/src/services/serviceTokens.ts
@@ -1,0 +1,173 @@
+/**
+ * Signed JWT service tokens for internal service-to-service calls.
+ *
+ * Replaces long-lived shared API keys with short-lived (default 5 minute),
+ * HMAC-SHA256 signed tokens carrying a service-account subject and a
+ * structured permission list. No external JWT library is used — the format
+ * is a minimal, dependency-free JWT (header.payload.signature, base64url,
+ * HS256) so verification has no supply-chain surface beyond Node's `crypto`.
+ *
+ * ## Key rotation without downtime
+ * Signing keys are held in an in-process registry keyed by `kid`. Rotating
+ * adds a new signing key (used for all newly minted tokens) while previously
+ * issued keys remain valid for verification until they age out of the
+ * retention window — so tokens minted just before a rotation are not
+ * invalidated mid-flight.
+ *
+ * ## Migration from shared API keys
+ * `requireServiceToken` (see `../middleware/serviceAuth.js`) is additive: it
+ * does not replace `createApiKeyMiddleware` on existing routes. Adopt it
+ * route-by-route; both mechanisms can run side by side during the migration
+ * window. See `docs/security/service-auth.md`.
+ */
+import * as crypto from 'node:crypto';
+
+const ISSUER = 'creditra-backend';
+const AUDIENCE = 'creditra-internal';
+const DEFAULT_TTL_SECONDS = 300;
+/** How many past signing keys remain valid for verification after a rotation. */
+const KEY_RETENTION = 3;
+
+export class ServiceTokenError extends Error {}
+
+interface SigningKey {
+  kid: string;
+  secret: string;
+}
+
+class ServiceTokenKeyRegistry {
+  /** Newest first; keys[0] is the current signing key. */
+  private keys: SigningKey[] = [];
+
+  constructor(initial: SigningKey) {
+    this.keys.push(initial);
+  }
+
+  current(): SigningKey {
+    const key = this.keys[0];
+    if (!key) throw new ServiceTokenError('No signing key configured');
+    return key;
+  }
+
+  getSecret(kid: string): string | undefined {
+    return this.keys.find((k) => k.kid === kid)?.secret;
+  }
+
+  /** Add a new current signing key, retiring the oldest once past retention. */
+  rotate(secret: string = crypto.randomBytes(32).toString('hex')): SigningKey {
+    const key: SigningKey = { kid: crypto.randomUUID(), secret };
+    this.keys.unshift(key);
+    this.keys = this.keys.slice(0, KEY_RETENTION);
+    return key;
+  }
+}
+
+let registry: ServiceTokenKeyRegistry | undefined;
+
+function getRegistry(): ServiceTokenKeyRegistry {
+  if (!registry) {
+    const secret = process.env.SERVICE_TOKEN_SECRET ?? crypto.randomBytes(32).toString('hex');
+    registry = new ServiceTokenKeyRegistry({
+      kid: process.env.SERVICE_TOKEN_KID ?? 'initial',
+      secret,
+    });
+  }
+  return registry;
+}
+
+/** Test-only hook to reset/inject a registry between cases. */
+export function resetServiceTokenRegistry(): void {
+  registry = undefined;
+}
+
+function base64url(input: string): string {
+  return Buffer.from(input, 'utf8').toString('base64url');
+}
+
+export interface ServiceTokenClaims {
+  /** Service account name, e.g. "reconciliation-worker". */
+  sub: string;
+  permissions: string[];
+}
+
+export interface VerifiedServiceToken extends ServiceTokenClaims {
+  kid: string;
+}
+
+/** Mint a short-lived signed service token. Returns the compact JWT string. */
+export function mintServiceToken(
+  claims: ServiceTokenClaims,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS,
+): { token: string; expiresAt: string } {
+  const { kid, secret } = getRegistry().current();
+  const header = { alg: 'HS256', typ: 'JWT', kid };
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + ttlSeconds;
+  const payload = {
+    iss: ISSUER,
+    aud: AUDIENCE,
+    sub: claims.sub,
+    permissions: claims.permissions,
+    iat: now,
+    exp,
+  };
+
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  const signature = crypto.createHmac('sha256', secret).update(signingInput).digest('base64url');
+  return { token: `${signingInput}.${signature}`, expiresAt: new Date(exp * 1000).toISOString() };
+}
+
+/** Verify a compact JWT service token. Throws {@link ServiceTokenError} on any failure. */
+export function verifyServiceToken(token: string): VerifiedServiceToken {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new ServiceTokenError('Malformed token');
+  const [headerPart, payloadPart, signaturePart] = parts as [string, string, string];
+
+  let header: { alg?: string; kid?: string };
+  let payload: {
+    iss?: string;
+    aud?: string;
+    sub?: string;
+    permissions?: unknown;
+    exp?: number;
+  };
+  try {
+    header = JSON.parse(Buffer.from(headerPart, 'base64url').toString('utf8'));
+    payload = JSON.parse(Buffer.from(payloadPart, 'base64url').toString('utf8'));
+  } catch {
+    throw new ServiceTokenError('Malformed token');
+  }
+
+  if (header.alg !== 'HS256' || !header.kid) {
+    throw new ServiceTokenError('Unsupported or missing key id');
+  }
+  const secret = getRegistry().getSecret(header.kid);
+  if (!secret) throw new ServiceTokenError('Unknown or expired signing key');
+
+  const signingInput = `${headerPart}.${payloadPart}`;
+  const expected = crypto.createHmac('sha256', secret).update(signingInput).digest();
+  const actual = Buffer.from(signaturePart, 'base64url');
+  if (expected.length !== actual.length || !crypto.timingSafeEqual(expected, actual)) {
+    throw new ServiceTokenError('Invalid signature');
+  }
+
+  if (payload.iss !== ISSUER) throw new ServiceTokenError('Invalid issuer');
+  if (payload.aud !== AUDIENCE) throw new ServiceTokenError('Invalid audience');
+  if (typeof payload.sub !== 'string' || !payload.sub) {
+    throw new ServiceTokenError('Missing subject');
+  }
+  if (typeof payload.exp !== 'number' || Math.floor(Date.now() / 1000) >= payload.exp) {
+    throw new ServiceTokenError('Token expired');
+  }
+
+  return {
+    sub: payload.sub,
+    permissions: Array.isArray(payload.permissions) ? (payload.permissions as string[]) : [],
+    kid: header.kid,
+  };
+}
+
+/** Rotate the active signing key. Previously issued tokens remain verifiable. */
+export function rotateServiceTokenKey(): { kid: string } {
+  return { kid: getRegistry().rotate().kid };
+}


### PR DESCRIPTION
Closes #219

## Summary
Adds signed, short-lived JWT service tokens for internal service-to-service calls, as an additive alternative to long-lived shared API keys.

- `src/services/serviceTokens.ts`: mint/verify/rotate. No external JWT library — a minimal, dependency-free token format (base64url `header.payload.signature`, HS256 over Node's built-in `crypto`), scoped with `iss`/`aud`/`sub`/`permissions`/`exp` (default TTL 5 minutes, max 1 hour).
- **Rotation without downtime**: signing keys live in a small in-process registry keyed by `kid`. Rotating adds a new *current* signing key (used for all newly-minted tokens); the last 3 keys remain valid for *verification*, so tokens minted just before a rotation aren't invalidated mid-flight.
- `src/middleware/serviceAuth.ts`: `requireServiceToken(permission?)` — Bearer-auth middleware for internal routes returning 401 (missing) / 403 (invalid/expired/insufficient permission).
- `POST /api/admin/service-tokens` (mint) and `POST /api/admin/service-tokens/rotate`, both gated by the existing `X-Admin-Api-Key` (`adminAuth` middleware, same pattern as `/api/admin/api-keys`).
- `docs/security/service-auth.md`: format, minting/verifying examples, rotation mechanics, and a **route-by-route migration plan** — `requireServiceToken` is additive and runs alongside `createApiKeyMiddleware`, so existing routes keep working unchanged until each is migrated individually.

## Scope note
The issue's "clear migration plan (support both for a window)" is covered as a documented plan + additive middleware design, not as a retrofit of every existing internal route — actually swapping call sites over would be a much larger, riskier change touching many unrelated files, out of scope for this PR.

## Tests
`src/services/__tests__/serviceTokens.test.ts` (6 passing): round-trip mint/verify, rejects a token signed with a different secret, rejects malformed tokens, rejects expired tokens (fake timers), rotation keeps a previously-issued token valid, and rotating past the retention window invalidates the oldest key.

## Verification
`npx vitest run src/services/__tests__/serviceTokens.test.ts` — 6/6 passing. `npx eslint` on all new/changed files — clean. This repo's broader test suite has pre-existing, unrelated loading issues in other files (see #221/#220 for what I found there); this PR's files are new and self-contained so I verified them directly rather than via the full suite.
