### PR TITLE
test(ci): staging smoke tests for critical backend flows

### DIFF
--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -1,0 +1,29 @@
+name: Staging Smoke Test
+
+# Validates critical flows against a already-deployed staging target. Read-only
+# / simulate-only checks — no chain writes, no destructive operations.
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Staging base URL to smoke test'
+        required: true
+        default: 'https://staging.example.com'
+  # Optionally triggered on deploy: uncomment and point at your deploy workflow
+  # once staging deploys emit a workflow_run event.
+  # workflow_run:
+  #   workflows: ['Deploy Staging']
+  #   types: [completed]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run smoke tests against staging
+        env:
+          SMOKE_BASE_URL: ${{ github.event.inputs.base_url || 'https://staging.example.com' }}
+          SMOKE_ADMIN_KEY: ${{ secrets.STAGING_ADMIN_API_KEY }}
+        run: node scripts/smoke/run.mjs

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "security:secrets:staged": "node scripts/security/scan-secrets.mjs --staged",
     "load:smoke": "k6 run scripts/load/smoke.js",
     "load:stress": "k6 run scripts/load/stress.js",
-    "load:spike": "k6 run scripts/load/spike.js"
+    "load:spike": "k6 run scripts/load/spike.js",
+    "smoke": "node scripts/smoke/run.mjs"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^15.1.0",

--- a/scripts/smoke/run.mjs
+++ b/scripts/smoke/run.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Minimal end-to-end smoke test for staging/production deploys.
+ *
+ * Validates a handful of critical flows respond correctly WITHOUT any
+ * destructive or chain-writing operation: health, an admin-auth boundary
+ * check, listing credit lines, and a draw simulation (preflight-only,
+ * touches no state). Exits non-zero on any failure so it can gate a
+ * deploy pipeline.
+ *
+ * Usage:
+ *   SMOKE_BASE_URL=https://staging.example.com node scripts/smoke/run.mjs
+ *
+ * Env vars:
+ *   SMOKE_BASE_URL   Target server (default http://localhost:3000)
+ *   SMOKE_ADMIN_KEY  Optional X-Admin-Api-Key to also check an admin route
+ *                    returns 401 without it and non-401 with it. Skipped
+ *                    (not failed) when unset, since staging admin keys are
+ *                    not always shared with CI.
+ */
+
+const baseUrl = process.env.SMOKE_BASE_URL ?? 'http://localhost:3000';
+const adminKey = process.env.SMOKE_ADMIN_KEY;
+
+let failures = 0;
+
+function report(name, ok, detail = '') {
+  const status = ok ? 'PASS' : 'FAIL';
+  console.log(`[smoke] ${status} ${name}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) failures += 1;
+}
+
+async function checkHealth() {
+  const res = await fetch(`${baseUrl}/health`);
+  const body = await res.json().catch(() => null);
+  report('GET /health', res.status === 200 && body?.status === 'ok', `status=${res.status}`);
+}
+
+async function checkCreditLinesList() {
+  const res = await fetch(`${baseUrl}/api/credit/lines?offset=0&limit=1`);
+  const body = await res.json().catch(() => null);
+  report(
+    'GET /api/credit/lines',
+    res.status === 200 && Array.isArray(body?.data?.creditLines),
+    `status=${res.status}`,
+  );
+}
+
+async function checkDrawSimulateReachable() {
+  // A nonexistent id is expected: this only proves the route is wired,
+  // validated, and reachable — it performs no chain write either way.
+  const res = await fetch(`${baseUrl}/api/credit/lines/00000000-0000-0000-0000-000000000000/draw/simulate`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ amount: '1' }),
+  });
+  report(
+    'POST /api/credit/lines/:id/draw/simulate (route reachable)',
+    res.status === 404 || res.status === 400,
+    `status=${res.status}`,
+  );
+}
+
+async function checkAdminAuthBoundary() {
+  const unauth = await fetch(`${baseUrl}/api/admin/api-keys`);
+  report('GET /api/admin/api-keys without key is rejected', unauth.status === 401, `status=${unauth.status}`);
+
+  if (!adminKey) {
+    console.log('[smoke] SKIP admin-key-accepted check (SMOKE_ADMIN_KEY not set)');
+    return;
+  }
+  const authed = await fetch(`${baseUrl}/api/admin/api-keys`, {
+    headers: { 'x-admin-api-key': adminKey },
+  });
+  report('GET /api/admin/api-keys with key succeeds', authed.status === 200, `status=${authed.status}`);
+}
+
+async function main() {
+  console.log(`[smoke] target: ${baseUrl}`);
+  await checkHealth();
+  await checkCreditLinesList();
+  await checkDrawSimulateReachable();
+  await checkAdminAuthBoundary();
+
+  if (failures > 0) {
+    console.error(`[smoke] ${failures} check(s) failed`);
+    process.exit(1);
+  }
+  console.log('[smoke] all checks passed');
+}
+
+main().catch((error) => {
+  console.error('[smoke] unexpected error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #217

## Summary
Adds a minimal e2e smoke test suite that can run against staging to validate critical flows, without any chain writes or destructive operations.

- `scripts/smoke/run.mjs`: env-driven target (`SMOKE_BASE_URL`, default `http://localhost:3000`), zero new dependencies (uses Node's built-in `fetch`). Checks:
  - `GET /health` returns 200 + `{status: 'ok'}`
  - `GET /api/credit/lines` returns 200 with a `creditLines` array (read-only)
  - `POST /api/credit/lines/:id/draw/simulate` is reachable and validated (simulate-only — touches no state either way)
  - `GET /api/admin/api-keys` is rejected without `X-Admin-Api-Key` (401), and optionally accepted when `SMOKE_ADMIN_KEY` is provided (skipped, not failed, when unset — staging admin keys aren't always available to CI)
  - Exits non-zero on any failure so it can gate a pipeline.
- `npm run smoke` script.
- `.github/workflows/staging-smoke.yml`: manually triggered (`workflow_dispatch` with a `base_url` input) with a commented `workflow_run` block to wire up "triggered on deploy" once a deploy workflow exists to hook into.
- This is a different tool for a different purpose than the existing `scripts/load/` — those are k6 load/perf tests; this is a functional smoke check.

## Verification
This repo's dev server currently fails to boot for a pre-existing, unrelated reason — `npx tsx src/index.ts` throws `Unexpected "catch"` at `src/routes/credit.ts:153`, which I also see via `npx tsc --noEmit` (13 pre-existing syntax errors across `credit.ts`/`creditBulk.ts`, unrelated to this or any of my other PRs here — see #295 for the full list of pre-existing issues I found while working in this repo). I could not start the real server to run the smoke script end-to-end because of this.

Instead I verified the script's actual HTTP/response-handling logic against a lightweight mock server implementing the same 4 endpoints: all 4 checks pass, and pointing it at an unreachable target correctly fails loudly with a non-zero exit code. The script itself has no dependency on the broken files, so it will work once `credit.ts` is fixed independent of this PR.
