### PR TITLE
[#303] Add tenant-scoped mutation rate limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { loadCorsPolicy, isAllowedCorsOrigin } from "./config/cors.js";
 import { loadRateLimitConfig } from "./config/rateLimit.js";
 import { Container } from "./container/Container.js";
 import { initializeWebhooks } from "./services/drawWebhookService.js";
+import { createTenantMutationRateLimiter } from "./middleware/tenantRateLimit.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const openapiSpec = yaml.parse(
@@ -50,6 +51,17 @@ const defaultRateLimit = createRateLimitMiddleware({
 const evaluateRateLimit = createRateLimitMiddleware({
   ...appRateLimitConfig.evaluate,
   keyGenerator: createIpKeyGenerator(),
+});
+const tenantMutationRateLimit = createTenantMutationRateLimiter({
+  windowMs: rateLimitConfig.default.windowMs,
+  maxRequests: rateLimitConfig.default.maxRequests,
+  isOverrideAllowed: (req) => {
+    const configured = process.env.RATE_LIMIT_OVERRIDE_TOKEN;
+    return Boolean(configured && req.headers['x-rate-limit-override-token'] === configured);
+  },
+  auditOverride: (entry) => {
+    console.log('[TenantRateLimit] administrative override', JSON.stringify(entry));
+  },
 });
 
 app.use(cors({
@@ -88,7 +100,7 @@ app.get("/docs.json", (_req, res) => {
   res.json(openapiSpec);
 });
 
-app.use("/api/credit", defaultRateLimit, creditRouter);
+app.use("/api/credit", defaultRateLimit, tenantMutationRateLimit, creditRouter);
 app.use("/api/risk/evaluate", evaluateRateLimit);
 app.use("/api/risk/wallet", defaultRateLimit);
 app.use("/api/risk", riskRouter);

--- a/src/middleware/__tests__/tenantRateLimit.integration.test.ts
+++ b/src/middleware/__tests__/tenantRateLimit.integration.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import { createTenantMutationRateLimiter, InMemoryTenantRateLimitStore } from '../tenantRateLimit.js';
+
+function req(method: string, tenant = 'tenant-1', route = '/api/credit/lines', subject = 'Bearer user-1'): Request {
+  const split = route.lastIndexOf('/');
+  return {
+    method,
+    path: route.slice(split),
+    baseUrl: route.slice(0, split),
+    headers: { 'x-tenant-id': tenant, authorization: subject },
+  } as unknown as Request;
+}
+
+function withHeaders(base: Request, headers: Record<string, string>): Request {
+  return Object.assign(base, { headers }) as Request;
+}
+
+function res(): Response & { statusCode: number; headers: Record<string, string>; body?: unknown } {
+  const output = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: undefined as unknown,
+    set(values: Record<string, string> | string, value?: string) {
+      if (typeof values === 'string') this.headers[values] = value ?? '';
+      else Object.assign(this.headers, values);
+    },
+    status(code: number) { this.statusCode = code; return this; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+  return output as unknown as Response & { statusCode: number; headers: Record<string, string>; body?: unknown };
+}
+
+describe('tenant rate-limit integration behavior', () => {
+  it('scopes the default route key to the mounted API path', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1 });
+    const next = vi.fn();
+    const first = res();
+    await limiter(req('POST', 'tenant-1', '/api/credit/lines'), first, next);
+    const differentApi = res();
+    await limiter(req('POST', 'tenant-1', '/api/risk/evaluate'), differentApi, next);
+    expect(differentApi.statusCode).toBe(200);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the budget tenant-scoped while retaining custom subject attribution', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, resolveSubject: (request) => String(request.headers['x-user-id'] ?? 'unknown') });
+    const next = vi.fn();
+    const headers = { 'x-tenant-id': 'tenant-1', 'x-user-id': 'user-a' };
+    await limiter(req('POST', 'tenant-1'), res(), next);
+    const blocked = res();
+    await limiter(withHeaders(req('POST', 'tenant-1'), headers), blocked, next);
+    expect(blocked.statusCode).toBe(429);
+    const userA = res();
+    await limiter(withHeaders(req('POST', 'tenant-1'), headers), userA, next);
+    expect(userA.statusCode).toBe(429);
+  });
+
+  it('allows custom route classes to group equivalent mutation endpoints', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, resolveRouteClass: () => 'credit-mutation' });
+    const next = vi.fn();
+    await limiter(req('POST', 'tenant-1', '/api/credit/lines'), res(), next);
+    const second = res();
+    await limiter(req('PUT', 'tenant-1', '/api/credit/lines/123'), second, next);
+    expect(second.statusCode).toBe(429);
+  });
+
+  it('returns a complete structured error body when a budget is exceeded', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 2_000, maxRequests: 1, now: () => 1_000 });
+    const next = vi.fn();
+    await limiter(req('POST'), res(), next);
+    const blocked = res();
+    await limiter(req('POST'), blocked, next);
+    expect(blocked.statusCode).toBe(429);
+    expect(blocked.body).toEqual({ data: null, error: expect.stringContaining('Retry after'), retryAfter: 2 });
+    expect(blocked.headers['Retry-After']).toBe('2');
+    expect(blocked.headers['X-RateLimit-Scope']).toBe('tenant-1:POST:/api/credit/lines');
+  });
+
+  it('does not call downstream handlers after denial', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1 });
+    const next = vi.fn() as unknown as NextFunction;
+    await limiter(req('POST'), res(), next);
+    await limiter(req('POST'), res(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a permitted override without changing the normal store bucket', async () => {
+    const store = new InMemoryTenantRateLimitStore();
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, isOverrideAllowed: () => true }, store);
+    const next = vi.fn();
+    await limiter(req('POST', 'tenant-1'), res(), next);
+    await limiter(withHeaders(req('POST', 'tenant-1'), { 'x-rate-limit-override': 'true', 'x-tenant-id': 'tenant-1' }), res(), next);
+    const normal = res();
+    await limiter(req('POST', 'tenant-1'), normal, next);
+    expect(normal.statusCode).toBe(429);
+  });
+
+  it('awaits asynchronous override authorization and audit hooks', async () => {
+    const events: string[] = [];
+    const limiter = createTenantMutationRateLimiter({
+      windowMs: 1_000,
+      maxRequests: 1,
+      isOverrideAllowed: async () => { events.push('authorized'); return true; },
+      auditOverride: async () => { await Promise.resolve(); events.push('audited'); },
+    });
+    await limiter(withHeaders(req('POST'), { 'x-rate-limit-override': 'true', 'x-tenant-id': 'tenant-1' }), res(), vi.fn());
+    expect(events).toEqual(['authorized', 'audited']);
+  });
+
+  it('does not audit a request that only presents a false override flag', async () => {
+    const audit = vi.fn();
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, isOverrideAllowed: () => false, auditOverride: audit });
+    await limiter(withHeaders(req('POST'), { 'x-rate-limit-override': 'false', 'x-tenant-id': 'tenant-1' }), res(), vi.fn());
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it('handles DELETE as a mutation and OPTIONS as a read', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1 });
+    const next = vi.fn();
+    await limiter(req('DELETE'), res(), next);
+    const blockedDelete = res();
+    await limiter(req('DELETE'), blockedDelete, next);
+    expect(blockedDelete.statusCode).toBe(429);
+    const options = res();
+    await limiter(req('OPTIONS'), options, next);
+    expect(options.statusCode).toBe(200);
+  });
+
+  it('keeps reset headers in epoch seconds and never reports negative retry time', async () => {
+    let now = 1_999;
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1, maxRequests: 1, now: () => now });
+    await limiter(withHeaders(req('POST'), { 'x-rate-limit-override': 'true' }), res(), vi.fn());
+    now = 2_001;
+    const after = res();
+    await limiter(req('POST'), after, vi.fn());
+    expect(Number(after.headers['X-RateLimit-Reset'])).toBeGreaterThanOrEqual(2);
+    expect(Number(after.headers['Retry-After'] ?? 0)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('rejects a custom resolver that returns an empty route class', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, resolveRouteClass: () => '  ' });
+    const result = res();
+    await limiter(req('POST'), result, vi.fn());
+    expect(result.statusCode).toBe(400);
+    expect(result.body).toEqual({ data: null, error: expect.stringContaining('route') });
+  });
+
+  it('does not leak a tenant identifier into the denial message', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1 });
+    await limiter(req('POST', 'secret-tenant'), res(), vi.fn());
+    const denied = res();
+    await limiter(req('POST', 'secret-tenant'), denied, vi.fn());
+    expect(JSON.stringify(denied.body)).not.toContain('secret-tenant');
+  });
+
+  it('rejects invalid limiter configuration at construction time', () => {
+    expect(() => createTenantMutationRateLimiter({ windowMs: 0, maxRequests: 1 })).toThrow('windowMs');
+    expect(() => createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 0 })).toThrow('maxRequests');
+    expect(() => createTenantMutationRateLimiter({ windowMs: -1, maxRequests: -1 })).toThrow('windowMs');
+  });
+
+  it('normalizes whitespace around tenant and route resolver values', async () => {
+    const seen: string[] = [];
+    const limiter = createTenantMutationRateLimiter({
+      windowMs: 1_000,
+      maxRequests: 1,
+      resolveTenant: () => ' tenant-normalized ',
+      resolveRouteClass: () => ' mutation ',
+      resolveSubject: () => ' subject ',
+      auditOverride: (entry) => { seen.push(`${entry.tenantId}:${entry.routeClass}:${entry.subject}`); },
+      isOverrideAllowed: () => true,
+    });
+    await limiter(withHeaders(req('POST'), { 'x-rate-limit-override': 'true' }), res(), vi.fn());
+    expect(seen).toEqual(['tenant-normalized:mutation:subject']);
+  });
+
+  it('keeps two tenants independent across several route classes', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1 });
+    const next = vi.fn();
+    for (const route of ['/lines', '/draw', '/repay']) {
+      await limiter(req('POST', 'tenant-a', `/api/credit${route}`), res(), next);
+      const secondTenant = res();
+      await limiter(req('POST', 'tenant-b', `/api/credit${route}`), secondTenant, next);
+      expect(secondTenant.statusCode).toBe(200);
+    }
+    expect(next).toHaveBeenCalledTimes(6);
+  });
+
+  it('does not consume a bucket when identity validation fails', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, resolveTenant: () => '' });
+    const next = vi.fn();
+    const invalid = res();
+    await limiter(req('POST'), invalid, next);
+    expect(invalid.statusCode).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('uses the request clock consistently for reset and audit timestamps', async () => {
+    const now = 123_456;
+    const audit = vi.fn();
+    const limiter = createTenantMutationRateLimiter({ windowMs: 2_000, maxRequests: 1, now: () => now, isOverrideAllowed: () => true, auditOverride: audit });
+    await limiter(withHeaders(req('POST'), { 'x-rate-limit-override': 'true' }), res(), vi.fn());
+    expect(audit.mock.calls[0][0].at).toEqual(new Date(now));
+    const allowed = res();
+    await limiter(req('POST'), allowed, vi.fn());
+    expect(allowed.headers['X-RateLimit-Reset']).toBe(String(Math.ceil((now + 2_000) / 1_000)));
+  });
+
+  it('counts POST, PUT, PATCH, and DELETE independently only by route class', async () => {
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 2, resolveRouteClass: () => 'all-credit-mutations' });
+    const next = vi.fn();
+    await limiter(req('POST'), res(), next);
+    await limiter(req('PUT'), res(), next);
+    const denied = res();
+    await limiter(req('PATCH'), denied, next);
+    expect(denied.statusCode).toBe(429);
+  });
+
+  it('preserves the same limit headers when a custom store is used', async () => {
+    const store = new InMemoryTenantRateLimitStore();
+    const limiter = createTenantMutationRateLimiter({ windowMs: 60_000, maxRequests: 4 }, store);
+    const result = res();
+    await limiter(req('POST'), result, vi.fn());
+    expect(result.headers).toEqual(expect.objectContaining({
+      'X-RateLimit-Limit': '4',
+      'X-RateLimit-Remaining': '3',
+      'X-RateLimit-Scope': 'tenant-1:POST:/api/credit/lines',
+    }));
+  });
+
+  it('does not call an audit hook for an allowed request without override', async () => {
+    const audit = vi.fn();
+    const limiter = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, auditOverride: audit });
+    await limiter(req('POST'), res(), vi.fn());
+    expect(audit).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/__tests__/tenantRateLimit.test.ts
+++ b/src/middleware/__tests__/tenantRateLimit.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { createTenantMutationRateLimiter, InMemoryTenantRateLimitStore } from '../tenantRateLimit.js';
+
+function request(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'POST',
+    path: '/lines',
+    baseUrl: '/api/credit',
+    headers: { 'x-tenant-id': 'tenant-a', authorization: 'Bearer token' },
+    ...overrides,
+  } as Request;
+}
+
+function response() {
+  const headers: Record<string, string> = {};
+  const res = {
+    set: vi.fn((values: Record<string, string> | string, value?: string) => {
+      if (typeof values === 'string') headers[values] = value ?? '';
+      else Object.assign(headers, values);
+    }),
+    setHeader: vi.fn((name: string, value: string) => { headers[name] = value; }),
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    headers,
+  } as unknown as Response & { headers: Record<string, string> };
+  return res;
+}
+
+describe('tenant mutation rate limiter', () => {
+  it('isolates counts by tenant and route class', async () => {
+    let now = 1_000;
+    const middleware = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, now: () => now });
+    const next = vi.fn();
+    const first = response();
+    await middleware(request(), first, next);
+    const blocked = response();
+    await middleware(request(), blocked, next);
+    expect(blocked.status).toHaveBeenCalledWith(429);
+    const otherTenant = response();
+    await middleware(request({ headers: { 'x-tenant-id': 'tenant-b' } }), otherTenant, next);
+    expect(otherTenant.status).not.toHaveBeenCalledWith(429);
+    const otherRoute = response();
+    await middleware(request({ path: '/risk' }), otherRoute, next);
+    expect(otherRoute.status).not.toHaveBeenCalledWith(429);
+    now += 1_000;
+    const reset = response();
+    await middleware(request(), reset, next);
+    expect(reset.status).not.toHaveBeenCalledWith(429);
+  });
+
+  it('sets truthful headers on allowed and rejected responses', async () => {
+    const middleware = createTenantMutationRateLimiter({ windowMs: 10_000, maxRequests: 2, now: () => 1_000 });
+    const next = vi.fn();
+    const first = response();
+    await middleware(request(), first, next);
+    expect(first.headers['X-RateLimit-Limit']).toBe('2');
+    expect(first.headers['X-RateLimit-Remaining']).toBe('1');
+    const second = response();
+    await middleware(request(), second, next);
+    expect(second.headers['X-RateLimit-Remaining']).toBe('0');
+    const third = response();
+    await middleware(request(), third, next);
+    expect(third.headers['X-RateLimit-Remaining']).toBe('0');
+    expect(third.headers['Retry-After']).toBe('10');
+  });
+
+  it('does not count read requests against the mutation budget', async () => {
+    const middleware = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1 });
+    const next = vi.fn();
+    const read = response();
+    await middleware(request({ method: 'GET' }), read, next);
+    const mutation = response();
+    await middleware(request(), mutation, next);
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(mutation.status).not.toHaveBeenCalledWith(429);
+  });
+
+  it('uses a fixed reset boundary rather than extending on each request', async () => {
+    let now = 5_000;
+    const middleware = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 2, now: () => now });
+    const next = vi.fn();
+    await middleware(request(), response(), next);
+    now = 5_900;
+    const second = response();
+    await middleware(request(), second, next);
+    expect(second.headers['X-RateLimit-Reset']).toBe('6');
+    now = 6_000;
+    const after = response();
+    await middleware(request(), after, next);
+    expect(after.headers['X-RateLimit-Remaining']).toBe('1');
+  });
+
+  it('requires all scoped identity components', async () => {
+    const middleware = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, resolveTenant: () => ' ' });
+    const res = response();
+    await middleware(request(), res, vi.fn());
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('audits a permitted administrative override and does not consume capacity', async () => {
+    const audit = vi.fn();
+    const middleware = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, isOverrideAllowed: () => true, auditOverride: audit });
+    const next = vi.fn();
+    await middleware(request({ headers: { 'x-tenant-id': 'tenant-a', 'x-rate-limit-override': 'true' } }), response(), next);
+    await middleware(request(), response(), next);
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-a', routeClass: 'POST:/api/credit/lines', reason: 'override' }));
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not grant an override when it is requested but unauthorized', async () => {
+    const middleware = createTenantMutationRateLimiter({ windowMs: 1_000, maxRequests: 1, isOverrideAllowed: () => false });
+    const next = vi.fn();
+    await middleware(request({ headers: { 'x-tenant-id': 'tenant-a', 'x-rate-limit-override': 'true' } }), response(), next);
+    const blocked = response();
+    await middleware(request({ headers: { 'x-tenant-id': 'tenant-a', 'x-rate-limit-override': 'true' } }), blocked, next);
+    expect(blocked.status).toHaveBeenCalledWith(429);
+  });
+
+  it('supports a shared injectable store for deterministic reset/inspection', () => {
+    const store = new InMemoryTenantRateLimitStore();
+    expect(store.consume('tenant-a:POST:/lines', 0, 100)).toEqual({ count: 1, resetAt: 100 });
+    expect(store.consume('tenant-a:POST:/lines', 99, 100).count).toBe(2);
+    expect(store.consume('tenant-a:POST:/lines', 100, 100)).toEqual({ count: 1, resetAt: 200 });
+    store.clear();
+    expect(store.consume('tenant-a:POST:/lines', 0, 100).count).toBe(1);
+  });
+});

--- a/src/middleware/tenantRateLimit.ts
+++ b/src/middleware/tenantRateLimit.ts
@@ -1,0 +1,122 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export type TenantRateLimitAudit = (entry: {
+  tenantId: string;
+  routeClass: string;
+  subject: string;
+  reason: 'override';
+  at: Date;
+}) => void | Promise<void>;
+
+export interface TenantRateLimitOptions {
+  windowMs: number;
+  maxRequests: number;
+  resolveTenant?: (req: Request) => string;
+  resolveRouteClass?: (req: Request) => string;
+  resolveSubject?: (req: Request) => string;
+  isOverrideAllowed?: (req: Request) => boolean | Promise<boolean>;
+  auditOverride?: TenantRateLimitAudit;
+  now?: () => number;
+}
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+export interface TenantRateLimitStore {
+  consume(key: string, now: number, windowMs: number): Bucket;
+  clear(): void;
+}
+
+/** Fixed-window store with an explicit reset boundary per tenant/route key. */
+export class InMemoryTenantRateLimitStore implements TenantRateLimitStore {
+  private readonly buckets = new Map<string, Bucket>();
+
+  consume(key: string, now: number, windowMs: number): Bucket {
+    const existing = this.buckets.get(key);
+    if (!existing || existing.resetAt <= now) {
+      const fresh = { count: 1, resetAt: now + windowMs };
+      this.buckets.set(key, fresh);
+      return fresh;
+    }
+    existing.count += 1;
+    return existing;
+  }
+
+  clear(): void { this.buckets.clear(); }
+}
+
+function defaultTenant(req: Request): string {
+  const header = req.headers['x-tenant-id'];
+  return typeof header === 'string' && header.trim() !== '' ? header.trim() : 'anonymous';
+}
+
+function defaultRouteClass(req: Request): string {
+  return `${req.method.toUpperCase()}:${req.baseUrl || ''}${req.path || ''}`;
+}
+
+function defaultSubject(req: Request): string {
+  const header = req.headers.authorization;
+  return typeof header === 'string' && header !== '' ? 'authenticated' : 'anonymous';
+}
+
+function isMutation(req: Request): boolean {
+  return ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method.toUpperCase());
+}
+
+/**
+ * Tenant/route scoped mutation limiter. The store is injectable so a Redis
+ * implementation can use an atomic INCR+EXPIRE without changing callers.
+ */
+export function createTenantMutationRateLimiter(
+  options: TenantRateLimitOptions,
+  store: TenantRateLimitStore = new InMemoryTenantRateLimitStore(),
+) {
+  if (!Number.isInteger(options.windowMs) || options.windowMs < 1) throw new Error('windowMs must be positive');
+  if (!Number.isInteger(options.maxRequests) || options.maxRequests < 1) throw new Error('maxRequests must be positive');
+  const resolveTenant = options.resolveTenant ?? defaultTenant;
+  const resolveRouteClass = options.resolveRouteClass ?? defaultRouteClass;
+  const resolveSubject = options.resolveSubject ?? defaultSubject;
+  const now = options.now ?? Date.now;
+
+  return async function tenantMutationRateLimit(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (!isMutation(req)) { next(); return; }
+    const tenantId = resolveTenant(req).trim();
+    const routeClass = resolveRouteClass(req).trim();
+    const subject = resolveSubject(req).trim();
+    if (!tenantId || !routeClass || !subject) {
+      res.status(400).json({ data: null, error: 'Tenant, route, and subject identity are required.' });
+      return;
+    }
+
+    const overrideRequested = req.headers['x-rate-limit-override'] === 'true';
+    const overrideAllowed = overrideRequested && options.isOverrideAllowed
+      ? await options.isOverrideAllowed(req)
+      : false;
+    const key = `${tenantId}:${routeClass}`;
+    const bucket = overrideAllowed
+      ? { count: 0, resetAt: now() + options.windowMs }
+      : store.consume(key, now(), options.windowMs);
+    const remaining = overrideAllowed ? options.maxRequests : Math.max(0, options.maxRequests - bucket.count);
+    res.set({
+      'X-RateLimit-Limit': String(options.maxRequests),
+      'X-RateLimit-Remaining': String(remaining),
+      'X-RateLimit-Reset': String(Math.ceil(bucket.resetAt / 1000)),
+      'X-RateLimit-Scope': `${tenantId}:${routeClass}`,
+    });
+
+    if (overrideAllowed) {
+      await options.auditOverride?.({ tenantId, routeClass, subject, reason: 'override', at: new Date(now()) });
+      next();
+      return;
+    }
+    if (bucket.count > options.maxRequests) {
+      const retryAfter = Math.max(1, Math.ceil((bucket.resetAt - now()) / 1000));
+      res.set('Retry-After', String(retryAfter));
+      res.status(429).json({ data: null, error: `Too many mutation requests. Retry after ${retryAfter} seconds.`, retryAfter });
+      return;
+    }
+    next();
+  };
+}


### PR DESCRIPTION
## Summary

Add tenant-scoped mutation budgets so one tenant cannot monopolize mutation capacity shared by other tenants or route classes.

## What changed

- Added an injectable fixed-window tenant limiter with stable reset boundaries and an explicit store abstraction for a future atomic Redis implementation.
- Scopes mutation budgets by tenant and route class, with normalized identities and safe anonymous fallback.
- Emits `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Scope`, and `Retry-After` headers on the relevant responses.
- Excludes GET/OPTIONS and other reads from the mutation budget.
- Added explicit administrative override authorization and an audit callback; unauthorized override requests remain rate-limited.
- Mounted the tenant limiter on `/api/credit` after the existing IP limiter so existing protections remain in place.
- Added 28 tests covering tenant/route isolation, bursts, fixed reset windows, headers, mutation methods, read exclusion, custom scopes, validation, override authorization/auditing, and message privacy.

## Acceptance criteria

- [x] Limits are isolated by tenant and route class.
- [x] Headers accurately describe remaining capacity and reset timing.
- [x] Overrides are explicit, authorization-gated, and audited.
- [x] Bursts, reset windows, and isolation are covered by deterministic tests.

## Validation

- `npm test -- src/middleware/__tests__/tenantRateLimit.test.ts src/middleware/__tests__/tenantRateLimit.integration.test.ts`
- `npm run typecheck`

## Security and failure modes

Tenant identifiers are not included in denial messages, overrides cannot be enabled by the request flag alone, rejected requests do not call downstream handlers, and the store interface keeps future distributed atomicity isolated from route code.

Closes #303